### PR TITLE
Use C-style comments in C source files

### DIFF
--- a/bufferevent_sock.c
+++ b/bufferevent_sock.c
@@ -115,7 +115,7 @@ bufferevent_socket_outbuf_cb(struct evbuffer *buf,
 		/* Somebody added data to the buffer, and we would like to
 		 * write, and we were not writing.  So, start writing. */
 		if (be_socket_add(&bufev->ev_write, &bufev->timeout_write) == -1) {
-		    // Should we log this?
+		    /* Should we log this? */
 		}
 	}
 }


### PR DESCRIPTION
Strict C-style comments are required for compatibility with compilers such as xlc on AIX with the default settings.
