### PR TITLE
Make sure filtered openssl connections properly drain the underlying BE

### DIFF
--- a/bufferevent_openssl.c
+++ b/bufferevent_openssl.c
@@ -783,9 +783,14 @@ consider_reading(struct bufferevent_openssl *bev_ssl)
 		 * regrettable).  The damage to the rate-limit has
 		 * already been done, since OpenSSL went and read a
 		 * whole SSL record anyway. */
-		n_to_read = SSL_pending(bev_ssl->ssl);
+        if (bev_ssl->underlying) {
+            n_to_read = evbuffer_get_length(bev_ssl->underlying->input);
+        }
+        else { 
+            n_to_read = SSL_pending(bev_ssl->ssl);
+        }
 	}
-
+	
 	if (!bev_ssl->underlying) {
 		/* Should be redundant, but let's avoid busy-looping */
 		if (bev_ssl->bev.read_suspended ||


### PR DESCRIPTION
I was investigating an issue with filtered openssl buffer events. The bufferevent stopped processing / pumping SSL data event when there was data available in the underlying BE. This is a regression in 2.0.16 and I believe the follow commit might have caused it:https://github.com/libevent/libevent/commit/2aa036fa0403977fa51812e711a1d5040c9fb5c9

Nick's suggestion of logging the number of bytes left in the underlying BE to see whether there was data available showed SSL_pending() ends up returning 0 in some cases even when the underlying BE's input buffer has data left to consume. To fix this, we now check if there is an underlying BE, and if there is, we drain it fully instead of relying on SSL_pending()
