### PR TITLE
Libevent http doesn't ignore spaces after field-content in headers

### DIFF
--- a/http.c
+++ b/http.c
@@ -219,6 +219,20 @@ strsep(char **s, const char *del)
 }
 #endif
 
+static void 
+rtrim(char *str)
+{
+	char *cp;
+
+	if( str == NULL )
+		return;
+
+	cp = strchr(str, '\0') - 1;
+
+	while (cp >= str && *cp == ' ')
+		*cp-- = '\0';
+}
+
 static size_t
 html_replace(const char ch, const char **escaped)
 {
@@ -1908,6 +1922,7 @@ evhttp_parse_headers_(struct evhttp_request *req, struct evbuffer* buffer)
 			goto error;
 
 		svalue += strspn(svalue, " ");
+		rtrim(svalue);
 
 		if (evhttp_add_header(headers, skey, svalue) == -1)
 			goto error;


### PR DESCRIPTION
I get warn messages from real web servers
[warn] evhttp_get_body_length: we got no content length, but the server wants to keep the connection open: close .
Note white space after close. Due to rfc2616 we may remove leading and trailing LWS. So probably it's a good way to do so, if we compare for "close" in "Connection" header later, and get no matching.
