### PR TITLE
Use python2 rather than python

### DIFF
--- a/event_rpcgen.py
+++ b/event_rpcgen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright (c) 2005-2007 Niels Provos <provos@citi.umich.edu>
 # Copyright (c) 2007-2012 Niels Provos and Nick Mathewson

--- a/make_epoll_table.py
+++ b/make_epoll_table.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 def get(old,wc,rc):
     if ('xxx' in (rc, wc)):

--- a/test/check-dumpevents.py
+++ b/test/check-dumpevents.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # Post-process the output of test-dumpevents and check it for correctness.
 #

--- a/test/test.sh
+++ b/test/test.sh
@@ -76,8 +76,8 @@ run_tests () {
 		fi
 	done
 	announce_n " test-dumpevents: "
-	if python -c 'import sys; assert(sys.version_info >= (2, 4))' 2>/dev/null; then
-	    if $TEST_DIR/test-dumpevents | python $TEST_SRC_DIR/check-dumpevents.py >> "$TEST_OUTPUT_FILE" ;
+	if python2 -c 'import sys; assert(sys.version_info >= (2, 4))' 2>/dev/null; then
+	    if $TEST_DIR/test-dumpevents | python2 $TEST_SRC_DIR/check-dumpevents.py >> "$TEST_OUTPUT_FILE" ;
 	    then
 	        announce OKAY ;
 	    else


### PR DESCRIPTION
python may refer to either python2 or python3 so rather by explicit by
using python2.
See PEP 394 - http://www.python.org/dev/peps/pep-0394/ for more
details.
