### PR TITLE
fix a few trivial documentation typos

### DIFF
--- a/README
+++ b/README
@@ -23,7 +23,7 @@ Install as root via
 
 # make install
 
-Before, reporting any problems, please run the regression tests.
+Before reporting any problems, please run the regression tests.
 
 To enable the low-level tracing build the library as:
 

--- a/configure.ac
+++ b/configure.ac
@@ -116,7 +116,7 @@ AC_ARG_ENABLE([verbose-debug],
 
 AC_PROG_LIBTOOL
 
-dnl   Uncomment "AC_DISABLE_SHARED" to make shared librraries not get
+dnl   Uncomment "AC_DISABLE_SHARED" to make shared libraries not get
 dnl   built by default.  You can also turn shared libs on and off from
 dnl   the command line with --enable-shared and --disable-shared.
 dnl AC_DISABLE_SHARED

--- a/whatsnew-2.1.txt
+++ b/whatsnew-2.1.txt
@@ -385,6 +385,6 @@
 
 5. Testing
 
-  Libevent's test coverage level is more or less unchanged sine before:
+  Libevent's test coverage level is more or less unchanged since before:
   we still have over 80% line coverage in our tests on Linux and OSX.
   There are some under-tested modules, though: we need to fix those.


### PR DESCRIPTION
This hardly seems worth making a merge request over, but I found three one-character typos in documentation.
