### PR TITLE
make it easier to use an OpenSSL in a non-default location

### DIFF
--- a/libevent_openssl.pc.in
+++ b/libevent_openssl.pc.in
@@ -11,6 +11,6 @@ Version: @VERSION@
 Requires: libevent
 Conflicts:
 Libs: -L${libdir} -levent_openssl
-Libs.private: @LIBS@ -lssl -lcrypto
-Cflags: -I${includedir}
+Libs.private: @LIBS@ @OPENSSL_LIBS@
+Cflags: -I${includedir} @OPENSSL_INCS@
 

--- a/test/include.am
+++ b/test/include.am
@@ -105,7 +105,8 @@ test_regress_LDFLAGS = $(PTHREAD_CFLAGS)
 
 if OPENSSL
 test_regress_SOURCES += test/regress_ssl.c
-test_regress_LDADD += libevent_openssl.la -lssl -lcrypto ${OPENSSL_LIBADD}
+test_regress_CPPFLAGS += $(OPENSSL_INCS)
+test_regress_LDADD += libevent_openssl.la $(OPENSSL_LIBS) ${OPENSSL_LIBADD}
 endif
 
 test_bench_SOURCES = test/bench.c


### PR DESCRIPTION
Perhaps I am doing something wrong, because I'm not an autoconf expert, but I was having trouble configuring libevent to use an OpenSSL I'd built in a non-default location.  I was configuring like this:

```
./configure --enable-gcc-hardening PKG_CONFIG_PATH=/opt/oblong/deps/lib/pkgconfig
```

For one thing, the regression tests were failing, I believe because although libevent itself had been built against my non-default-location OpenSSL (1.0.1c), the tests were being run against the system's OpenSSL (0.9.8k).  Presumably some sort of binary-incompatibility hilarity ensued, although I didn't fully track down why the tests were failing.  But, adding the OPENSSL_INCS and OPENSSL_LIBS to regress's CPPFLAGS and LDADD seems to have fixed the problem.

Similarly, the pkg-config file for libevent_openssl was hardcoding "-lssl -lcrypto", but wasn't using OPENSSL_INCS and OPENSSL_LIBS to get the nonstandard -I and -L options I needed to compile and link against my non-default OpenSSL.
