### PR TITLE
remove stray 'x' so print_err will compile when uncommented

### DIFF
--- a/bufferevent_openssl.c
+++ b/bufferevent_openssl.c
@@ -88,7 +88,7 @@ print_err(int val)
 	int err;
 	printf("Error was %d\n", val);
 
-	while ((err = ERR_get_error()))x {
+	while ((err = ERR_get_error())) {
 		const char *msg = (const char*)ERR_reason_error_string(err);
 		const char *lib = (const char*)ERR_lib_error_string(err);
 		const char *func = (const char*)ERR_func_error_string(err);


### PR DESCRIPTION
This is a trivial, one character fix.  Although it normally doesn't matter since the print_err() function is #if 0'ed out, I discovered after #if 1'ing it to do some debugging, that it needs this "x" removed in order to compile.
