### PR TITLE
Fix event_dlist definition when sys/queue not included

### DIFF
--- a/include/event2/event_struct.h
+++ b/include/event2/event_struct.h
@@ -91,7 +91,15 @@ struct {								\
 	struct type *le_next;	/* next element */			\
 	struct type **le_prev;	/* address of previous next element */	\
 }
-#endif /* !TAILQ_ENTRY */
+#endif /* !LIST_ENTRY */
+
+#ifndef LIST_HEAD
+#define EVENT_DEFINED_LISTHEAD_
+#define LIST_HEAD(name, type)						\
+struct name {								\
+	struct type *lh_first;  /* first element */			\
+	}
+#endif /* !LIST_HEAD */
 
 struct event_callback {
 	TAILQ_ENTRY(event_callback) evcb_active_next;
@@ -150,13 +158,15 @@ TAILQ_HEAD (event_list, event);
 #undef TAILQ_HEAD
 #endif
 
+LIST_HEAD (event_dlist, event); 
+
 #ifdef EVENT_DEFINED_LISTENTRY_
 #undef LIST_ENTRY
-struct event_dlist;
-#undef EVENT_DEFINED_LISTENTRY_
-#else
-LIST_HEAD (event_dlist, event);
-#endif /* EVENT_DEFINED_LISTENTRY_ */
+#endif
+
+#ifdef EVENT_DEFINED_LISTHEAD_
+#undef LIST_HEAD
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This header adds TAILQ_HEAD and TAILQ_ENTRY if sys/queue is not included.
There is a similar macro that adds LIST_ENTRY but not LIST_HEAD, even though
LIST_HEAD is used later.

This change pulls in the correct definition (swiped from sys/queue) for
LIST_HEAD and cleans up the one spot where it is used.  The change can be
tested by adding

```
#undef LIST_HEAD
#undef LIST_ENTRY
```

right before the #ifndef checks and removing

```
#define EVENT_DEFINED_LISTENTRY_
#define EVENT_DEFINED_LISTHEAD_
```

so that the macros persist later.
