### PR TITLE
preserve errno in evhttp_connection_fail_ for inspection by the callback

### DIFF
--- a/http.c
+++ b/http.c
@@ -681,6 +681,7 @@ void
 evhttp_connection_fail_(struct evhttp_connection *evcon,
     enum evhttp_connection_error error)
 {
+	const int errsave = errno;
 	struct evhttp_request* req = TAILQ_FIRST(&evcon->requests);
 	void (*cb)(struct evhttp_request *, void *);
 	void *cb_arg;
@@ -725,6 +726,12 @@ evhttp_connection_fail_(struct evhttp_connection *evcon,
 	/* We are trying the next request that was queued on us */
 	if (TAILQ_FIRST(&evcon->requests) != NULL)
 		evhttp_connection_connect_(evcon);
+
+	/* The call to evhttp_connection_reset_ overwrote errno.
+	 * Let's restore the original errno, so that the user's
+	 * callback can have a better idea of what the error was.
+	 */
+	errno = errsave;
 
 	/* inform the user */
 	if (cb != NULL)


### PR DESCRIPTION
This addresses the issue that I brought up on the mailing list:

http://archives.seul.org/libevent/users/Nov-2012/msg00014.html

In evhttp_connection_fail_, the call to evhttp_connection_reset_ is overwriting errno, so that when the user's callback gets called at the end of evhttp_connection_fail_, it no longer has access to the original errno that caused the failure.

So, it seems to me it would be helpful if evhttp_connection_fail_ saves and restores errno.  That's what this commit does.

Although I fear I still may be missing something about the big picture of how error handling in evhttp is supposed to work.
