### PR TITLE
avoid valgrind false positive by zeroing epoll_event

### DIFF
--- a/epoll.c
+++ b/epoll.c
@@ -182,6 +182,7 @@ epoll_init(struct event_base *base)
 		fd = epollop->timerfd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK|TFD_CLOEXEC);
 		if (epollop->timerfd >= 0) {
 			struct epoll_event epev;
+			memset(&epev, 0, sizeof(epev));
 			epev.data.fd = epollop->timerfd;
 			epev.events = EPOLLIN;
 			if (epoll_ctl(epollop->epfd, EPOLL_CTL_ADD, fd, &epev) < 0) {


### PR DESCRIPTION
Not sure what your feeling on valgrind is, and whether you feel it's worth it to add a little bit of code to avoid valgrind false positives.  If not, that's fine, but if you do, this one-line memset avoids this valgrind false positive I was running into:

```
==26101== Syscall param epoll_ctl(event) points to uninitialised byte(s)
==26101==    at 0x5FC327A: epoll_ctl (syscall-template.S:82)
==26101==    by 0x53EF8DA: epoll_init (epoll.c:187)
==26101==    by 0x53E73F5: event_base_new_with_config (event.c:633)
==26101==    by 0x53E7524: event_base_new (event.c:468)
==26101==    by 0x409093: main (http-example-client.c:174)
==26101==  Address 0x7feffffb8 is on thread 1's stack
==26101==  Uninitialised value was created by a stack allocation
==26101==    at 0x53EF7E0: epoll_init (epoll.c:130)
```
