### PR TITLE
(for master) workaround for missing AC_PROG_SED on older Autoconfs

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -35,10 +35,15 @@ esac
 dnl Checks for programs.
 AC_PROG_CC
 AM_PROG_CC_C_O
-AC_PROG_SED
 AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MKDIR_P
+
+# AC_PROG_SED is only available in Autoconf >= 2.59b; workaround for older
+# versions
+ifdef([AC_PROG_SED], [AC_PROG_SED], [
+AC_CHECK_PROGS(SED, [gsed sed])
+])
 
 AC_PROG_GCC_TRADITIONAL
 


### PR DESCRIPTION
For pre-2.59b Autoconfs, AC_PROG_SED is not available [1]; on such
systems, avoid calling AC_PROG_SED, while providing a sensible SED.

This aids backporting to Autoconf 2.59.

[1] http://lists.gnu.org/archive/html/autotools-announce/2004-08/msg00002.html
