### PR TITLE
(for patches-2.0) workaround for missing AC_PROG_SED, drop to Autoconf 2.59

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -6,7 +6,7 @@ dnl See LICENSE for copying information.
 dnl
 dnl Original version Dug Song <dugsong@monkey.org>
 
-AC_PREREQ(2.59c)
+AC_PREREQ(2.59)
 AC_INIT(event.c)
 
 AC_CONFIG_MACRO_DIR([m4])
@@ -37,7 +37,7 @@ AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_INSTALL
 AC_PROG_LN_S
-AC_PROG_MKDIR_P
+# AC_PROG_MKDIR_P - $(MKDIR_P) should be defined by AM_INIT_AUTOMAKE
 
 # AC_PROG_SED is only available in Autoconf >= 2.59b; workaround for older
 # versions

--- a/m4/ac_backport_259_ssizet.m4
+++ b/m4/ac_backport_259_ssizet.m4
@@ -1,0 +1,3 @@
+AN_IDENTIFIER([ssize_t], [AC_TYPE_SSIZE_T])
+AC_DEFUN([AC_TYPE_SSIZE_T], [AC_CHECK_TYPE(ssize_t, int)])
+


### PR DESCRIPTION
Backport 9ab2b3f and ad03952, allowing libevent 2.0.x to be build on systems with old Autoconfs (RHEL5, I'm looking at you).
