### PR TITLE
Don't use return since return type is void and build error occurs using ...

### DIFF
--- a/evutil_rand.c
+++ b/evutil_rand.c
@@ -67,6 +67,7 @@ ev_arc4random_buf(void *buf, size_t n)
 {
 #if defined(EVENT__HAVE_ARC4RANDOM_BUF) && !defined(__APPLE__)
 	arc4random_buf(buf, n);
+	return;
 #else
 	unsigned char *b = buf;
 
@@ -79,6 +80,7 @@ ev_arc4random_buf(void *buf, size_t n)
 	 */
 	if (arc4random_buf != NULL) {
 		arc4random_buf(buf, n);
+		return;
 	}
 #endif
 	/* Make sure that we start out with b at a 4-byte alignment; plenty


### PR DESCRIPTION
When using clang, libevent causes build error that it uses return even if return type of function is void.
