### PR TITLE
evdns_server_request_parse

### DIFF
--- a/evdns.c
+++ b/evdns.c
@@ -1756,6 +1756,9 @@ evdns_server_request_add_reply(struct evdns_server_request *req_, int section, c
 	int *countp;
 	int result = -1;
 
+	if (req->port) {
+		EVDNS_LOCK(req->port);
+	}
 	if (req->response) /* have we already answered? */
 		goto done;
 
@@ -1815,6 +1818,9 @@ evdns_server_request_add_reply(struct evdns_server_request *req_, int section, c
 	++(*countp);
 	result = 0;
 done:
+	if (req->port) {
+		EVDNS_UNLOCK(req->port);
+	}
 	return result;
 }
 

--- a/evdns.c
+++ b/evdns.c
@@ -1200,9 +1200,7 @@ reply_parse(struct evdns_base *base, u8 *packet, int length) {
 	return -1;
 }
 
-/* Parse a raw request (packet,length) sent to a nameserver port (port) from */
-/* a DNS client (addr,addrlen), and if it's well-formed, call the corresponding */
-/* callback. */
+/* Parse a raw request (packet,length) */
 struct evdns_server_request* evdns_server_request_parse(ev_uint8_t *packet, int length)
 {
 	int j = 0;	/* index into packet */

--- a/evdns.c
+++ b/evdns.c
@@ -283,7 +283,6 @@ struct server_request {
 	struct server_request *next_pending;
 	struct server_request *prev_pending;
 
-	u16 trans_id; /* Transaction id. */
 	struct evdns_server_port *port; /* Which port received this request on? */
 	struct sockaddr_storage addr; /* Where to send the response */
 	ev_socklen_t addrlen; /* length of addr */
@@ -1229,7 +1228,7 @@ struct evdns_server_request* evdns_server_request_parse(ev_uint8_t *packet, int 
 	if (server_req == NULL) return NULL;
 	memset(server_req, 0, sizeof(struct server_request));
 
-	server_req->trans_id = trans_id;
+	server_req->base.trans_id = trans_id;
 
 	server_req->base.flags = flags;
 	server_req->base.nquestions = 0;
@@ -1903,7 +1902,7 @@ evdns_server_request_format_response(struct server_request *req, int err)
 	flags |= (0x8000 | err);
 
 	dnslabel_table_init(&table);
-	APPEND16(req->trans_id);
+	APPEND16(req->base.trans_id);
 	APPEND16(flags);
 	APPEND16(req->base.nquestions);
 	APPEND16(req->n_answer);

--- a/evdns.c
+++ b/evdns.c
@@ -1756,7 +1756,6 @@ evdns_server_request_add_reply(struct evdns_server_request *req_, int section, c
 	int *countp;
 	int result = -1;
 
-	EVDNS_LOCK(req->port);
 	if (req->response) /* have we already answered? */
 		goto done;
 
@@ -1816,7 +1815,6 @@ evdns_server_request_add_reply(struct evdns_server_request *req_, int section, c
 	++(*countp);
 	result = 0;
 done:
-	EVDNS_UNLOCK(req->port);
 	return result;
 }
 

--- a/evdns.c
+++ b/evdns.c
@@ -1203,7 +1203,7 @@ reply_parse(struct evdns_base *base, u8 *packet, int length) {
 /* Parse a raw request (packet,length) sent to a nameserver port (port) from */
 /* a DNS client (addr,addrlen), and if it's well-formed, call the corresponding */
 /* callback. */
-struct evdns_server_request* evdns_request_parse(ev_uint8_t *packet, int length, struct sockaddr *addr, ev_socklen_t addrlen)
+struct evdns_server_request* evdns_server_request_parse(ev_uint8_t *packet, int length, struct sockaddr *addr, ev_socklen_t addrlen)
 {
 	int j = 0;	/* index into packet */
 	u16 t_;	 /* used by the macros */
@@ -1402,7 +1402,7 @@ server_port_read(struct evdns_server_port *s) {
 			    evutil_socket_error_to_string(err), err);
 			return;
 		}
-		req = evdns_request_parse(packet, r, (struct sockaddr*) &addr, addrlen);
+		req = evdns_server_request_parse(packet, r, (struct sockaddr*) &addr, addrlen);
 		if (!req) {
 			continue;
 		}

--- a/evdns.c
+++ b/evdns.c
@@ -1983,6 +1983,28 @@ overflow:
 
 /* exported function */
 int
+evdns_server_request_get_response(struct evdns_server_request *req_, int err, char **response, size_t *response_len)
+{
+	struct server_request *req = TO_SERVER_REQUEST(req_);
+	int r = 0;
+	if (req->port) {
+		EVDNS_LOCK(req->port);
+	}
+	if (!req->response) {
+		r = evdns_server_request_format_response(req, err);
+	}
+	if (r == 0) {
+		*response = req->response;
+		*response_len = req->response_len;
+	}
+	if (req->port) {
+		EVDNS_LOCK(req->port);
+	}
+	return r;
+}
+
+/* exported function */
+int
 evdns_server_request_respond(struct evdns_server_request *req_, int err)
 {
 	struct server_request *req = TO_SERVER_REQUEST(req_);

--- a/include/event2/dns.h
+++ b/include/event2/dns.h
@@ -599,7 +599,7 @@ int evdns_server_request_add_cname_reply(struct evdns_server_request *req, const
 /**
     Parse a DNS request and return the caller-visible struct
 */
-struct evdns_server_request* evdns_request_parse(ev_uint8_t *packet, int length, struct sockaddr *addr, ev_socklen_t addrlen);
+struct evdns_server_request* evdns_server_request_parse(ev_uint8_t *packet, int length, struct sockaddr *addr, ev_socklen_t addrlen);
 /**
    Send back a response to a DNS request, and free the request structure.
 */

--- a/include/event2/dns.h
+++ b/include/event2/dns.h
@@ -599,7 +599,7 @@ int evdns_server_request_add_cname_reply(struct evdns_server_request *req, const
 /**
     Parse a DNS request and return the caller-visible struct
 */
-struct evdns_server_request* evdns_server_request_parse(ev_uint8_t *packet, int length, struct sockaddr *addr, ev_socklen_t addrlen);
+struct evdns_server_request* evdns_server_request_parse(ev_uint8_t *packet, int length);
 /**
     Construct the DNS response and return it
 */

--- a/include/event2/dns.h
+++ b/include/event2/dns.h
@@ -597,6 +597,10 @@ int evdns_server_request_add_ptr_reply(struct evdns_server_request *req, struct 
 int evdns_server_request_add_cname_reply(struct evdns_server_request *req, const char *name, const char *cname, int ttl);
 
 /**
+    Parse a DNS request and return the caller-visible struct
+*/
+struct evdns_server_request* evdns_request_parse(ev_uint8_t *packet, int length, struct sockaddr *addr, ev_socklen_t addrlen);
+/**
    Send back a response to a DNS request, and free the request structure.
 */
 int evdns_server_request_respond(struct evdns_server_request *req, int err);

--- a/include/event2/dns.h
+++ b/include/event2/dns.h
@@ -601,6 +601,10 @@ int evdns_server_request_add_cname_reply(struct evdns_server_request *req, const
 */
 struct evdns_server_request* evdns_server_request_parse(ev_uint8_t *packet, int length, struct sockaddr *addr, ev_socklen_t addrlen);
 /**
+    Construct the DNS response and return it
+*/
+int evdns_server_request_get_response(struct evdns_server_request *req, int err, char **response, size_t *response_len);
+/**
    Send back a response to a DNS request, and free the request structure.
 */
 int evdns_server_request_respond(struct evdns_server_request *req, int err);

--- a/include/event2/dns_struct.h
+++ b/include/event2/dns_struct.h
@@ -54,6 +54,7 @@ extern "C" {
  */
 
 struct evdns_server_request {
+	ev_uint16_t trans_id; /* Transaction id. */
 	int flags;
 	int nquestions;
 	struct evdns_server_question **questions;


### PR DESCRIPTION
Here is the direction I was thinking for exposing request_parse to the world. My use case is that I have a packet in memory and I would like to parse it, inspect it, etc. I don't have or need an `evdns_server_port`.

One confusing thing for users might be that `evdns_server_request_parse` returns a `evdns_server_request` which is not associated with a port, so for example passing it to `evdns_server_request_respond` would result in an error. Either we could document that, or provide a new function `evdns_server_request_set_port` or whatever, which would do the stuff `server_port_read` now does.

I'm also happy to write tests, if you think there is something new to be tested.

Thoughts?
