### PR TITLE
Avoid racy bufferevent activation

### DIFF
--- a/http.c
+++ b/http.c
@@ -364,8 +364,6 @@ evhttp_write_buffer(struct evhttp_connection *evcon,
 	evcon->cb = cb;
 	evcon->cb_arg = arg;
 
-	bufferevent_enable(evcon->bufev, EV_WRITE);
-
 	/* Disable the read callback: we don't actually care about data;
 	 * we only care about close detection.  (We don't disable reading,
 	 * since we *do* want to learn about any close events.) */
@@ -374,6 +372,8 @@ evhttp_write_buffer(struct evhttp_connection *evcon,
 	    evhttp_write_cb,
 	    evhttp_error_cb,
 	    evcon);
+
+	bufferevent_enable(evcon->bufev, EV_WRITE);
 }
 
 static void


### PR DESCRIPTION
The evhttp_send_reply method invokes evhttp_write_buffer with a
callback that may release the underlying request object and
bufferevent upon completion. This cleanup callback is invoked by the
underlying bufferevent's write callback. Improperly enabling write
events before referencing the bufferevent could lead to use after free
and memory corruption.
