### PR TITLE
Update epoll.c

### DIFF
--- a/epoll.c
+++ b/epoll.c
@@ -544,79 +544,6 @@ static int
 epoll_nochangelist_del(struct event_base *base, evutil_socket_t fd,
     short old, short events, void *p)
 {
-	struct event_change ch;
-	ch.fd = fd;
-	ch.old_events = old;
-	ch.read_change = ch.write_change = 0;
-	if (events & EV_WRITE)
-		ch.write_change = EV_CHANGE_DEL;518
-519
-520
-521
-522
-523
-524
-525
-526
-527
-528
-529
-530
-531
-532
-533
-534
-535
-536
-537
-538
-539
-540
-541
-542
-543
-544
-545
-546
-547
-548
-549
-550
-551
-552
-553
-554
-555
-556
-557
-558
-559
-560
-                if (epoll_apply_one_change(base, epollop, ch) < 0)
-                        r = -1;
-        }
-        return (r);
-}
-static int
-epoll_nochangelist_add(struct event_base *base, evutil_socket_t fd,
-    short old, short events, void *p)
-{
-        struct event_change ch;
-        ch.fd = fd;
-        ch.old_events = old;
-        ch.read_change = ch.write_change = 0;
-        if (events & EV_WRITE)
-                ch.write_change = EV_CHANGE_ADD |
-                    (events & EV_ET);
-        if (events & EV_READ)
-                ch.read_change = EV_CHANGE_ADD |
-                    (events & EV_ET);
-        return epoll_apply_one_change(base, base->evbase, &ch);
-}
-static int
-epoll_nochangelist_del(struct event_base *base, evutil_socket_t fd,
-    short old, short events, void *p)
-{
         struct event_change ch;
         ch.fd = fd;
         ch.old_events = old;
@@ -626,16 +553,6 @@ epoll_nochangelist_del(struct event_base *base, evutil_socket_t fd,
         if (events & EV_READ)
                 ch.read_change = EV_CHANGE_DEL;
         return epoll_apply_one_change(base, base->evbase, &ch);
-}
-static int
-epoll_dispatch(struct event_base *base, struct timeval *tv)
-Commit summary: Extended description: (optional)
-zmldndx 375021616@qq.com
-
-	if (events & EV_READ)
-		ch.read_change = EV_CHANGE_DEL;
-
-	return epoll_apply_one_change(base, base->evbase, &ch);
 }
 
 static int


### PR DESCRIPTION
epollop->events will be changed by other threads(by realloc below), but events would not change to the new memory, and the original memory would be freed. it will probably cause problems unknown.
also, after realloc, we should initialize the new alloced memory with 0, or purifyplus will warn UMR
