### PR TITLE
Disable global_randomize_case of evdns by default

### DIFF
--- a/evdns.c
+++ b/evdns.c
@@ -3894,7 +3894,7 @@ evdns_base_new(struct event_base *event_base, int flags)
 	base->global_max_retransmits = 3;
 	base->global_max_nameserver_timeout = 3;
 	base->global_search_state = NULL;
-	base->global_randomize_case = 1;
+	base->global_randomize_case = 0;
 	base->global_getaddrinfo_allow_skew.tv_sec = 3;
 	base->global_getaddrinfo_allow_skew.tv_usec = 0;
 	base->global_nameserver_probe_initial_timeout.tv_sec = 10;


### PR DESCRIPTION
Disable global_randomize_case of evdns by default. Because some nameservers do not follow the expected response behavior, they do not match the exact case of the name in the response. This mechanism must be used with a whitelist of nameservers which we know apply the standards correctly. See more at https://developers.google.com/speed/public-dns/docs/security 
