### PR TITLE
Add new evsignal_add_with_flags() for signal events

### DIFF
--- a/event-internal.h
+++ b/event-internal.h
@@ -52,6 +52,7 @@ extern "C" {
 /* used only by signals */
 #define ev_ncalls	ev_.ev_signal.ev_ncalls
 #define ev_pncalls	ev_.ev_signal.ev_pncalls
+#define ev_sa_flags	ev_.ev_signal.sa_flags
 
 #define ev_pri ev_evcallback.evcb_pri
 #define ev_flags ev_evcallback.evcb_flags
@@ -400,7 +401,7 @@ struct event_config {
 	((base)->event_count_active)
 
 int evsig_set_handler_(struct event_base *base, int evsignal,
-			  void (*fn)(int));
+			  void (*fn)(int), int);
 int evsig_restore_handler_(struct event_base *base, int evsignal);
 
 int event_add_nolock_(struct event *ev,

--- a/event.c
+++ b/event.c
@@ -2071,6 +2071,8 @@ event_new(struct event_base *base, evutil_socket_t fd, short events, void (*cb)(
 	ev = mm_malloc(sizeof(struct event));
 	if (ev == NULL)
 		return (NULL);
+
+	ev->ev_sa_flags = SA_RESTART;
 	if (event_assign(ev, base, fd, events, cb, arg) < 0) {
 		mm_free(ev);
 		return (NULL);
@@ -2357,6 +2359,14 @@ event_add(struct event *ev, const struct timeval *tv)
 	EVBASE_RELEASE_LOCK(ev->ev_base, th_base_lock);
 
 	return (res);
+}
+
+int
+evsignal_add_with_flags(struct event *ev, const struct timeval *tv, int flags)
+{
+	ev->ev_sa_flags = flags;
+
+	return evsignal_add(ev, tv);
 }
 
 /* Helper callback: wake an event_base from another thread.  This version

--- a/evmap.c
+++ b/evmap.c
@@ -454,7 +454,7 @@ evmap_signal_add_(struct event_base *base, int sig, struct event *ev)
 	    base->evsigsel->fdinfo_len);
 
 	if (LIST_EMPTY(&ctx->events)) {
-		if (evsel->add(base, ev->ev_fd, 0, EV_SIGNAL, NULL)
+		if (evsel->add(base, ev->ev_fd, 0, EV_SIGNAL, (void *)&ev->ev_sa_flags)
 		    == -1)
 			return (-1);
 	}

--- a/include/event2/event.h
+++ b/include/event2/event.h
@@ -936,6 +936,13 @@ int event_base_got_break(struct event_base *);
 #define evtimer_initialized(ev)		event_initialized(ev)
 /**@}*/
 
+
+/**
+ * Change default sa_flags for sigaction(2) from SA_RESTART
+ * to user-specific.
+ */
+int evsignal_add_with_flags(struct event *, const struct timeval *, int);
+
 /**
    @name evsignal_* macros
 

--- a/include/event2/event_struct.h
+++ b/include/event2/event_struct.h
@@ -145,6 +145,8 @@ struct event {
 			short ev_ncalls;
 			/* Allows deletes in callback */
 			short *ev_pncalls;
+			/* Passed to sigaction(). */
+			int sa_flags;
 		} ev_signal;
 	} ev_;
 


### PR DESCRIPTION
```
This patch, change `struct event`, and this can break binary compatibility.
If this is a major issue, we can fix this patch to avoid breaking it.
Thanks.
```

By default libevent set SA_RESTART flag for sigaction(2), which will restart
syscall automatically, and this is not always good.
(That because it need to be compitable with signal(2), while it vary
across systems)

This patch add new function evsignal_add_with_flags(), which will change
this flag from default SA_RESTART to user defined.
