### PR TITLE
Add -Qunused-arguments for clang on macos

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -817,6 +817,15 @@ if test x$enable_gcc_warnings != xno && test "$GCC" = "yes"; then
     # Disable the unused-function warnings, because these trigger
     # for minheap-internal.h related code.
     CFLAGS="$CFLAGS -Wno-unused-function"
+
+    # clang on macosx emits warnigns for each directory specified which
+    # isn't "used" generating a lot of build noise (typically 3 warnings
+    # per file
+    case "$host_os" in
+        darwin*)
+            CFLAGS="$CFLAGS -Qunused-arguments"
+        ;;
+    esac
   fi
 
 ##This will break the world on some 64-bit architectures


### PR DESCRIPTION
The clang compiler provided with macosx emits warnings like:

  CC       bufferevent.lo
clang: warning: argument unused during compilation: '-I .'
clang: warning: argument unused during compilation: '-I ./compat'
clang: warning: argument unused during compilation: '-I ./include'
clang: warning: argument unused during compilation: '-I ./include'

for each file being compiled. This generates a lot of noise during
compilation making it hard to see "real" errors. This patch mute
those warnings.
