### PR TITLE
evdns: disable probing with EVDNS_BASE_DISABLE_WHEN_INACTIVE

### DIFF
--- a/evdns.c
+++ b/evdns.c
@@ -662,6 +662,7 @@ request_finished(struct request *const req, struct request **head, int free_hand
 	    req->ns->requests_inflight == 0 &&
 	    req->base->disable_when_inactive) {
 		event_del(&req->ns->event);
+		evtimer_del(&req->ns->timeout_event);
 	}
 
 	if (!req->request_appended) {
@@ -2199,7 +2200,8 @@ evdns_request_transmit_to(struct request *req, struct nameserver *server) {
 
 	if (server->requests_inflight == 1 &&
 		req->base->disable_when_inactive &&
-		event_add(&server->event, NULL) < 0) {
+		event_add(&server->event, NULL) < 0 &&
+		evtimer_add(&req->ns->timeout_event, &req->base->global_nameserver_probe_initial_timeout) < 0) {
 		return 1;
 	}
 


### PR DESCRIPTION
When user install EVDNS_BASE_DISABLE_WHEN_INACTIVE flag for evdns base,
we must remove the timer that is used for probing, if current dns server
failed, otherwise it won't break the loop.
