### PR TITLE
Add missing headerfile for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,6 +526,7 @@ set(HDR_PUBLIC
     include/event2/http.h
     include/event2/http_compat.h
     include/event2/http_struct.h
+    include/event2/keyvalq_struct.h
     include/event2/listener.h
     include/event2/rpc.h
     include/event2/rpc_compat.h


### PR DESCRIPTION
make install didn't install all of the headerfiles causing compilation error...
