### PR TITLE
Add support for systemd watchdog protocol

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -757,6 +757,14 @@ if test x$enable_verbose_debug = xyes; then
 	CFLAGS="$CFLAGS -DUSE_DEBUG"
 fi
 
+# check if we can compile systemd watchdog support
+AC_CHECK_HEADERS([systemd/sd-daemon.h],
+    AC_SEARCH_LIBS([sd_watchdog_enabled], [systemd-daemon],
+        [AC_DEFINE(HAVE_SYSTEMD_WATCHDOG,1,[Have systemd v209 or more])
+        SYSTEMD_LIBS="-lsystemd-daemon"]))
+
+AC_SUBST(SYSTEMD_LIBS)
+
 # check if we have and should use openssl
 AM_CONDITIONAL(OPENSSL, [test "$enable_openssl" != "no" && test "$have_openssl" = "yes"])
 

--- a/libevent.pc.in
+++ b/libevent.pc.in
@@ -10,7 +10,7 @@ Description: libevent is an asynchronous notification event loop library
 Version: @VERSION@
 Requires:
 Conflicts:
-Libs: -L${libdir} -levent
+Libs: -L${libdir} -levent @SYSTEMD_LIBS@
 Libs.private: @LIBS@
 Cflags: -I${includedir}
 


### PR DESCRIPTION
This permit to directly have all servers using libevent
to be aware of systemd watchdog monitoring protocol.
It work by sending a message over a specific FD, with
sd_notify.

Unless explicitely enabled by the configuration of the systemd unit,
nothing will be done, so it is safe to enable by default. There is
also protection against accidental triggering with check of the PID
supervised by systemd.

This feature requires at least the version 209 of systemd
due to sd_watchdog_enabled function.