### PR TITLE
rework libevent linkage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -222,8 +222,8 @@ endif
 
 GENERIC_LDFLAGS = -version-info $(VERSION_INFO) $(RELEASE) $(NO_UNDEFINED)
 
-libevent_la_SOURCES = $(CORE_SRC) $(EXTRAS_SRC)
-libevent_la_LIBADD = @LTLIBOBJS@ $(SYS_LIBS)
+libevent_la_SOURCES =
+libevent_la_LIBADD = @LTLIBOBJS@ $(SYS_LIBS) libevent_core.la libevent_extra.la
 libevent_la_LDFLAGS = $(GENERIC_LDFLAGS)
 
 libevent_core_la_SOURCES = $(CORE_SRC)


### PR DESCRIPTION
This changes libevent.so so that it doesn't contain any code.  Instead,
it links against the existing core/extra libraries.  At runtime, the
ldso will load those, so the ABI should stay the same.

However, at link time, trying to use -levent with newer linkers might
have trouble.  They will event require you to explicitly link against
the libraries you use and not allow indirect references.  This only
impacts people who hardcode -levent directly rather than using the
pkg-config file, so this shouldn't be a big deal.  If anything, it
encourages people to switch to the pkg-config file.

There's a similar issue for libevent.a as it is empty.  If you use
libtool or pkg-config, things will still work, but if you try to use
-static -levent directly, things will fail.
