### PR TITLE
add a --disable-samples configure flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,9 @@ AC_ARG_ENABLE([libevent-install],
 AC_ARG_ENABLE([libevent-regress],
      AS_HELP_STRING([--disable-libevent-regress, skip regress in make check]),
 	[], [enable_libevent_regress=yes])
+AC_ARG_ENABLE([samples],
+     AS_HELP_STRING([--disable-samples, skip building of sample programs]),
+	[], [enable_samples=yes])
 AC_ARG_ENABLE([function-sections],
      AS_HELP_STRING([--enable-function-sections, make static library allow smaller binaries with --gc-sections]),
 	[], [enable_function_sections=no])
@@ -127,6 +130,7 @@ dnl   the command line with --enable-shared and --disable-shared.
 dnl AC_DISABLE_SHARED
 AC_SUBST(LIBTOOL_DEPS)
 
+AM_CONDITIONAL([BUILD_SAMPLES], [test "$enable_samples" = "yes"])
 AM_CONDITIONAL([BUILD_REGRESS], [test "$enable_libevent_regress" = "yes"])
 
 dnl Checks for libraries.

--- a/sample/include.am
+++ b/sample/include.am
@@ -30,7 +30,9 @@ noinst_HEADERS += \
 	sample/openssl_hostname_validation.h
 endif
 
+if BUILD_SAMPLES
 noinst_PROGRAMS += $(SAMPLES)
+endif
 
 $(SAMPLES) : libevent.la
 


### PR DESCRIPTION
For people building & installing libevent in a distro, building all these
sample apps are not useful.  Add a flag to turn them off.
