### PR TITLE
Update event_tagging.c

### DIFF
--- a/event_tagging.c
+++ b/event_tagging.c
@@ -208,7 +208,7 @@ decode_tag_internal(ev_uint32_t *ptag, struct evbuffer *evbuf, int dodrain)
 	data = evbuffer_pullup(
 		evbuf, len < sizeof(number) + 1 ? len : sizeof(number) + 1);
 
-	while (count++ < len) {
+	while (count++ < len && data) {
 		ev_uint8_t lower = *data++;
 		if (shift >= 28) {
 			/* Make sure it fits into 32 bits */


### PR DESCRIPTION
In function decode_tag_internal 
static int decode_tag_internal(ev_uint32_t *ptag, struct evbuffer *evbuf, int dodrain)
{...
 data = evbuffer_pullup(evbuf, len < sizeof(number) + 1 ? len : sizeof(number) + 1);
//evbuffer_pullup may return null.
//data is used below which causes dereferencing null
while (count++ < len) {
        ev_uint8_t lower = *data++;
//dereference: Incrementing a pointer which might be null: data might be null.
        number |= (lower & 0x7f) << shift;
        shift += 7;

```
    if (!(lower & 0x80)) {
        done = 1;
        break;
    }
}
```

To resolve this checking data in while loop
line no 211 
while (count++ < len) { 
is replaced with 
while (count++ < len && data) {
