### PR TITLE
Update evdns.c

### DIFF
--- a/evdns.c
+++ b/evdns.c
@@ -4679,7 +4679,7 @@ evdns_getaddrinfo(struct evdns_base *dns_base,
 		data->ipv6_request.r = evdns_base_resolve_ipv6(dns_base,
 		    nodename, 0, evdns_getaddrinfo_gotresolve,
 		    &data->ipv6_request);
-		if (want_cname)
+		if (want_cname && data->ipv6_request.r)
 			data->ipv6_request.r->current_req->put_cname_in_ptr =
 			    &data->cname_result;
 	}


### PR DESCRIPTION
In function evdns_getaddrinfo
API evdns_base_resolve_ipv6 may return null at line no 4682
afterwards we are trying to dereference it below
if (want_cname)
{
data->ipv6_request.r->current_req->put_cname_in_ptr = &data->cname_result;
}
which may cause problem
To resolve checking the data->ipv6_request.r before dereferencing it as below
if (want_cname ) 
is replaced with
if (want_cname && data->ipv6_request.r)
