### PR TITLE
Update bufferevent_filter.c

### DIFF
--- a/bufferevent_filter.c
+++ b/bufferevent_filter.c
@@ -507,7 +507,9 @@ be_filter_ctrl(struct bufferevent *bev, enum bufferevent_ctrl_op op,
 	switch (op) {
 	case BEV_CTRL_GET_UNDERLYING:
 		bevf = upcast(bev);
-		data->ptr = bevf->underlying;
+		if (bevf) {
+			data->ptr = bevf->underlying;
+		}
 		return 0;
 	case BEV_CTRL_GET_FD:
 	case BEV_CTRL_SET_FD:


### PR DESCRIPTION
In function 
static int
be_filter_ctrl(struct bufferevent *bev, enum bufferevent_ctrl_op op,
    union bufferevent_ctrl_data *data)
{
    struct bufferevent_filtered *bevf;
    switch (op) {
    case BEV_CTRL_GET_UNDERLYING:
        bevf = upcast(bev);
        data->ptr = bevf->underlying;
        return 0;
    case BEV_CTRL_GET_FD:
    case BEV_CTRL_SET_FD:
    case BEV_CTRL_CANCEL_ALL:
    default:
        return -1;
    }
}

upcast api may return null and we are trying to dereference bevf (bufferevent_filtered)
To resolve the issue null check added for bevf
