### PR TITLE
Update bufferevent_filter.c

### DIFF
--- a/bufferevent_filter.c
+++ b/bufferevent_filter.c
@@ -262,8 +262,9 @@ be_filter_enable(struct bufferevent *bev, short event)
 
 	if (event & EV_READ) {
 		BEV_RESET_GENERIC_READ_TIMEOUT(bev);
-		bufferevent_unsuspend_read_(bevf->underlying,
-		    BEV_SUSPEND_FILT_READ);
+		if(bevf)
+			bufferevent_unsuspend_read_(bevf->underlying,
+		    	    BEV_SUSPEND_FILT_READ);
 	}
 	return 0;
 }
@@ -276,8 +277,9 @@ be_filter_disable(struct bufferevent *bev, short event)
 		BEV_DEL_GENERIC_WRITE_TIMEOUT(bev);
 	if (event & EV_READ) {
 		BEV_DEL_GENERIC_READ_TIMEOUT(bev);
-		bufferevent_suspend_read_(bevf->underlying,
-		    BEV_SUSPEND_FILT_READ);
+		if(bevf)
+			bufferevent_suspend_read_(bevf->underlying,
+		    	    BEV_SUSPEND_FILT_READ);
 	}
 	return 0;
 }


### PR DESCRIPTION
Adding null check for buffer event filter pointer in below API's 
static int be_filter_enable(struct bufferevent *bev, short event)
and
static int be_filter_disable(struct bufferevent *bev, short event)

before dereferencing the buffer event filter pointer we should check for null as upcast api might return null (buffer event filter pointer )
