### PR TITLE
bufferevent_openssl: reset fd_is_set when setfd with -1 is called

### DIFF
--- a/bufferevent_openssl.c
+++ b/bufferevent_openssl.c
@@ -1276,6 +1276,8 @@ be_openssl_ctrl(struct bufferevent *bev,
 			SSL_set_bio(bev_ssl->ssl, bio, bio);
 			bev_ssl->fd_is_set = 1;
 		}
+		if (data->fd == -1)
+			bev_ssl->fd_is_set = 0;
 		if (bev_ssl->state == BUFFEREVENT_SSL_OPEN)
 			return set_open_callbacks(bev_ssl, data->fd);
 		else {


### PR DESCRIPTION
Otherwise we will use old fd after close(2) called on it:
(Traces trimmed, to minimize it)
$ strace -keclose,open,socket,epoll_ctl https-client -url https://libevent.org
socket(PF_INET, SOCK_STREAM|SOCK_NONBLOCK, IPPROTO_IP) = 5

> /lib/x86_64-linux-gnu/libc-2.19.so(socket+0x7) [0xe6da7]
> /usr/lib/libevent-2.1.so.4.0.0(evutil_socket_+0x25) [0x27835]
> /usr/lib/libevent-2.1.so.4.0.0(bufferevent_socket_connect+0xe9) [0x1b1a9]
> /usr/lib/libevent-2.1.so.4.0.0(bufferevent_socket_connect+0x21f) [0x1b2df]
> /usr/lib/libevent-2.1.so.4.0.0(evutil_getaddrinfo_async_+0x65) [0x271a5]
> /usr/lib/libevent-2.1.so.4.0.0(bufferevent_socket_connect_hostname+0x106) [0x1b416]
> /usr/lib/libevent-2.1.so.4.0.0(evhttp_connection_connect_+0xe7) [0x39f07]
> /usr/lib/libevent-2.1.so.4.0.0(evhttp_make_request+0xb8) [0x3a218]
> epoll_ctl(3, EPOLL_CTL_ADD, 5, {EPOLLIN, {u32=5, u64=5}}) = 0
> ...
> /usr/lib/libevent_openssl-2.1.so.4.0.0(_init+0xfdd) [0x2ced]
> /usr/lib/libevent-2.1.so.4.0.0(bufferevent_setfd+0x3b) [0x16d9b]
> /usr/lib/libevent-2.1.so.4.0.0(bufferevent_socket_connect+0x75) [0x1b135]
> /usr/lib/libevent-2.1.so.4.0.0(bufferevent_socket_connect+0x21f) [0x1b2df]
> /usr/lib/libevent-2.1.so.4.0.0(evutil_getaddrinfo_async_+0x65) [0x271a5]
> /usr/lib/libevent-2.1.so.4.0.0(bufferevent_socket_connect_hostname+0x106) [0x1b416]
> /usr/lib/libevent-2.1.so.4.0.0(evhttp_connection_connect_+0xe7) [0x39f07]
> /usr/lib/libevent-2.1.so.4.0.0(evhttp_make_request+0xb8) [0x3a218]
> epoll_ctl(3, EPOLL_CTL_MOD, 5, {EPOLLIN|EPOLLOUT, {u32=5, u64=5}}) = 0
> ...
> /usr/lib/libevent_openssl-2.1.so.4.0.0(_init+0xfee) [0x2cfe]
> /usr/lib/libevent-2.1.so.4.0.0(bufferevent_setfd+0x3b) [0x16d9b]
> /usr/lib/libevent-2.1.so.4.0.0(bufferevent_socket_connect+0x75) [0x1b135]
> /usr/lib/libevent-2.1.so.4.0.0(bufferevent_socket_connect+0x21f) [0x1b2df]
> /usr/lib/libevent-2.1.so.4.0.0(evutil_getaddrinfo_async_+0x65) [0x271a5]
> /usr/lib/libevent-2.1.so.4.0.0(bufferevent_socket_connect_hostname+0x106) [0x1b416]
> /usr/lib/libevent-2.1.so.4.0.0(evhttp_connection_connect_+0xe7) [0x39f07]
> /usr/lib/libevent-2.1.so.4.0.0(evhttp_make_request+0xb8) [0x3a218]
> epoll_ctl(3, EPOLL_CTL_MOD, 5, {EPOLLOUT, {u32=5, u64=5}}) = 0
> ...
> /usr/lib/libevent_openssl-2.1.so.4.0.0(_init+0xbbc) [0x28cc]
> /usr/lib/libevent_openssl-2.1.so.4.0.0(_init+0xd96) [0x2aa6]
> /usr/lib/libevent_openssl-2.1.so.4.0.0(_init+0xeb8) [0x2bc8]
> /usr/lib/libevent-2.1.so.4.0.0(event_free+0x3fe) [0x1fd1e]
> /usr/lib/libevent-2.1.so.4.0.0(event_base_loop+0x407) [0x20677]
> epoll_ctl(3, EPOLL_CTL_DEL, 5, 7fffa1f841e0) = 0
> ...
> /usr/lib/libevent_openssl-2.1.so.4.0.0(_init+0xbc4) [0x28d4]
> /usr/lib/libevent_openssl-2.1.so.4.0.0(_init+0xd96) [0x2aa6]
> /usr/lib/libevent_openssl-2.1.so.4.0.0(_init+0xeb8) [0x2bc8]
> /usr/lib/libevent-2.1.so.4.0.0(event_free+0x3fe) [0x1fd1e]
> /usr/lib/libevent-2.1.so.4.0.0(event_base_loop+0x407) [0x20677]
> close(5)                                = 0
> /lib/x86_64-linux-gnu/libpthread-2.19.so(__close_nocancel+0x7) [0xeb20]
> /usr/lib/libevent-2.1.so.4.0.0(evhttp_connection_reset_+0x55) [0x373f5]
> /usr/lib/libevent-2.1.so.4.0.0(evhttp_connection_connect_+0x1d) [0x39e3d]
> /usr/lib/libevent-2.1.so.4.0.0(event_free+0x3fe) [0x1fd1e]
> /usr/lib/libevent-2.1.so.4.0.0(event_base_loop+0x407) [0x20677]
> epoll_ctl(3, EPOLL_CTL_ADD, 5, {EPOLLIN, {u32=5, u64=5}}) = -1 EBADF (Bad file descriptor)
> ) = -1 EBADF (Bad file descriptor)
> /src/oss/strace-code/strace: Can't initiate libunwind: No such process
> ...
> /usr/lib/libevent_openssl-2.1.so.4.0.0(_init+0xfdd) [0x2ced]
> /usr/lib/libevent-2.1.so.4.0.0(bufferevent_setfd+0x3b) [0x16d9b]
> /usr/lib/libevent-2.1.so.4.0.0(evhttp_connection_connect_+0x14c) [0x39f6c]
> /usr/lib/libevent-2.1.so.4.0.0(event_free+0x3fe) [0x1fd1e]
> /usr/lib/libevent-2.1.so.4.0.0(event_base_loop+0x407) [0x20677]
> /src/oss/strace-code/strace: Exit of unknown pid 28185 seen
> [warn] Epoll ADD(1) on fd 5 failed.  Old events were 0; read change was 1 (add); write change was 0 (none); close change was 0 (none): Bad file descriptor
> epoll_ctl(3, EPOLL_CTL_ADD, 5, {EPOLLOUT, {u32=5, u64=5}}) = -1 EBADF (Bad file descriptor)
> ) = -1 EBADF (Bad file descriptor)
> /src/oss/strace-code/strace: Can't initiate libunwind: No such process
> ...
> /usr/lib/libevent_openssl-2.1.so.4.0.0(_init+0xfee) [0x2cfe]
> /usr/lib/libevent-2.1.so.4.0.0(bufferevent_setfd+0x3b) [0x16d9b]
> /usr/lib/libevent-2.1.so.4.0.0(evhttp_connection_connect_+0x14c) [0x39f6c]
> /usr/lib/libevent-2.1.so.4.0.0(event_free+0x3fe) [0x1fd1e]
> /usr/lib/libevent-2.1.so.4.0.0(event_base_loop+0x407) [0x20677]
> /src/oss/strace-code/strace: Exit of unknown pid 28186 seen
> [warn] Epoll ADD(4) on fd 5 failed.  Old events were 0; read change was 0 (none); write change was 1 (add); close change was 0 (none): Bad file descriptor
> <getaddrinfo traces trimmed>
> close(5)                                = -1 EBADF (Bad file descriptor)
> )                                = -1 EBADF (Bad file descriptor)
> /src/oss/strace-code/strace: Can't initiate libunwind: No such process
> /lib/x86_64-linux-gnu/libpthread-2.19.so(__close_nocancel+0x7) [0xeb20]
> /usr/lib/libevent-2.1.so.4.0.0(evhttp_connection_reset_+0x55) [0x373f5]
> /usr/lib/libevent-2.1.so.4.0.0(evhttp_connection_fail_+0xc1) [0x3aed1]
> /usr/lib/libevent-2.1.so.4.0.0(evhttp_connection_fail_+0x4a3) [0x3b2b3]
> /usr/lib/libevent-2.1.so.4.0.0(bufferevent_enable+0x192) [0x16722]
> /usr/lib/libevent-2.1.so.4.0.0(event_free+0x5df) [0x1feff]
> /usr/lib/libevent-2.1.so.4.0.0(event_base_loop+0x407) [0x20677]
> /src/oss/strace-code/strace: Exit of unknown pid 28187 seen
> some request failed - no idea which one though!
> socket error = Bad file descriptor (9)

Before this patch:
$ sample/https-client -retries 1 -url https://libevent.org
[warn] Epoll ADD(1) on fd 6 failed.  Old events were 0; read change was 1 (add); write change was 0 (none); close change was 0 (none): Bad file descriptor
[warn] Epoll ADD(4) on fd 6 failed.  Old events were 0; read change was 0 (none); write change was 1 (add); close change was 0 (none): Bad file descriptor
some request failed - no idea which one though!
socket error = Bad file descriptor (9)

After this patch:
$ sample/https-client -retries 1 -url https://libevent.org
Response line: 0 (null)

Reported-by: gerkenjohannes@web.de
