### PR TITLE
remove trailing comma from enum

### DIFF
--- a/include/event2/bufferevent.h
+++ b/include/event2/bufferevent.h
@@ -599,7 +599,7 @@ enum bufferevent_trigger_options {
 	BEV_TRIG_IGNORE_WATERMARKS = (1<<16),
 
 	/** defer even if the callbacks are not */
-	BEV_TRIG_DEFER_CALLBACKS = BEV_OPT_DEFER_CALLBACKS,
+	BEV_TRIG_DEFER_CALLBACKS = BEV_OPT_DEFER_CALLBACKS
 
 	/* (Note: for internal reasons, these need to be disjoint from
 	 * bufferevent_options, except when they mean the same thing. */


### PR DESCRIPTION
makes being included from something with -std=c89 happy
