### PR TITLE
evhttp: Fix failure to send all output data for POST/PUT requests

### DIFF
--- a/http.c
+++ b/http.c
@@ -1108,6 +1108,9 @@ evhttp_write_connectioncb(struct evhttp_connection *evcon, void *arg)
 
 	EVUTIL_ASSERT(evcon->state == EVCON_WRITING);
 
+	/* We need to wait until we've written all of our output data before we can continue */
+	if (evbuffer_get_length(bufferevent_get_output(evcon->bufev)) > 0) { return; }
+
 	/* We are done writing our header and are now expecting the response */
 	req->kind = EVHTTP_RESPONSE;
 


### PR DESCRIPTION
Issuing a POST or PUT request with an output buffer that has enough data to cause an EAGAIN will cause the underlying bufferevent on the evhttp connection to start listening for headers before the rest of the output data is sent. The server/endpoint would then sit waiting for the rest of the data and the client will eventually timeout causing the request to fail.