### PR TITLE
Implemented bufferevent_socket_connect_hostname_hints()

### DIFF
--- a/bufferevent_sock.c
+++ b/bufferevent_sock.c
@@ -467,13 +467,27 @@ int
 bufferevent_socket_connect_hostname(struct bufferevent *bev,
     struct evdns_base *evdns_base, int family, const char *hostname, int port)
 {
-	char portbuf[10];
 	struct evutil_addrinfo hint;
+	memset(&hint, 0, sizeof(hint));
+	hint.ai_family = family;
+	hint.ai_protocol = IPPROTO_TCP;
+	hint.ai_socktype = SOCK_STREAM;
+
+	return bufferevent_socket_connect_hostname_hints(bev, evdns_base, &hint, hostname, port);
+}
+
+int
+bufferevent_socket_connect_hostname_hints(struct bufferevent *bev,
+    struct evdns_base *evdns_base, const struct evutil_addrinfo *hints_in,
+    const char *hostname, int port)
+{
+	char portbuf[10];
 	int err;
 	struct bufferevent_private *bev_p =
 	    EVUTIL_UPCAST(bev, struct bufferevent_private, bev);
 
-	if (family != AF_INET && family != AF_INET6 && family != AF_UNSPEC)
+	if (hints_in->ai_family != AF_INET && hints_in->ai_family != AF_INET6 &&
+	    hints_in->ai_family != AF_UNSPEC)
 		return -1;
 	if (port < 1 || port > 65535)
 		return -1;
@@ -484,17 +498,12 @@ bufferevent_socket_connect_hostname(struct bufferevent *bev,
 
 	evutil_snprintf(portbuf, sizeof(portbuf), "%d", port);
 
-	memset(&hint, 0, sizeof(hint));
-	hint.ai_family = family;
-	hint.ai_protocol = IPPROTO_TCP;
-	hint.ai_socktype = SOCK_STREAM;
-
 	bufferevent_suspend_write_(bev, BEV_SUSPEND_LOOKUP);
 	bufferevent_suspend_read_(bev, BEV_SUSPEND_LOOKUP);
 
 	bufferevent_incref_(bev);
 	err = evutil_getaddrinfo_async_(evdns_base, hostname, portbuf,
-	    &hint, bufferevent_connect_getaddrinfo_cb, bev);
+	    hints_in, bufferevent_connect_getaddrinfo_cb, bev);
 
 	if (err == 0) {
 		return 0;

--- a/include/event2/bufferevent.h
+++ b/include/event2/bufferevent.h
@@ -243,6 +243,36 @@ int bufferevent_socket_connect_hostname(struct bufferevent *,
     struct evdns_base *, int, const char *, int);
 
 /**
+   Resolve the hostname 'hostname' and connect to it as with
+   bufferevent_socket_connect().
+
+   @param bufev An existing bufferevent allocated with bufferevent_socket_new()
+   @param evdns_base Optionally, an evdns_base to use for resolving hostnames
+      asynchronously. May be set to NULL for a blocking resolve.
+   @param hints_in points to an addrinfo structure that specifies criteria for
+      selecting the socket address structures to be used
+   @param hostname The hostname to resolve; see below for notes on recognized
+      formats
+   @param port The port to connect to on the resolved address.
+   @return 0 if successful, -1 on failure.
+
+   Recognized hostname formats are:
+
+       www.example.com	(hostname)
+       1.2.3.4		(ipv4address)
+       ::1		(ipv6address)
+       [::1]		([ipv6address])
+
+   Performance note: If you do not provide an evdns_base, this function
+   may block while it waits for a DNS response.	 This is probably not
+   what you want.
+ */
+EVENT2_EXPORT_SYMBOL
+int bufferevent_socket_connect_hostname_hints(struct bufferevent *,
+    struct evdns_base *, const struct evutil_addrinfo *, const char *, int);
+
+
+/**
    Return the error code for the last failed DNS lookup attempt made by
    bufferevent_socket_connect_hostname().
 

--- a/test/regress_dns.c
+++ b/test/regress_dns.c
@@ -1262,6 +1262,140 @@ end:
 		bufferevent_free(be5);
 }
 
+static void
+test_bufferevent_connect_hostname_hints(void *arg)
+{
+	struct basic_test_data *data = arg;
+	struct evconnlistener *listener = NULL;
+	struct bufferevent *be1=NULL, *be2=NULL, *be3=NULL, *be4=NULL, *be5=NULL;
+	struct be_conn_hostname_result be1_outcome={0,0}, be2_outcome={0,0},
+	       be3_outcome={0,0}, be4_outcome={0,0}, be5_outcome={0,0};
+	int expect_err5;
+	struct evdns_base *dns=NULL;
+	struct evdns_server_port *port=NULL;
+	struct sockaddr_in sin;
+	int listener_port=-1;
+	ev_uint16_t dns_port=0;
+	int n_accept=0, n_dns=0;
+	char buf[128];
+	struct evutil_addrinfo hints;
+
+	be_connect_hostname_base = data->base;
+
+	/* Bind an address and figure out what port it's on. */
+	memset(&sin, 0, sizeof(sin));
+	sin.sin_family = AF_INET;
+	sin.sin_addr.s_addr = htonl(0x7f000001); /* 127.0.0.1 */
+	sin.sin_port = 0;
+	listener = evconnlistener_new_bind(data->base, nil_accept_cb,
+	    &n_accept,
+	    LEV_OPT_REUSEABLE|LEV_OPT_CLOSE_ON_EXEC,
+	    -1, (struct sockaddr *)&sin, sizeof(sin));
+	tt_assert(listener);
+	listener_port = regress_get_socket_port(
+		evconnlistener_get_fd(listener));
+
+	port = regress_get_dnsserver(data->base, &dns_port, NULL,
+	    be_getaddrinfo_server_cb, &n_dns);
+	tt_assert(port);
+	tt_int_op(dns_port, >=, 0);
+
+	/* Start an evdns_base that uses the server as its resolver. */
+	dns = evdns_base_new(data->base, 0);
+	evutil_snprintf(buf, sizeof(buf), "127.0.0.1:%d", (int)dns_port);
+	evdns_base_nameserver_ip_add(dns, buf);
+
+	/* Now, finally, at long last, launch the bufferevents.	 One should do
+	 * a failing lookup IP, one should do a successful lookup by IP,
+	 * and one should do a successful lookup by hostname. */
+	be1 = bufferevent_socket_new(data->base, -1, BEV_OPT_CLOSE_ON_FREE);
+	be2 = bufferevent_socket_new(data->base, -1, BEV_OPT_CLOSE_ON_FREE);
+	be3 = bufferevent_socket_new(data->base, -1, BEV_OPT_CLOSE_ON_FREE);
+	be4 = bufferevent_socket_new(data->base, -1, BEV_OPT_CLOSE_ON_FREE);
+	be5 = bufferevent_socket_new(data->base, -1, BEV_OPT_CLOSE_ON_FREE);
+
+	bufferevent_setcb(be1, NULL, NULL, be_connect_hostname_event_cb,
+	    &be1_outcome);
+	bufferevent_setcb(be2, NULL, NULL, be_connect_hostname_event_cb,
+	    &be2_outcome);
+	bufferevent_setcb(be3, NULL, NULL, be_connect_hostname_event_cb,
+	    &be3_outcome);
+	bufferevent_setcb(be4, NULL, NULL, be_connect_hostname_event_cb,
+	    &be4_outcome);
+	bufferevent_setcb(be5, NULL, NULL, be_connect_hostname_event_cb,
+	    &be5_outcome);
+
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_INET;
+	hints.ai_protocol = IPPROTO_TCP;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_flags = AI_ADDRCONFIG;
+
+	/* Launch an async resolve that will fail. */
+	tt_assert(!bufferevent_socket_connect_hostname_hints(be1, dns, &hints,
+		"nosuchplace.example.com", listener_port));
+	/* Connect to the IP without resolving. */
+	tt_assert(!bufferevent_socket_connect_hostname_hints(be2, dns, &hints,
+		"127.0.0.1", listener_port));
+	/* Launch an async resolve that will succeed. */
+	tt_assert(!bufferevent_socket_connect_hostname_hints(be3, dns, &hints,
+		"nobodaddy.example.com", listener_port));
+	/* Use the blocking resolver.  This one will fail if your resolver
+	 * can't resolve localhost to 127.0.0.1 */
+	tt_assert(!bufferevent_socket_connect_hostname_hints(be4, NULL, &hints,
+		"localhost", listener_port));
+	/* Use the blocking resolver with a nonexistent hostname. */
+	tt_assert(!bufferevent_socket_connect_hostname_hints(be5, NULL, &hints,
+		"nonesuch.nowhere.example.com", 80));
+	{
+		/* The blocking resolver will use the system nameserver, which
+		 * might tell us anything.  (Yes, some twits even pretend that
+		 * example.com is real.) Let's see what answer to expect. */
+		struct evutil_addrinfo hints, *ai = NULL;
+		memset(&hints, 0, sizeof(hints));
+		hints.ai_family = AF_INET;
+		hints.ai_socktype = SOCK_STREAM;
+		hints.ai_protocol = IPPROTO_TCP;
+		expect_err5 = evutil_getaddrinfo(
+			"nonesuch.nowhere.example.com", "80", &hints, &ai);
+	}
+
+	event_base_dispatch(data->base);
+
+	tt_int_op(be1_outcome.what, ==, BEV_EVENT_ERROR);
+	tt_int_op(be1_outcome.dnserr, ==, EVUTIL_EAI_NONAME);
+	tt_int_op(be2_outcome.what, ==, BEV_EVENT_CONNECTED);
+	tt_int_op(be2_outcome.dnserr, ==, 0);
+	tt_int_op(be3_outcome.what, ==, BEV_EVENT_CONNECTED);
+	tt_int_op(be3_outcome.dnserr, ==, 0);
+	tt_int_op(be4_outcome.what, ==, BEV_EVENT_CONNECTED);
+	tt_int_op(be4_outcome.dnserr, ==, 0);
+	if (expect_err5) {
+		tt_int_op(be5_outcome.what, ==, BEV_EVENT_ERROR);
+		tt_int_op(be5_outcome.dnserr, ==, expect_err5);
+	}
+
+	tt_int_op(n_accept, ==, 3);
+	tt_int_op(n_dns, ==, 2);
+
+end:
+	if (listener)
+		evconnlistener_free(listener);
+	if (port)
+		evdns_close_server_port(port);
+	if (dns)
+		evdns_base_free(dns, 0);
+	if (be1)
+		bufferevent_free(be1);
+	if (be2)
+		bufferevent_free(be2);
+	if (be3)
+		bufferevent_free(be3);
+	if (be4)
+		bufferevent_free(be4);
+	if (be5)
+		bufferevent_free(be5);
+}
 
 struct gai_outcome {
 	int err;
@@ -1998,6 +2132,8 @@ struct testcase_t dns_testcases[] = {
 	  TT_FORK|TT_NEED_BASE|TT_NO_LOGS, &basic_setup, NULL },
 	{ "inflight", dns_inflight_test, TT_FORK|TT_NEED_BASE, &basic_setup, NULL },
 	{ "bufferevent_connect_hostname", test_bufferevent_connect_hostname,
+	  TT_FORK|TT_NEED_BASE, &basic_setup, NULL },
+	{ "bufferevent_connect_hostname_hints", test_bufferevent_connect_hostname_hints,
 	  TT_FORK|TT_NEED_BASE, &basic_setup, NULL },
 	{ "disable_when_inactive", dns_disable_when_inactive_test,
 	  TT_FORK|TT_NEED_BASE, &basic_setup, NULL },


### PR DESCRIPTION
- Implemented bufferevent_socket_connect_hostname_hints so that ai_flags (such as AI_ADDRCONFIG) can be specified.
- Added a simple unit test
