### PR TITLE
Add support for EV_TIMEOUT to event_base_active_by_fd

### DIFF
--- a/include/event2/event.h
+++ b/include/event2/event.h
@@ -1570,7 +1570,7 @@ void event_base_dump_events(struct event_base *, FILE *);
 
    @param base the event_base on which to activate the events.
    @param fd An fd to active events on.
-   @param events One or more of EV_{READ,WRITE}.
+   @param events One or more of EV_{READ,WRITE,TIMEOUT}.
  */
 EVENT2_EXPORT_SYMBOL
 void event_base_active_by_fd(struct event_base *base, evutil_socket_t fd, short events);

--- a/test/regress.c
+++ b/test/regress.c
@@ -3195,6 +3195,7 @@ test_active_by_fd(void *arg)
 	/* Trigger 2, 3, 4 */
 	event_base_active_by_fd(base, data->pair[0], EV_WRITE);
 	event_base_active_by_fd(base, data->pair[1], EV_READ);
+	event_base_active_by_fd(base, data->pair[1], EV_TIMEOUT);
 #ifndef _WIN32
 	event_base_active_by_signal(base, SIGHUP);
 #endif
@@ -3207,7 +3208,7 @@ test_active_by_fd(void *arg)
 	tt_int_op(e2, ==, EV_WRITE | 0x10000);
 	tt_int_op(e3, ==, EV_READ | 0x10000);
 	/* Mask out EV_WRITE here, since it could be genuinely writeable. */
-	tt_int_op((e4 & ~EV_WRITE), ==, EV_READ | 0x10000);
+	tt_int_op((e4 & ~EV_WRITE), ==, EV_READ | EV_TIMEOUT | 0x10000);
 #ifndef _WIN32
 	tt_int_op(es, ==, EV_SIGNAL | 0x10000);
 #endif


### PR DESCRIPTION
Support for EV_TIMEOUT was removed from event_base_active_by_fd back in 87fa2b004a65257a6cba4b57dc7fc0fb06106342. This adds it back. 

Let me know if anything seems amiss, thanks!
