### PR TITLE
Upnp ext add NOTIFY SUBSCRIBE UNSUBSCRIBE methods

### DIFF
--- a/http.c
+++ b/http.c
@@ -2282,7 +2282,7 @@ evhttp_connection_base_bufferevent_new(struct event_base *base, struct evdns_bas
 {
 	struct evhttp_connection *evcon = NULL;
 
-	event_debug(("Attempting connection to %s:%d\n", address, port));
+	event_debug(("%s %s:%d\n", (dnsbase?"New connection from":"Attempting connection to"), address, port));
 
 	if ((evcon = mm_calloc(1, sizeof(struct evhttp_connection))) == NULL) {
 		event_warn("%s: calloc failed", __func__);

--- a/http.c
+++ b/http.c
@@ -188,6 +188,8 @@ static void evhttp_get_request(struct evhttp *, evutil_socket_t, struct sockaddr
 static void evhttp_write_buffer(struct evhttp_connection *,
     void (*)(struct evhttp_connection *, void *), void *);
 static void evhttp_make_header(struct evhttp_connection *, struct evhttp_request *);
+static int
+evhttp_method_may_have_body(enum evhttp_cmd_type type);
 
 /* callbacks for bufferevent */
 static void evhttp_read_cb(struct bufferevent *, void *);
@@ -446,7 +448,7 @@ evhttp_make_header_request(struct evhttp_connection *evcon,
 	    method, req->uri, req->major, req->minor);
 
 	/* Add the content length on a post or put request if missing */
-	if ((req->type == EVHTTP_REQ_POST || req->type == EVHTTP_REQ_PUT) &&
+	if (evhttp_method_may_have_body(req->type) &&
 	    evhttp_find_header(req->output_headers, "Content-Length") == NULL){
 		char size[22];
 		evutil_snprintf(size, sizeof(size), EV_SIZE_FMT,

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -469,7 +469,8 @@ void evhttp_send_reply_end(struct evhttp_request *req);
  */
 
 /** The different request types supported by evhttp.  These are as specified
- * in RFC2616, except for PATCH which is specified by RFC5789.
+ * in RFC2616, except for PATCH which is specified by RFC5789 and
+ * SUBSCRIBE, UNSUBSCRIBE and NOTIFY which are UPnP extensions.
  *
  * By default, only some of these methods are accepted and passed to user
  * callbacks; use evhttp_set_allowed_methods() to change which methods
@@ -484,7 +485,10 @@ enum evhttp_cmd_type {
 	EVHTTP_REQ_OPTIONS = 1 << 5,
 	EVHTTP_REQ_TRACE   = 1 << 6,
 	EVHTTP_REQ_CONNECT = 1 << 7,
-	EVHTTP_REQ_PATCH   = 1 << 8
+	EVHTTP_REQ_PATCH   = 1 << 8,
+	EVHTTP_REQ_SUBSCRIBE   = 1 << 9,
+	EVHTTP_REQ_UNSUBSCRIBE = 1 << 10,
+	EVHTTP_REQ_NOTIFY  = 1 << 11
 };
 
 /** a request object can represent either a request or a reply */

--- a/sample/http-server.c
+++ b/sample/http-server.c
@@ -125,6 +125,9 @@ dump_request_cb(struct evhttp_request *req, void *arg)
 	case EVHTTP_REQ_TRACE: cmdtype = "TRACE"; break;
 	case EVHTTP_REQ_CONNECT: cmdtype = "CONNECT"; break;
 	case EVHTTP_REQ_PATCH: cmdtype = "PATCH"; break;
+	case EVHTTP_REQ_NOTIFY: cmdtype = "NOTIFY"; break;
+	case EVHTTP_REQ_SUBSCRIBE: cmdtype = "SUBSCRIBE"; break;
+	case EVHTTP_REQ_UNSUBSCRIBE: cmdtype = "UNSUBSCRIBE"; break;
 	default: cmdtype = "unknown"; break;
 	}
 


### PR DESCRIPTION
NOTIFY / SUBSCRIBE / UNSUBSCRIBE are defined by UPnP
See UPnP device Architecture v1.1 document :
http://upnp.org/specs/arch/UPnP-arch-DeviceArchitecture-v1.1.pdf

It is used here : https://github.com/miniupnp/miniupnp/tree/master/miniupnpc-libevent
