### PR TITLE
Fix warnings when compiling with clang 3.5

### DIFF
--- a/test/regress.h
+++ b/test/regress.h
@@ -118,7 +118,7 @@ int test_ai_eq_(const struct evutil_addrinfo *ai, const char *sockaddr_port,
 	} while (0)
 
 #define test_timeval_diff_leq(tv1, tv2, diff, tolerance)		\
-	tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
+	tt_int_op(labs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
 
 #define test_timeval_diff_eq(tv1, tv2, diff)				\
 	test_timeval_diff_leq((tv1), (tv2), (diff), 50)

--- a/test/regress_thread.c
+++ b/test/regress_thread.c
@@ -361,7 +361,7 @@ thread_conditions_simple(void *arg)
 			    &tv_signal);
 			diff2 = timeval_msec_diff(&actual_delay,
 			    &tv_broadcast);
-			if (abs(diff1) < abs(diff2)) {
+			if (labs(diff1) < labs(diff2)) {
 				TT_BLATHER(("%d looks like a signal\n", i));
 				target_delay = &tv_signal;
 				++n_signal;


### PR DESCRIPTION
Clang complains about the use of `abs` instead of `labs` for calculating the absolute value of a `long`. This should help make it happy.

Example `make` output:

```
make
  GEN    test/rpcgen-attempted
make  all-am
make[1]: Entering directory `/home/John/Libraries/libevent'
  CC     buffer.lo
  CC     bufferevent.lo
  CC     bufferevent_filter.lo
  CC     bufferevent_pair.lo
  CC     bufferevent_ratelim.lo
  CC     bufferevent_sock.lo
  CC     event.lo
  CC     evmap.lo
  CC     evthread.lo
  CC     evutil.lo
  CC     evutil_rand.lo
  CC     evutil_time.lo
  CC     listener.lo
  CC     log.lo
  CC     strlcpy.lo
  CC     select.lo
  CC     poll.lo
  CC     epoll.lo
  CC     signal.lo
  CC     evdns.lo
  CC     event_tagging.lo
  CC     evrpc.lo
  CC     http.lo
  CCLD   libevent.la
  CCLD   libevent_core.la
  CCLD   libevent_extra.la
  CC     evthread_pthread.lo
  CCLD   libevent_pthreads.la
  CC     libevent_openssl_la-bufferevent_openssl.lo
  CCLD   libevent_openssl.la
  CC     sample/dns-example.o
  CCLD   sample/dns-example
  CC     sample/event-read-fifo.o
  CCLD   sample/event-read-fifo
  CC     sample/hello-world.o
  CCLD   sample/hello-world
  CC     sample/http-server.o
  CCLD   sample/http-server
  CC     sample/signal-test.o
  CCLD   sample/signal-test
  CC     sample/time-test.o
  CCLD   sample/time-test
  CC     sample/le-proxy.o
  CCLD   sample/le-proxy
  CC     sample/https-client.o
  CC     sample/hostcheck.o
  CC     sample/openssl_hostname_validation.o
  CCLD   sample/https-client
  CC     test/bench.o
  CCLD   test/bench
  CC     test/bench_cascade.o
  CCLD   test/bench_cascade
  CC     test/bench_http.o
  CCLD   test/bench_http
  CC     test/bench_httpclient.o
  CCLD   test/bench_httpclient
  CC     test/test-changelist.o
  CCLD   test/test-changelist
  CC     test/test-dumpevents.o
  CCLD   test/test-dumpevents
  CC     test/test-eof.o
  CCLD   test/test-eof
  CC     test/test-closed.o
  CCLD   test/test-closed
  CC     test/test-fdleak.o
  CCLD   test/test-fdleak
  CC     test/test-init.o
  CCLD   test/test-init
  CC     test/test-ratelim.o
  CCLD   test/test-ratelim
  CC     test/test-time.o
  CCLD   test/test-time
  CC     test/test-weof.o
  CCLD   test/test-weof
  CC     test/test_regress-regress.o
test/regress.c:580:2: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        test_timeval_diff_eq(&tset, &tcalled, 200);
        ^
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress.c:580:2: note: use function 'labs' instead
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress.c:702:2: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        test_timeval_diff_eq(&start, &res.tvs[0], 100);
        ^
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress.c:702:2: note: use function 'labs' instead
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress.c:703:2: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        test_timeval_diff_eq(&start, &res.tvs[1], 300);
        ^
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress.c:703:2: note: use function 'labs' instead
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress.c:704:2: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        test_timeval_diff_eq(&start, &res.tvs[2], 500);
        ^
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress.c:704:2: note: use function 'labs' instead
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress.c:798:4: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
                        test_timeval_diff_eq(&start, &info[i].called_at, 400);
                        ^
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress.c:798:4: note: use function 'labs' instead
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress.c:800:4: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
                        test_timeval_diff_eq(&start, &info[i].called_at, 800);
                        ^
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress.c:800:4: note: use function 'labs' instead
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress.c:1873:2: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        test_timeval_diff_eq(&tv_start, &tv_end, 300);
        ^
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress.c:1873:2: note: use function 'labs' instead
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress.c:1907:2: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        test_timeval_diff_eq(&tv_start, &tv_end, 200);
        ^
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress.c:1907:2: note: use function 'labs' instead
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress.c:2719:2: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        test_timeval_diff_eq(&now, &tv2, 500);
        ^
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress.c:2719:2: note: use function 'labs' instead
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
9 warnings generated.
  CC     test/test_regress-regress.gen.o
  CC     test/test_regress-regress_buffer.o
  CC     test/test_regress-regress_bufferevent.o
test/regress_bufferevent.c:812:2: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        test_timeval_diff_eq(&started_at, &res1.read_timeout_at, 150);
        ^
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_bufferevent.c:812:2: note: use function 'labs' instead
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_bufferevent.c:813:2: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        test_timeval_diff_eq(&started_at, &res1.write_timeout_at, 100);
        ^
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_bufferevent.c:813:2: note: use function 'labs' instead
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
2 warnings generated.
  CC     test/test_regress-regress_dns.o
  CC     test/test_regress-regress_et.o
  CC     test/test_regress-regress_finalize.o
  CC     test/test_regress-regress_http.o
test/regress_http.c:3405:2: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        test_timeval_diff_leq(&tv_start, &tv_end, 500, 200);
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_http.c:3405:2: note: use function 'labs' instead
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_http.c:3441:2: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        test_timeval_diff_leq(&tv_start, &tv_end, 1000, 400);
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_http.c:3441:2: note: use function 'labs' instead
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
2 warnings generated.
  CC     test/test_regress-regress_listener.o
  CC     test/test_regress-regress_main.o
  CC     test/test_regress-regress_minheap.o
  CC     test/test_regress-regress_rpc.o
  CC     test/test_regress-regress_testutils.o
  CC     test/test_regress-regress_util.o
  CC     test/test_regress-tinytest.o
  CC     test/test_regress-regress_thread.o
test/regress_thread.c:364:8: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
                        if (abs(diff1) < abs(diff2)) {
                            ^
test/regress_thread.c:364:8: note: use function 'labs' instead
                        if (abs(diff1) < abs(diff2)) {
                            ^~~
                            labs
test/regress_thread.c:364:21: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
                        if (abs(diff1) < abs(diff2)) {
                                         ^
test/regress_thread.c:364:21: note: use function 'labs' instead
                        if (abs(diff1) < abs(diff2)) {
                                         ^~~
                                         labs
test/regress_thread.c:378:3: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
                test_timeval_diff_leq(&target_time, &alerted[i].alerted_at,
                ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_thread.c:378:3: note: use function 'labs' instead
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_thread.c:556:2: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        test_timeval_diff_eq(&starttime, &times[0], 100);
        ^
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_thread.c:556:2: note: use function 'labs' instead
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_thread.c:557:2: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        test_timeval_diff_eq(&starttime, &times[1], 200);
        ^
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_thread.c:557:2: note: use function 'labs' instead
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_thread.c:558:2: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        test_timeval_diff_eq(&starttime, &times[2], 400);
        ^
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_thread.c:558:2: note: use function 'labs' instead
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_thread.c:559:2: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        test_timeval_diff_eq(&starttime, &times[3], 450);
        ^
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_thread.c:559:2: note: use function 'labs' instead
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_thread.c:560:2: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        test_timeval_diff_eq(&starttime, &times[4], 500);
        ^
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_thread.c:560:2: note: use function 'labs' instead
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_thread.c:561:2: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        test_timeval_diff_eq(&starttime, &endtime,  500);
        ^
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
test/regress_thread.c:561:2: note: use function 'labs' instead
test/regress.h:124:2: note: expanded from macro 'test_timeval_diff_eq'
        test_timeval_diff_leq((tv1), (tv2), (diff), 50)
        ^
test/regress.h:121:12: note: expanded from macro 'test_timeval_diff_leq'
        tt_int_op(abs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
                  ^
test/tinytest_macros.h:158:22: note: expanded from macro 'tt_int_op'
        tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
                            ^
test/tinytest_macros.h:144:26: note: expanded from macro 'tt_assert_test_type'
        tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt,        \
                                ^
test/tinytest_macros.h:116:16: note: expanded from macro 'tt_assert_test_fmt_type'
        type val1_ = (a);                                               \
                      ^
9 warnings generated.
  CC     test/test_regress-regress_zlib.o
  CC     test/test_regress-regress_ssl.o
  CCLD   test/regress
make[1]: Leaving directory `/home/John/Libraries/libevent'
```
