### PR TITLE
Fix compiler warning about missing prototype for event_disable_debug_mode

### DIFF
--- a/event.c
+++ b/event.c
@@ -131,6 +131,7 @@ struct event_base *event_global_current_base_ = NULL;
 static void *event_self_cbarg_ptr_ = NULL;
 
 /* Prototypes */
+static void	event_disable_debug_mode(void);
 static void	event_queue_insert_active(struct event_base *, struct event_callback *);
 static void	event_queue_insert_active_later(struct event_base *, struct event_callback *);
 static void	event_queue_insert_timeout(struct event_base *, struct event *);
@@ -526,7 +527,7 @@ event_enable_debug_mode(void)
 #endif
 }
 
-void
+static void
 event_disable_debug_mode(void)
 {
 #ifndef EVENT__DISABLE_DEBUG_MODE


### PR DESCRIPTION
Fixes the following compiler warning:
```
event.c:530:1: warning: no previous prototype for function 'event_disable_debug_mode' [-Wmissing-prototypes]
event_disable_debug_mode(void)
^
```

Additionally, I made the method declaration and prototype static since it isn't a public method anyway ;-)

Full build output:
```
Johns-MacBook-Pro:libevent John$ ./autogen.sh
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in `.'.
libtoolize: copying file `./ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIR, `m4'.
libtoolize: copying file `m4/libtool.m4'
libtoolize: copying file `m4/ltoptions.m4'
libtoolize: copying file `m4/ltsugar.m4'
libtoolize: copying file `m4/ltversion.m4'
libtoolize: copying file `m4/lt~obsolete.m4'
autoreconf: running: /usr/local/bin/autoconf --force
autoreconf: running: /usr/local/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:31: installing './compile'
configure.ac:33: installing './config.guess'
configure.ac:33: installing './config.sub'
configure.ac:13: installing './install-sh'
configure.ac:13: installing './missing'
Makefile.am: installing './depcomp'
parallel-tests: installing './test-driver'
autoreconf: Leaving directory `.'
Johns-MacBook-Pro:libevent John$ ./configure --disable-shared CFLAGS=-I/usr/local/ssl/include LDFLAGS=-L/usr/local/ssl/lib
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... ./install-sh -c -d
checking for gawk... no
checking for mawk... no
checking for nawk... no
checking for awk... awk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether make supports nested variables... (cached) yes
checking for style of include used by make... GNU
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking dependency style of gcc... gcc3
checking how to run the C preprocessor... gcc -E
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking minix/config.h usability... no
checking minix/config.h presence... no
checking for minix/config.h... no
checking whether it is safe to define __EXTENSIONS__... yes
checking build system type... x86_64-apple-darwin14.1.0
checking host system type... x86_64-apple-darwin14.1.0
checking whether ln -s works... yes
checking for a sed that does not truncate output... /usr/bin/sed
checking whether gcc needs -traditional... no
checking how to print strings... printf
checking for a sed that does not truncate output... (cached) /usr/bin/sed
checking for fgrep... /usr/bin/grep -F
checking for ld used by gcc... /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld
checking if the linker (/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld) is GNU ld... no
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm
checking the name lister (/usr/bin/nm) interface... BSD nm
checking the maximum length of command line arguments... 196608
checking whether the shell understands some XSI constructs... yes
checking whether the shell understands "+="... yes
checking how to convert x86_64-apple-darwin14.1.0 file names to x86_64-apple-darwin14.1.0 format... func_convert_file_noop
checking how to convert x86_64-apple-darwin14.1.0 file names to toolchain format... func_convert_file_noop
checking for /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld option to reload object files... -r
checking for objdump... no
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for ar... ar
checking for archiver @FILE support... no
checking for strip... strip
checking for ranlib... ranlib
checking command to parse /usr/bin/nm output from gcc object... ok
checking for sysroot... no
checking for mt... no
checking if : is a manifest tool... no
checking for dsymutil... dsymutil
checking for nmedit... nmedit
checking for lipo... lipo
checking for otool... otool
checking for otool64... no
checking for -single_module linker flag... yes
checking for -exported_symbols_list linker flag... yes
checking for -force_load linker flag... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if gcc supports -fno-rtti -fno-exceptions... yes
checking for gcc option to produce PIC... -fno-common -DPIC
checking if gcc PIC flag -fno-common -DPIC works... yes
checking if gcc static flag -static works... no
checking if gcc supports -c -o file.o... yes
checking if gcc supports -c -o file.o... (cached) yes
checking whether the gcc linker (/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld) supports shared libraries... yes
checking dynamic linker characteristics... darwin14.1.0 dyld
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... no
checking whether to build static libraries... yes
checking for library containing inet_ntoa... none required
checking for library containing socket... none required
checking for library containing inet_aton... none required
checking for library containing clock_gettime... no
checking for library containing sendfile... none required
checking for WIN32... no
checking for CYGWIN... no
checking zlib.h usability... yes
checking zlib.h presence... yes
checking for zlib.h... yes
checking for library containing inflateEnd... -lz
checking for special C compiler options needed for large files... no
checking for _FILE_OFFSET_BITS value needed for large files... no
checking for pkg-config... /opt/pkgconfig/bin/pkg-config
checking if pkg-config is at least version 0.15.0... yes
checking for library containing SSL_new... -lssl
checking arpa/inet.h usability... yes
checking arpa/inet.h presence... yes
checking for arpa/inet.h... yes
checking fcntl.h usability... yes
checking fcntl.h presence... yes
checking for fcntl.h... yes
checking ifaddrs.h usability... yes
checking ifaddrs.h presence... yes
checking for ifaddrs.h... yes
checking mach/mach_time.h usability... yes
checking mach/mach_time.h presence... yes
checking for mach/mach_time.h... yes
checking netdb.h usability... yes
checking netdb.h presence... yes
checking for netdb.h... yes
checking netinet/in.h usability... yes
checking netinet/in.h presence... yes
checking for netinet/in.h... yes
checking netinet/in6.h usability... no
checking netinet/in6.h presence... no
checking for netinet/in6.h... no
checking netinet/tcp.h usability... yes
checking netinet/tcp.h presence... yes
checking for netinet/tcp.h... yes
checking poll.h usability... yes
checking poll.h presence... yes
checking for poll.h... yes
checking port.h usability... no
checking port.h presence... no
checking for port.h... no
checking stdarg.h usability... yes
checking stdarg.h presence... yes
checking for stdarg.h... yes
checking stddef.h usability... yes
checking stddef.h presence... yes
checking for stddef.h... yes
checking sys/devpoll.h usability... no
checking sys/devpoll.h presence... no
checking for sys/devpoll.h... no
checking sys/epoll.h usability... no
checking sys/epoll.h presence... no
checking for sys/epoll.h... no
checking sys/event.h usability... yes
checking sys/event.h presence... yes
checking for sys/event.h... yes
checking sys/eventfd.h usability... no
checking sys/eventfd.h presence... no
checking for sys/eventfd.h... no
checking sys/ioctl.h usability... yes
checking sys/ioctl.h presence... yes
checking for sys/ioctl.h... yes
checking sys/mman.h usability... yes
checking sys/mman.h presence... yes
checking for sys/mman.h... yes
checking sys/param.h usability... yes
checking sys/param.h presence... yes
checking for sys/param.h... yes
checking sys/queue.h usability... yes
checking sys/queue.h presence... yes
checking for sys/queue.h... yes
checking sys/resource.h usability... yes
checking sys/resource.h presence... yes
checking for sys/resource.h... yes
checking sys/select.h usability... yes
checking sys/select.h presence... yes
checking for sys/select.h... yes
checking sys/sendfile.h usability... no
checking sys/sendfile.h presence... no
checking for sys/sendfile.h... no
checking sys/socket.h usability... yes
checking sys/socket.h presence... yes
checking for sys/socket.h... yes
checking for sys/stat.h... (cached) yes
checking sys/time.h usability... yes
checking sys/time.h presence... yes
checking for sys/time.h... yes
checking sys/timerfd.h usability... no
checking sys/timerfd.h presence... no
checking for sys/timerfd.h... no
checking sys/uio.h usability... yes
checking sys/uio.h presence... yes
checking for sys/uio.h... yes
checking sys/wait.h usability... yes
checking sys/wait.h presence... yes
checking for sys/wait.h... yes
checking for sys/sysctl.h... yes
checking for TAILQ_FOREACH in sys/queue.h... yes
checking for timeradd in sys/time.h... yes
checking for timercmp in sys/time.h... yes
checking for timerclear in sys/time.h... yes
checking for timerisset in sys/time.h... yes
checking whether CTL_KERN is declared... yes
checking whether KERN_RANDOM is declared... no
checking whether RANDOM_UUID is declared... no
checking whether KERN_ARND is declared... no
checking for an ANSI C-conforming const... yes
checking for inline... inline
checking whether time.h and sys/time.h may both be included... yes
checking for accept4... no
checking for arc4random... yes
checking for arc4random_buf... yes
checking for clock_gettime... no
checking for eventfd... no
checking for epoll_create1... no
checking for fcntl... yes
checking for getegid... yes
checking for geteuid... yes
checking for getifaddrs... yes
checking for getnameinfo... yes
checking for getprotobynumber... yes
checking for gettimeofday... yes
checking for inet_ntop... yes
checking for inet_pton... yes
checking for issetugid... yes
checking for mach_absolute_time... yes
checking for mmap... yes
checking for nanosleep... yes
checking for pipe... yes
checking for pipe2... no
checking for putenv... yes
checking for sendfile... yes
checking for setenv... yes
checking for setrlimit... yes
checking for sigaction... yes
checking for signal... yes
checking for splice... no
checking for strlcpy... yes
checking for strsep... yes
checking for strtok_r... yes
checking for strtoll... yes
checking for sysctl... yes
checking for timerfd_create... no
checking for umask... yes
checking for unsetenv... yes
checking for usleep... yes
checking for vasprintf... yes
checking for getaddrinfo... yes
checking for F_SETFD in fcntl.h... yes
checking for select... yes
checking for poll... yes
checking for kqueue... yes
checking for working kqueue... yes
checking for epoll_ctl... no
checking for port_create... no
checking for pid_t... yes
checking for size_t... yes
checking for ssize_t... yes
checking for uint64_t... yes
checking for uint32_t... yes
checking for uint16_t... yes
checking for uint8_t... yes
checking for uintptr_t... yes
checking for fd_mask... yes
checking size of long long... 8
checking size of long... 8
checking size of int... 4
checking size of short... 2
checking size of size_t... 8
checking size of void *... 8
checking size of off_t... 8
checking for struct in6_addr... yes
checking for struct sockaddr_in6... yes
checking for sa_family_t... yes
checking for struct addrinfo... yes
checking for struct sockaddr_storage... yes
checking for struct in6_addr.s6_addr32... no
checking for struct in6_addr.s6_addr16... no
checking for struct sockaddr_in.sin_len... yes
checking for struct sockaddr_in6.sin6_len... yes
checking for struct sockaddr_storage.ss_family... yes
checking for struct sockaddr_storage.__ss_family... no
checking for struct so_linger... no
checking for socklen_t... yes
checking whether our compiler supports __func__... yes
checking for the pthreads library -lpthreads... no
checking whether pthreads work without any flags... yes
checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
checking if more special flags are required for pthreads... -D_THREAD_SAFE
checking size of pthread_t... 8
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating libevent.pc
config.status: creating libevent_openssl.pc
config.status: creating libevent_pthreads.pc
config.status: creating Makefile
config.status: creating config.h
config.status: creating evconfig-private.h
config.status: executing depfiles commands
config.status: executing libtool commands
Johns-MacBook-Pro:libevent John$ make && sudo make install
  GEN      test/rpcgen-attempted
  GEN      include/event2/event-config.h
/Applications/Xcode.app/Contents/Developer/usr/bin/make  all-am
  CC       buffer.lo
  CC       bufferevent.lo
  CC       bufferevent_filter.lo
  CC       bufferevent_pair.lo
  CC       bufferevent_ratelim.lo
  CC       bufferevent_sock.lo
  CC       event.lo
event.c:530:1: warning: no previous prototype for function 'event_disable_debug_mode' [-Wmissing-prototypes]
event_disable_debug_mode(void)
^
1 warning generated.
  CC       evmap.lo
  CC       evthread.lo
  CC       evutil.lo
  CC       evutil_rand.lo
  CC       evutil_time.lo
  CC       listener.lo
  CC       log.lo
  CC       select.lo
  CC       poll.lo
  CC       kqueue.lo
  CC       signal.lo
  CC       evdns.lo
  CC       event_tagging.lo
  CC       evrpc.lo
  CC       http.lo
  CCLD     libevent.la
  CCLD     libevent_core.la
  CCLD     libevent_extra.la
  CC       evthread_pthread.lo
  CCLD     libevent_pthreads.la
  CC       libevent_openssl_la-bufferevent_openssl.lo
  CCLD     libevent_openssl.la
  CC       sample/dns-example.o
  CCLD     sample/dns-example
  CC       sample/event-read-fifo.o
  CCLD     sample/event-read-fifo
  CC       sample/hello-world.o
  CCLD     sample/hello-world
  CC       sample/http-server.o
  CCLD     sample/http-server
  CC       sample/signal-test.o
  CCLD     sample/signal-test
  CC       sample/time-test.o
  CCLD     sample/time-test
  CC       sample/le-proxy.o
  CCLD     sample/le-proxy
  CC       sample/https-client.o
  CC       sample/hostcheck.o
  CC       sample/openssl_hostname_validation.o
  CCLD     sample/https-client
  CC       test/bench.o
  CCLD     test/bench
  CC       test/bench_cascade.o
  CCLD     test/bench_cascade
  CC       test/bench_http.o
  CCLD     test/bench_http
  CC       test/bench_httpclient.o
  CCLD     test/bench_httpclient
  CC       test/test-changelist.o
  CCLD     test/test-changelist
  CC       test/test-dumpevents.o
  CCLD     test/test-dumpevents
  CC       test/test-eof.o
  CCLD     test/test-eof
  CC       test/test-closed.o
  CCLD     test/test-closed
  CC       test/test-fdleak.o
  CCLD     test/test-fdleak
  CC       test/test-init.o
  CCLD     test/test-init
  CC       test/test-ratelim.o
  CCLD     test/test-ratelim
  CC       test/test-time.o
  CCLD     test/test-time
  CC       test/test-weof.o
  CCLD     test/test-weof
  CC       test/test_regress-regress.o
  CC       test/test_regress-regress.gen.o
  CC       test/test_regress-regress_buffer.o
  CC       test/test_regress-regress_bufferevent.o
  CC       test/test_regress-regress_dns.o
  CC       test/test_regress-regress_et.o
  CC       test/test_regress-regress_finalize.o
  CC       test/test_regress-regress_http.o
  CC       test/test_regress-regress_listener.o
  CC       test/test_regress-regress_main.o
  CC       test/test_regress-regress_minheap.o
  CC       test/test_regress-regress_rpc.o
  CC       test/test_regress-regress_testutils.o
  CC       test/test_regress-regress_util.o
  CC       test/test_regress-tinytest.o
  CC       test/test_regress-regress_thread.o
  CC       test/test_regress-regress_zlib.o
  CC       test/test_regress-regress_ssl.o
  CCLD     test/regress
```