### PR TITLE
http-client: correctly handle URLs with no path (like "https://host:port")

### DIFF
--- a/sample/https-client.c
+++ b/sample/https-client.c
@@ -275,7 +275,7 @@ main(int argc, char **argv)
 	}
 
 	path = evhttp_uri_get_path(http_uri);
-	if (path == NULL) {
+	if (strlen(path) == 0) {
 		path = "/";
 	}
 


### PR DESCRIPTION
Path is set to "/" if omitted in -url parameter. 
Otherwise erroneous HTTP request was performed ("GET HTTP/1.1")