### PR TITLE
Remove event-core code from event-extra for CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -698,7 +698,6 @@ configure_file(
 # Create the libraries.
 #
 
-# TODO: Add dynamic versions of the libraries as well.
 add_library(event_core ${EVENT__LIBRARY_TYPE}
     ${HDR_PRIVATE}
     ${HDR_COMPAT}
@@ -707,10 +706,6 @@ add_library(event_core ${EVENT__LIBRARY_TYPE}
     )
 
 add_library(event_extra ${EVENT__LIBRARY_TYPE}
-    ${HDR_PRIVATE}
-    ${HDR_COMPAT}
-    ${HDR_PUBLIC}
-    ${SRC_CORE}
     ${SRC_EXTRA}
     )
 
@@ -726,37 +721,25 @@ add_library(event ${EVENT__LIBRARY_TYPE}
     )
 
 if (EVENT__BUILD_SHARED_LIBRARIES)
-endif (EVENT__BUILD_SHARED_LIBRARIES)
+    target_link_libraries(event_core ${OPENSSL_LIBRARIES}
+                                     ${CMAKE_THREAD_LIBS_INIT}
+                                     ${LIB_PLATFORM})
+    set_target_properties(event_core PROPERTIES DEFINE_SYMBOL event_core_EXPORTS)
 
-if (EVENT__BUILD_SHARED_LIBRARIES)
-    # Prepare static library to be linked to tests that need hidden symbols
-    add_library(event_extra_static STATIC
-        ${HDR_PRIVATE}
-        ${HDR_COMPAT}
-        ${HDR_PUBLIC}
-        ${SRC_CORE}
-        ${SRC_EXTRA}
-        )
-    set(EVENT_EXTRA_FOR_TEST event_extra_static)
+    target_link_libraries(event ${OPENSSL_LIBRARIES}
+                                ${CMAKE_THREAD_LIBS_INIT}
+                                ${LIB_PLATFORM})
+    set_target_properties(event PROPERTIES DEFINE_SYMBOL event_EXPORTS)
 
-   target_link_libraries(event_core ${OPENSSL_LIBRARIES}
-                                    ${CMAKE_THREAD_LIBS_INIT}
-                                    ${LIB_PLATFORM})
-
-   target_link_libraries(event ${OPENSSL_LIBRARIES}
-                               ${CMAKE_THREAD_LIBS_INIT}
-                               ${LIB_PLATFORM})
-
-   target_link_libraries(event_extra ${OPENSSL_LIBRARIES}
+    target_link_libraries(event_extra event_core
+                                      ${OPENSSL_LIBRARIES}
                                       ${CMAKE_THREAD_LIBS_INIT}
                                       ${LIB_PLATFORM})
+    set_target_properties(event_extra PROPERTIES DEFINE_SYMBOL event_extra_EXPORTS)
 
-  set_target_properties(event PROPERTIES SOVERSION ${EVENT_ABI_LIBVERSION})
-  set_target_properties(event_core PROPERTIES SOVERSION ${EVENT_ABI_LIBVERSION})
-  set_target_properties(event_extra PROPERTIES SOVERSION ${EVENT_ABI_LIBVERSION})
-
-else (EVENT__BUILD_SHARED_LIBRARIES)
-    set(EVENT_EXTRA_FOR_TEST event_extra)
+    set_target_properties(event PROPERTIES SOVERSION ${EVENT_ABI_LIBVERSION})
+    set_target_properties(event_core PROPERTIES SOVERSION ${EVENT_ABI_LIBVERSION})
+    set_target_properties(event_extra PROPERTIES SOVERSION ${EVENT_ABI_LIBVERSION})
 endif (EVENT__BUILD_SHARED_LIBRARIES)
 
 #
@@ -778,8 +761,8 @@ if (NOT EVENT__DISABLE_SAMPLES)
             sample/https-client.c
             sample/openssl_hostname_validation.c
             sample/hostcheck.c)
-        target_link_libraries(https-client event_extra ${LIB_APPS} ${LIB_PLATFORM})
-        add_dependencies(https-client event_extra)
+        target_link_libraries(https-client event_extra event_core ${LIB_APPS} ${LIB_PLATFORM})
+        add_dependencies(https-client event_extra event_core)
 
         # Requires OpenSSL.
         list(APPEND SAMPLES le-proxy)
@@ -787,10 +770,31 @@ if (NOT EVENT__DISABLE_SAMPLES)
 
     foreach(SAMPLE ${SAMPLES})
         add_executable(${SAMPLE} sample/${SAMPLE}.c)
-        target_link_libraries(${SAMPLE} event_extra ${LIB_APPS} ${LIB_PLATFORM})
-        add_dependencies(${SAMPLE} event_extra)
+        target_link_libraries(${SAMPLE} event_extra event_core ${LIB_APPS} ${LIB_PLATFORM})
+        add_dependencies(${SAMPLE} event_extra event_core)
     endforeach()
 endif()
+
+
+# When building shared lib, we still need to link tests to static lib because
+# some tests need hidden symbols.
+if (EVENT__BUILD_SHARED_LIBRARIES)
+    # Define "EXPORTS" to avoid dllimport on Windows.
+    # We need to do this here (after libs and samples, before benchmarks and
+    # tests) not to pollute compiler definitions with this hack.
+    # With cmake 2.8.12 or later, we can use target_compile_definitions instead.
+    add_definitions(-Devent_EXPORTS)
+    add_library(event_all_static STATIC
+        ${HDR_PRIVATE}
+        ${HDR_COMPAT}
+        ${HDR_PUBLIC}
+        ${SRC_CORE}
+        ${SRC_EXTRA}
+        )
+    set(LIBEVENT_FOR_TEST event_all_static)
+else (EVENT__BUILD_SHARED_LIBRARIES)
+    set(LIBEVENT_FOR_TEST event_extra event_core)
+endif (EVENT__BUILD_SHARED_LIBRARIES)
 
 if (NOT EVENT__DISABLE_BENCHMARK)
     foreach (BENCHMARK bench bench_cascade bench_http bench_httpclient)
@@ -801,8 +805,8 @@ if (NOT EVENT__DISABLE_BENCHMARK)
         endif()
 
         add_executable(${BENCHMARK} ${BENCH_SRC})
-        target_link_libraries(${BENCHMARK} event_extra ${LIB_PLATFORM})
-        add_dependencies(${BENCHMARK} event_extra)
+        target_link_libraries(${BENCHMARK} ${LIBEVENT_FOR_TEST} ${LIB_PLATFORM})
+        add_dependencies(${BENCHMARK} ${LIBEVENT_FOR_TEST})
     endforeach()
 endif()
 
@@ -901,8 +905,8 @@ if (NOT EVENT__DISABLE_TESTS)
     # Create test program executables.
     foreach (TESTPROG ${ALL_TESTPROGS})
         add_executable(${TESTPROG} test/${TESTPROG}.c)
-        target_link_libraries(${TESTPROG} ${EVENT_EXTRA_FOR_TEST} ${LIB_PLATFORM})
-        add_dependencies(${TESTPROG} ${EVENT_EXTRA_FOR_TEST})
+        target_link_libraries(${TESTPROG} ${LIBEVENT_FOR_TEST} ${LIB_PLATFORM})
+        add_dependencies(${TESTPROG} ${LIBEVENT_FOR_TEST})
     endforeach()
 
     #

--- a/bufferevent-internal.h
+++ b/bufferevent-internal.h
@@ -322,6 +322,7 @@ void bufferevent_unsuspend_write_(struct bufferevent *bufev, bufferevent_suspend
   @return 0 if successful, or -1 if an error occurred
   @see bufferevent_disable()
  */
+EVENT2_INTERNAL_EXPORT
 int bufferevent_disable_hard_(struct bufferevent *bufev, short event);
 
 /** Internal: Set up locking on a bufferevent.  If lock is set, use it.
@@ -387,6 +388,7 @@ void bufferevent_init_generic_timeout_cbs_(struct bufferevent *bev);
  * that enabled EV_READ or EV_WRITE, or that disables EV_READ or EV_WRITE. */
 int bufferevent_generic_adj_timeouts_(struct bufferevent *bev);
 
+EVENT2_INTERNAL_EXPORT
 enum bufferevent_options bufferevent_get_options_(struct bufferevent *bev);
 
 /** Internal use: We have just successfully read data into an inbuf, so

--- a/defer-internal.h
+++ b/defer-internal.h
@@ -46,6 +46,7 @@ typedef void (*deferred_cb_fn)(struct event_callback *, void *);
    @param cb The function to run when the struct event_callback executes.
    @param arg The function's second argument.
  */
+EVENT2_INTERNAL_EXPORT
 void event_deferred_cb_init_(struct event_callback *, ev_uint8_t, deferred_cb_fn, void *);
 /**
    Change the priority of a non-pending event_callback.
@@ -54,12 +55,14 @@ void event_deferred_cb_set_priority_(struct event_callback *, ev_uint8_t);
 /**
    Cancel a struct event_callback if it is currently scheduled in an event_base.
  */
+EVENT2_INTERNAL_EXPORT
 void event_deferred_cb_cancel_(struct event_base *, struct event_callback *);
 /**
    Activate a struct event_callback if it is not currently scheduled in an event_base.
 
    Return true if it was not previously scheduled.
  */
+EVENT2_INTERNAL_EXPORT
 int event_deferred_cb_schedule_(struct event_base *, struct event_callback *);
 
 #ifdef __cplusplus

--- a/evthread-internal.h
+++ b/evthread-internal.h
@@ -49,9 +49,11 @@ struct event_base;
 #if ! defined(EVENT__DISABLE_THREAD_SUPPORT) && defined(EVTHREAD_EXPOSE_STRUCTS)
 /* Global function pointers to lock-related functions. NULL if locking isn't
    enabled. */
+EVENT2_INTERNAL_EXPORT
 extern struct evthread_lock_callbacks evthread_lock_fns_;
 extern struct evthread_condition_callbacks evthread_cond_fns_;
 extern unsigned long (*evthread_id_fn_)(void);
+EVENT2_INTERNAL_EXPORT
 extern int evthread_lock_debugging_enabled_;
 
 /** Return the ID of the current thread, or 1 if threading isn't enabled. */
@@ -182,10 +184,15 @@ EVLOCK_TRY_LOCK_(void *lock)
 #elif ! defined(EVENT__DISABLE_THREAD_SUPPORT)
 
 unsigned long evthreadimpl_get_id_(void);
+EVENT2_INTERNAL_EXPORT
 int evthreadimpl_is_lock_debugging_enabled_(void);
+EVENT2_INTERNAL_EXPORT
 void *evthreadimpl_lock_alloc_(unsigned locktype);
+EVENT2_INTERNAL_EXPORT
 void evthreadimpl_lock_free_(void *lock, unsigned locktype);
+EVENT2_INTERNAL_EXPORT
 int evthreadimpl_lock_lock_(unsigned mode, void *lock);
+EVENT2_INTERNAL_EXPORT
 int evthreadimpl_lock_unlock_(unsigned mode, void *lock);
 void *evthreadimpl_cond_alloc_(unsigned condtype);
 void evthreadimpl_cond_free_(void *cond);
@@ -355,6 +362,7 @@ EVLOCK_TRY_LOCK_(void *lock)
 		EVLOCK_UNLOCK(lock1_tmplock_,mode1);			\
 	} while (0)
 
+EVENT2_INTERNAL_EXPORT
 int evthread_is_debug_lock_held_(void *lock);
 void *evthread_debug_get_real_lock_(void *lock);
 

--- a/include/event2/visibility.h
+++ b/include/event2/visibility.h
@@ -52,4 +52,11 @@
 
 #endif
 
+// For internal symbols referenced by event-extra
+#if defined(event_core_EXPORTS) || (defined(EVENT__NEED_DLLIMPORT) && defined(_MSC_VER) && !defined(EVENT_BUILDING_REGRESS_TEST))
+#define EVENT2_INTERNAL_EXPORT EVENT2_EXPORT_SYMBOL
+#else
+#define EVENT2_INTERNAL_EXPORT
+#endif
+
 #endif /* EVENT2_VISIBILITY_H_INCLUDED_ */

--- a/log-internal.h
+++ b/log-internal.h
@@ -39,13 +39,17 @@
 
 #define EVENT_ERR_ABORT_ ((int)0xdeaddead)
 
+// Except when shared lib on MSVC, since dllexport + extern does not work
+#if !defined(EVENT__NEED_DLLIMPORT) && !defined(_MSC_VER)
 #define USE_GLOBAL_FOR_DEBUG_LOGGING
+#endif
 
 #if !defined(EVENT__DISABLE_DEBUG_MODE) || defined(USE_DEBUG)
 #define EVENT_DEBUG_LOGGING_ENABLED
 #endif
 
 #ifdef EVENT_DEBUG_LOGGING_ENABLED
+EVENT2_INTERNAL_EXPORT
 #ifdef USE_GLOBAL_FOR_DEBUG_LOGGING
 extern ev_uint32_t event_debug_logging_mask_;
 #define event_debug_get_logging_mask_() (event_debug_logging_mask_)
@@ -56,15 +60,22 @@ ev_uint32_t event_debug_get_logging_mask_(void);
 #define event_debug_get_logging_mask_() (0)
 #endif
 
+EVENT2_INTERNAL_EXPORT
 void event_err(int eval, const char *fmt, ...) EV_CHECK_FMT(2,3) EV_NORETURN;
+EVENT2_INTERNAL_EXPORT
 void event_warn(const char *fmt, ...) EV_CHECK_FMT(1,2);
 void event_sock_err(int eval, evutil_socket_t sock, const char *fmt, ...) EV_CHECK_FMT(3,4) EV_NORETURN;
+EVENT2_INTERNAL_EXPORT
 void event_sock_warn(evutil_socket_t sock, const char *fmt, ...) EV_CHECK_FMT(2,3);
+EVENT2_INTERNAL_EXPORT
 void event_errx(int eval, const char *fmt, ...) EV_CHECK_FMT(2,3) EV_NORETURN;
+EVENT2_INTERNAL_EXPORT
 void event_warnx(const char *fmt, ...) EV_CHECK_FMT(1,2);
 void event_msgx(const char *fmt, ...) EV_CHECK_FMT(1,2);
+EVENT2_INTERNAL_EXPORT
 void event_debugx_(const char *fmt, ...) EV_CHECK_FMT(1,2);
 
+EVENT2_INTERNAL_EXPORT
 void event_logv_(int severity, const char *errstr, const char *fmt, va_list ap)
 	EV_CHECK_FMT(3,0);
 

--- a/mm-internal.h
+++ b/mm-internal.h
@@ -43,6 +43,7 @@ extern "C" {
  *     On failure, set errno to ENOMEM and return NULL.
  *     If the argument sz is 0, simply return NULL.
  */
+EVENT2_INTERNAL_EXPORT
 void *event_mm_malloc_(size_t sz);
 
 /** Allocate memory initialized to zero.
@@ -53,6 +54,7 @@ void *event_mm_malloc_(size_t sz);
  *     set errno to ENOMEM and return NULL.
  *     If either arguments are 0, simply return NULL.
  */
+EVENT2_INTERNAL_EXPORT
 void *event_mm_calloc_(size_t count, size_t size);
 
 /** Duplicate a string.
@@ -63,9 +65,12 @@ void *event_mm_calloc_(size_t count, size_t size);
  *     occurs (or would occur) in the process.
  *     If the argument str is NULL, set errno to EINVAL and return NULL.
  */
+EVENT2_INTERNAL_EXPORT
 char *event_mm_strdup_(const char *str);
 
+EVENT2_INTERNAL_EXPORT
 void *event_mm_realloc_(void *p, size_t sz);
+EVENT2_INTERNAL_EXPORT
 void event_mm_free_(void *p);
 #define mm_malloc(sz) event_mm_malloc_(sz)
 #define mm_calloc(count, size) event_mm_calloc_((count), (size))

--- a/strlcpy-internal.h
+++ b/strlcpy-internal.h
@@ -9,7 +9,9 @@ extern "C" {
 #include "evconfig-private.h"
 
 #ifndef EVENT__HAVE_STRLCPY
+#include "event2/visibility.h"
 #include <string.h>
+EVENT2_INTERNAL_EXPORT
 size_t event_strlcpy_(char *dst, const char *src, size_t siz);
 #define strlcpy event_strlcpy_
 #endif

--- a/util-internal.h
+++ b/util-internal.h
@@ -219,19 +219,25 @@ extern "C" {
  * when you care about ASCII's notion of character types, because you are about
  * to send those types onto the wire.
  */
+EVENT2_INTERNAL_EXPORT
 int EVUTIL_ISALPHA_(char c);
+EVENT2_INTERNAL_EXPORT
 int EVUTIL_ISALNUM_(char c);
 int EVUTIL_ISSPACE_(char c);
+EVENT2_INTERNAL_EXPORT
 int EVUTIL_ISDIGIT_(char c);
+EVENT2_INTERNAL_EXPORT
 int EVUTIL_ISXDIGIT_(char c);
 int EVUTIL_ISPRINT_(char c);
 int EVUTIL_ISLOWER_(char c);
 int EVUTIL_ISUPPER_(char c);
 char EVUTIL_TOUPPER_(char c);
+EVENT2_INTERNAL_EXPORT
 char EVUTIL_TOLOWER_(char c);
 
 /** Remove all trailing horizontal whitespace (space or tab) from the end of a
  * string */
+EVENT2_INTERNAL_EXPORT
 void evutil_rtrim_lws_(char *);
 
 
@@ -258,6 +264,7 @@ void evutil_rtrim_lws_(char *);
  */
 int evutil_open_closeonexec_(const char *pathname, int flags, unsigned mode);
 
+EVENT2_INTERNAL_EXPORT
 int evutil_read_file_(const char *filename, char **content_out, size_t *len_out,
     int is_binary);
 
@@ -358,13 +365,18 @@ typedef struct evdns_getaddrinfo_request* (*evdns_getaddrinfo_fn)(
     const struct evutil_addrinfo *hints_in,
     void (*cb)(int, struct evutil_addrinfo *, void *), void *arg);
 
+EVENT2_INTERNAL_EXPORT
 void evutil_set_evdns_getaddrinfo_fn_(evdns_getaddrinfo_fn fn);
 
+EVENT2_INTERNAL_EXPORT
 struct evutil_addrinfo *evutil_new_addrinfo_(struct sockaddr *sa,
     ev_socklen_t socklen, const struct evutil_addrinfo *hints);
+EVENT2_INTERNAL_EXPORT
 struct evutil_addrinfo *evutil_addrinfo_append_(struct evutil_addrinfo *first,
     struct evutil_addrinfo *append);
+EVENT2_INTERNAL_EXPORT
 void evutil_adjust_hints_for_addrconfig_(struct evutil_addrinfo *hints);
+EVENT2_INTERNAL_EXPORT
 int evutil_getaddrinfo_common_(const char *nodename, const char *servname,
     struct evutil_addrinfo *hints, struct evutil_addrinfo **res, int *portnum);
 
@@ -375,6 +387,7 @@ int evutil_getaddrinfo_async_(struct evdns_base *dns_base,
 
 /** Return true iff sa is a looback address. (That is, it is 127.0.0.1/8, or
  * ::1). */
+EVENT2_INTERNAL_EXPORT
 int evutil_sockaddr_is_loopback_(const struct sockaddr *sa);
 
 
@@ -383,6 +396,7 @@ int evutil_sockaddr_is_loopback_(const struct sockaddr *sa);
     Returns a pointer to out.  Always writes something into out, so it's safe
     to use the output of this function without checking it for NULL.
  */
+EVENT2_INTERNAL_EXPORT
 const char *evutil_format_sockaddr_port_(const struct sockaddr *sa, char *out, size_t outlen);
 
 int evutil_hex_char_to_int_(char c);
@@ -392,6 +406,7 @@ void evutil_free_secure_rng_globals_(void);
 void evutil_free_globals_(void);
 
 #ifdef _WIN32
+EVENT2_INTERNAL_EXPORT
 HMODULE evutil_load_windows_system_library_(const TCHAR *library_name);
 #endif
 
@@ -440,12 +455,12 @@ HMODULE evutil_load_windows_system_library_(const TCHAR *library_name);
 #endif
 #endif
 
+EVENT2_INTERNAL_EXPORT
 evutil_socket_t evutil_socket_(int domain, int type, int protocol);
 evutil_socket_t evutil_accept4_(evutil_socket_t sockfd, struct sockaddr *addr,
     ev_socklen_t *addrlen, int flags);
 
-    /* used by one of the test programs.. */
-EVENT2_EXPORT_SYMBOL
+EVENT2_INTERNAL_EXPORT
 int evutil_make_internal_pipe_(evutil_socket_t fd[2]);
 evutil_socket_t evutil_eventfd_(unsigned initval, int flags);
 


### PR DESCRIPTION
Currently, `event-extra` in CMakeLists.txt is superset of `event-core` and identical to `event` target that also has everything.

This PR makes it identical to Autotools version.

Note:
For the static libraries build, it is straight forward fix.
For the shared libraries build, I exported symbols used by `event-extra`.
What Autotools version does in this regard is to export everything (visibility=default).
Pros of this PR's approach is that it works for Visual C++ too, while obvious cons is the verbosity.

Alternatively, just dropping `event-extra` shared build for VC++ might be a simpler solution.