### PR TITLE
Call underlying bev ctrl SET_FD on filtered bufferevents

### DIFF
--- a/bufferevent_filter.c
+++ b/bufferevent_filter.c
@@ -536,10 +536,20 @@ be_filter_ctrl(struct bufferevent *bev, enum bufferevent_ctrl_op op,
 		bevf = upcast(bev);
 		data->ptr = bevf->underlying;
 		return 0;
-	case BEV_CTRL_GET_FD:
 	case BEV_CTRL_SET_FD:
+		bevf = upcast(bev);
+
+		if (bevf->underlying &&
+			bevf->underlying->be_ops &&
+			bevf->underlying->be_ops->ctrl) {
+		    return (bevf->underlying->be_ops->ctrl)(bevf->underlying, op, data);
+		}
+
+	case BEV_CTRL_GET_FD:
 	case BEV_CTRL_CANCEL_ALL:
 	default:
 		return -1;
 	}
+
+	return -1;
 }


### PR DESCRIPTION
If a bufferevent_filter is set on an underlying bufferevent which has
ctrl functions, bufferevent_filter needs to handle this.

For now I have added just BEV_CTRL_SET_FD, since this is needed for
bufferevent_sock to assign file descriptors to the proper
bufferevent_read/write callbacks.

A good example of the problem can be found in issue #237