### PR TITLE
Fix download link for appveyor SSL

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 install:
-  - appveyor DownloadFile http://slproweb.com/download/Win32OpenSSL-1_0_1L.exe
-  - Win32OpenSSL-1_0_1L.exe /silent /verysilent /sp- /suppressmsgboxes
+  - appveyor DownloadFile https://strcpy.net/packages/Win32OpenSSL-1_0_2a.exe 
+  - Win32OpenSSL-1_0_2a.exe /silent /verysilent /sp- /suppressmsgboxes
 build_script:
   - md build
   - cd build


### PR DESCRIPTION
* change and move the openssl self installer off to a site we own
   - the old link was 404, probably due to being replaced with a newer
     non-vuln version. But since we are only using this installer to
     auto-build with on appveyor (not as a release), then having a file
     we don't change and own seems to be a better solution.