### PR TITLE
Fix garbage value in socketpair util function, stdint?

### DIFF
--- a/evutil.c
+++ b/evutil.c
@@ -257,6 +257,9 @@ evutil_ersatz_socketpair_(int family, int type, int protocol,
 	connector = socket(AF_INET, type, 0);
 	if (connector < 0)
 		goto tidy_up_and_fail;
+
+	memset(&connect_addr, 0, sizeof(connect_addr));
+
 	/* We want to find out the port number to connect to.  */
 	size = sizeof(connect_addr);
 	if (getsockname(listener, (struct sockaddr *) &connect_addr, &size) == -1)

--- a/include/event2/util.h
+++ b/include/event2/util.h
@@ -233,6 +233,7 @@ extern "C" {
 
    @{
 */
+#ifndef EVENT__HAVE_STDINT_H
 #define EV_UINT64_MAX ((((ev_uint64_t)0xffffffffUL) << 32) | 0xffffffffUL)
 #define EV_INT64_MAX  ((((ev_int64_t) 0x7fffffffL) << 32) | 0xffffffffL)
 #define EV_INT64_MIN  ((-EV_INT64_MAX) - 1)
@@ -245,7 +246,21 @@ extern "C" {
 #define EV_UINT8_MAX  255
 #define EV_INT8_MAX   127
 #define EV_INT8_MIN   ((-EV_INT8_MAX) - 1)
+#else
+#define EV_UINT64_MAX UINT64_MAX
+#define EV_INT64_MAX  INT64_MAX
+#define EV_INT64_MIN  INT64_MIN
+#define EV_UINT32_MAX UINT32_MAX
+#define EV_INT32_MAX  INT32_MAX
+#define EV_INT32_MIN  INT32_MIN
+#define EV_UINT16_MAX UINT16_MAX
+#define EV_INT16_MAX  INT16_MAX
+#define EV_UINT8_MAX  UINT8_MAX
+#define EV_INT8_MAX   INT8_MAX
+#define EV_INT8_MIN   INT8_MIN
 /** @} */
+#endif
+
 
 /**
    @name Limits for SIZE_T and SSIZE_T


### PR DESCRIPTION
* Fixed an issue with evutil_ersatz_socketpair_, listen_addr could all
  be compared against with agarbage values. So just memset it before
  using it anywhere.

* Nick might punch me in the face, but if we have stdint.h; (as in
  EVENT__HAVE_STDINT_H is defined), might as well use those instead of
  the manual [U]INT[X}_MAX/MIN muck in there now.