### PR TITLE
Set correct socklen for PF_INET6 sockaddr len

### DIFF
--- a/evutil.c
+++ b/evutil.c
@@ -1162,7 +1162,7 @@ addrinfo_from_hostent(const struct hostent *ent,
 		sin6.sin6_family = AF_INET6;
 		sin6.sin6_port = htons(port);
 		sa = (struct sockaddr *)&sin6;
-		socklen = sizeof(struct sockaddr_in);
+		socklen = sizeof(struct sockaddr_in6);
 		addrp = &sin6.sin6_addr;
 		if (ent->h_length != sizeof(sin6.sin6_addr)) {
 			event_warnx("Weird h_length from gethostbyname");


### PR DESCRIPTION
Reported and patched by Pankaj Sharma on SF: https://sourceforge.net/p/levent/bugs/359/