### PR TITLE
Fix compilation error when debug is disabled and threading is enabled.

### DIFF
--- a/event.c
+++ b/event.c
@@ -670,7 +670,9 @@ event_base_new_with_config(const struct event_config *cfg)
 	/* prepare for threading */
 
 #ifndef EVENT__DISABLE_THREAD_SUPPORT
+#ifndef EVENT__DISABLE_DEBUG_MODE
 	event_debug_created_threadable_ctx_ = 1;
+#endif
 
 	if (EVTHREAD_LOCKING_ENABLED() &&
 	    (!cfg || !(cfg->flags & EVENT_BASE_FLAG_NOLOCK))) {


### PR DESCRIPTION
This patch fixes an issue when you attempt to configure libevent with debugging disabled but threading enabled. 

Environment: Mac OS X 10.10.4; Xcode 6.4.

Reproduction:

````
 ./configure --disable-debug-mode --enable-thread-support
make
````

Output:

````
  GEN      include/event2/event-config.h
/Applications/Xcode.app/Contents/Developer/usr/bin/make  all-am
  CC       buffer.lo
  CC       bufferevent.lo
  CC       bufferevent_filter.lo
  CC       bufferevent_pair.lo
  CC       bufferevent_ratelim.lo
  CC       bufferevent_sock.lo
  CC       event.lo
event.c:544:1: warning: no previous prototype for function 'event_disable_debug_mode' [-Wmissing-prototypes]
event_disable_debug_mode(void)
^
event.c:673:2: error: use of undeclared identifier 'event_debug_created_threadable_ctx_'
        event_debug_created_threadable_ctx_ = 1;
        ^
1 warning and 1 error generated.
make[1]: *** [event.lo] Error 1
make: *** [all] Error 2
````
