### PR TITLE
Don't use BSD u_* types.

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -184,7 +184,7 @@ evbuffer_chain_new(size_t size)
 	/* this way we can manipulate the buffer to different addresses,
 	 * which is required for mmap for example.
 	 */
-	chain->buffer = EVBUFFER_CHAIN_EXTRA(u_char, chain);
+	chain->buffer = EVBUFFER_CHAIN_EXTRA(unsigned char, chain);
 
 	chain->refcnt = 1;
 
@@ -2909,7 +2909,7 @@ evbuffer_add_reference(struct evbuffer *outbuf,
 	if (!chain)
 		return (-1);
 	chain->flags |= EVBUFFER_REFERENCE | EVBUFFER_IMMUTABLE;
-	chain->buffer = (u_char *)data;
+	chain->buffer = (unsigned char *)data;
 	chain->buffer_len = datlen;
 	chain->off = datlen;
 

--- a/event.3
+++ b/event.3
@@ -183,14 +183,14 @@
 .Fn "evbuffer_write" "struct evbuffer *buf" "int fd"
 .Ft int
 .Fn "evbuffer_read" "struct evbuffer *buf" "int fd" "int size"
-.Ft "u_char *"
-.Fn "evbuffer_find" "struct evbuffer *buf" "const u_char *data" "size_t size"
+.Ft "unsigned char *"
+.Fn "evbuffer_find" "struct evbuffer *buf" "const unsigned char *data" "size_t size"
 .Ft "char *"
 .Fn "evbuffer_readline" "struct evbuffer *buf"
 .Ft "struct evhttp *"
 .Fn "evhttp_new" "struct event_base *base"
 .Ft int
-.Fn "evhttp_bind_socket" "struct evhttp *http" "const char *address" "u_short port"
+.Fn "evhttp_bind_socket" "struct evhttp *http" "const char *address" "unsigned short port"
 .Ft "void"
 .Fn "evhttp_free" "struct evhttp *http"
 .Ft int

--- a/evutil.c
+++ b/evutil.c
@@ -313,7 +313,7 @@ evutil_make_socket_nonblocking(evutil_socket_t fd)
 {
 #ifdef _WIN32
 	{
-		u_long nonblocking = 1;
+		unsigned long nonblocking = 1;
 		if (ioctlsocket(fd, FIONBIO, &nonblocking) == SOCKET_ERROR) {
 			event_sock_warn(fd, "fcntl(%d, F_GETFL)", (int)fd);
 			return -1;

--- a/http-internal.h
+++ b/http-internal.h
@@ -62,10 +62,10 @@ struct evhttp_connection {
 	struct event retry_ev;		/* for retrying connects */
 
 	char *bind_address;		/* address to use for binding the src */
-	u_short bind_port;		/* local port for binding the src */
+	unsigned short bind_port;	/* local port for binding the src */
 
 	char *address;			/* address to connect to */
-	u_short port;
+	unsigned short port;
 
 	size_t max_headers_size;
 	ev_uint64_t max_body_size;

--- a/include/event.h
+++ b/include/event.h
@@ -63,8 +63,6 @@ extern "C" {
 #include <winsock2.h>
 #include <windows.h>
 #undef WIN32_LEAN_AND_MEAN
-typedef unsigned char u_char;
-typedef unsigned short u_short;
 #endif
 
 #include <event2/event_struct.h>

--- a/test/bench.c
+++ b/test/bench.c
@@ -74,7 +74,7 @@ static void
 read_cb(evutil_socket_t fd, short which, void *arg)
 {
 	ev_intptr_t idx = (ev_intptr_t) arg, widx = idx + 1;
-	u_char ch;
+	unsigned char ch;
 	ev_ssize_t n;
 
 	n = recv(fd, (char*)&ch, sizeof(ch), 0);

--- a/test/regress.c
+++ b/test/regress.c
@@ -2290,7 +2290,7 @@ end:
 static void
 evtag_fuzz(void *ptr)
 {
-	u_char buffer[4096];
+	unsigned char buffer[4096];
 	struct evbuffer *tmp = evbuffer_new();
 	struct timeval tv;
 	int i, j;

--- a/test/regress_buffer.c
+++ b/test/regress_buffer.c
@@ -1292,7 +1292,7 @@ test_evbuffer_iterative(void *ptr)
 static void
 test_evbuffer_find(void *ptr)
 {
-	u_char* p;
+	unsigned char* p;
 	const char* test1 = "1234567890\r\n";
 	const char* test2 = "1234567890\r";
 #define EVBUFFER_INITIAL_LENGTH 256
@@ -1303,13 +1303,13 @@ test_evbuffer_find(void *ptr)
 	tt_assert(buf);
 
 	/* make sure evbuffer_find doesn't match past the end of the buffer */
-	evbuffer_add(buf, (u_char*)test1, strlen(test1));
+	evbuffer_add(buf, (unsigned char*)test1, strlen(test1));
 	evbuffer_validate(buf);
 	evbuffer_drain(buf, strlen(test1));
 	evbuffer_validate(buf);
-	evbuffer_add(buf, (u_char*)test2, strlen(test2));
+	evbuffer_add(buf, (unsigned char*)test2, strlen(test2));
 	evbuffer_validate(buf);
-	p = evbuffer_find(buf, (u_char*)"\r\n", 2);
+	p = evbuffer_find(buf, (unsigned char*)"\r\n", 2);
 	tt_want(p == NULL);
 
 	/*
@@ -1321,13 +1321,13 @@ test_evbuffer_find(void *ptr)
 	for (i = 0; i < EVBUFFER_INITIAL_LENGTH; ++i)
 		test3[i] = 'a';
 	test3[EVBUFFER_INITIAL_LENGTH - 1] = 'x';
-	evbuffer_add(buf, (u_char *)test3, EVBUFFER_INITIAL_LENGTH);
+	evbuffer_add(buf, (unsigned char *)test3, EVBUFFER_INITIAL_LENGTH);
 	evbuffer_validate(buf);
-	p = evbuffer_find(buf, (u_char *)"xy", 2);
+	p = evbuffer_find(buf, (unsigned char *)"xy", 2);
 	tt_want(p == NULL);
 
 	/* simple test for match at end of allocated buffer */
-	p = evbuffer_find(buf, (u_char *)"ax", 2);
+	p = evbuffer_find(buf, (unsigned char *)"ax", 2);
 	tt_assert(p != NULL);
 	tt_want(strncmp((char*)p, "ax", 2) == 0);
 

--- a/test/regress_http.c
+++ b/test/regress_http.c
@@ -151,7 +151,7 @@ http_setup(ev_uint16_t *pport, struct event_base *base, int ipv6)
 #endif
 
 static evutil_socket_t
-http_connect(const char *address, u_short port)
+http_connect(const char *address, unsigned short port)
 {
 	/* Stupid code for connecting */
 	struct evutil_addrinfo ai, *aitop;

--- a/win32select.c
+++ b/win32select.c
@@ -57,7 +57,7 @@ extern struct event_list timequeue;
 extern struct event_list addqueue;
 
 struct win_fd_set {
-	u_int fd_count;
+	unsigned int fd_count;
 	SOCKET fd_array[1];
 };
 


### PR DESCRIPTION
These types are not part of POSIX. As we only use them in a small number
of places, we'd better replace them by C standard types. This makes a
larger part of the code build for CloudABI.