### PR TITLE
Test against SO_REUSEADDR instead of _WIN32.

### DIFF
--- a/evutil.c
+++ b/evutil.c
@@ -358,7 +358,7 @@ evutil_fast_socket_nonblocking(evutil_socket_t fd)
 int
 evutil_make_listen_socket_reuseable(evutil_socket_t sock)
 {
-#ifndef _WIN32
+#ifdef SO_REUSEADDR
 	int one = 1;
 	/* REUSEADDR on Unix means, "don't hang on to this address after the
 	 * listener is closed."  On Windows, though, it means "don't keep other


### PR DESCRIPTION
This makes the code build on other systems that also don't have
SO_REUSEADDR without requiring special code.