### PR TITLE
Remove BSD-ism: TIMEVAL_TO_TIMESPEC().

### DIFF
--- a/kqueue.c
+++ b/kqueue.c
@@ -260,7 +260,8 @@ kq_dispatch(struct event_base *base, struct timeval *tv)
 	int i, n_changes, res;
 
 	if (tv != NULL) {
-		TIMEVAL_TO_TIMESPEC(tv, &ts);
+		ts.tv_sec = tv->tv_sec;
+		ts.tv_nsec = tv->tv_usec * 1000;
 		ts_p = &ts;
 	}
 


### PR DESCRIPTION
Systems like CloudABI implement kqueue() but do not provide the
BSD-specific TIMEVAL_TO_TIMESPEC() macro. Change the code to perform
this manually, as it is not hard to do this conversion.