### PR TITLE
add http 1.1 extension-method feature

### DIFF
--- a/http-internal.h
+++ b/http-internal.h
@@ -102,7 +102,7 @@ struct evhttp_connection {
 	struct evdns_base *dns_base;
 	int ai_family;
 
-	const struct evhttp_extended_methods *ext_methods;
+	const struct evhttp_extended_method *ext_methods;
 };
 
 /* A callback for an http server */
@@ -170,7 +170,7 @@ struct evhttp {
 
 	struct event_base *base;
 
-	const struct evhttp_extended_methods *ext_methods;
+	const struct evhttp_extended_method *ext_methods;
 };
 
 /* XXX most of these functions could be static. */

--- a/http-internal.h
+++ b/http-internal.h
@@ -101,6 +101,8 @@ struct evhttp_connection {
 	struct event_base *base;
 	struct evdns_base *dns_base;
 	int ai_family;
+
+	const struct evhttp_extended_methods *ext_methods;
 };
 
 /* A callback for an http server */
@@ -167,6 +169,8 @@ struct evhttp {
 	void *bevcbarg;
 
 	struct event_base *base;
+
+	const struct evhttp_extended_methods *ext_methods;
 };
 
 /* XXX most of these functions could be static. */

--- a/http.c
+++ b/http.c
@@ -305,7 +305,7 @@ evhttp_method(struct evhttp_connection *evcon,
               enum evhttp_cmd_type type)
 {
 	const char *method;
-	const struct evhttp_extended_methods * ext_methods;
+	const struct evhttp_extended_method * ext_methods;
 
 	switch (type) {
 	case EVHTTP_REQ_GET:
@@ -1743,7 +1743,7 @@ evhttp_parse_request_line(struct evhttp_request *req, char *line)
 
 	if ((int)type == EVHTTP_REQ_UNKNOWN_) {
 		/* check extended methods */
-		const struct evhttp_extended_methods * ext_methods = req->evcon->ext_methods;
+		const struct evhttp_extended_method * ext_methods = req->evcon->ext_methods;
 		if (ext_methods == NULL && req->evcon->http_server != NULL)
 			ext_methods = req->evcon->http_server->ext_methods;
 		if (ext_methods != NULL) {
@@ -2112,7 +2112,7 @@ evhttp_method_may_have_body(struct evhttp_connection *evcon, enum evhttp_cmd_typ
 		return 0;
 	default:
 		if (evcon) {
-			const struct evhttp_extended_methods * ext_methods = evcon->ext_methods;
+			const struct evhttp_extended_method * ext_methods = evcon->ext_methods;
 			if (ext_methods == NULL && evcon->http_server != NULL)
 				ext_methods = evcon->http_server->ext_methods;
 			if (ext_methods) {
@@ -2397,7 +2397,7 @@ int evhttp_connection_set_flags(struct evhttp_connection *evcon,
 }
 
 void evhttp_connection_set_extended_methods(struct evhttp_connection *evcon,
-	const struct evhttp_extended_methods *ext_methods)
+	const struct evhttp_extended_method *ext_methods)
 {
 	evcon->ext_methods = ext_methods;
 }
@@ -3770,7 +3770,7 @@ evhttp_set_allowed_methods(struct evhttp* http, ev_uint16_t methods)
 
 void
 evhttp_set_extended_methods(struct evhttp* http,
-    const struct evhttp_extended_methods *ext_methods)
+    const struct evhttp_extended_method *ext_methods)
 {
 	http->ext_methods = ext_methods;
 }

--- a/http.c
+++ b/http.c
@@ -2299,7 +2299,9 @@ evhttp_connection_base_bufferevent_new(struct event_base *base, struct evdns_bas
 {
 	struct evhttp_connection *evcon = NULL;
 
-	event_debug(("%s %s:%d\n", (dnsbase?"New connection from":"Attempting connection to"), address, port));
+	event_debug(("%s %s:%d\n",
+	             (dnsbase?"New connection from":"Attempting connection to"),
+	             address, port));
 
 	if ((evcon = mm_calloc(1, sizeof(struct evhttp_connection))) == NULL) {
 		event_warn("%s: calloc failed", __func__);

--- a/http.c
+++ b/http.c
@@ -192,6 +192,8 @@ static void evhttp_get_request(struct evhttp *, evutil_socket_t, struct sockaddr
 static void evhttp_write_buffer(struct evhttp_connection *,
     void (*)(struct evhttp_connection *, void *), void *);
 static void evhttp_make_header(struct evhttp_connection *, struct evhttp_request *);
+static int
+evhttp_method_may_have_body(enum evhttp_cmd_type type);
 
 /* callbacks for bufferevent */
 static void evhttp_read_cb(struct bufferevent *, void *);
@@ -441,7 +443,7 @@ evhttp_make_header_request(struct evhttp_connection *evcon,
 	    method, req->uri, req->major, req->minor);
 
 	/* Add the content length on a post or put request if missing */
-	if ((req->type == EVHTTP_REQ_POST || req->type == EVHTTP_REQ_PUT) &&
+	if (evhttp_method_may_have_body(req->type) &&
 	    evhttp_find_header(req->output_headers, "Content-Length") == NULL){
 		char size[22];
 		evutil_snprintf(size, sizeof(size), EV_SIZE_FMT,

--- a/http.c
+++ b/http.c
@@ -2258,7 +2258,7 @@ evhttp_connection_base_bufferevent_new(struct event_base *base, struct evdns_bas
 {
 	struct evhttp_connection *evcon = NULL;
 
-	event_debug(("Attempting connection to %s:%d\n", address, port));
+	event_debug(("%s %s:%d\n", (dnsbase?"New connection from":"Attempting connection to"), address, port));
 
 	if ((evcon = mm_calloc(1, sizeof(struct evhttp_connection))) == NULL) {
 		event_warn("%s: calloc failed", __func__);

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -73,6 +73,7 @@ struct evkeyvalq;
 struct evhttp_bound_socket;
 struct evconnlistener;
 struct evdns_base;
+struct evhttp_extended_methods;
 
 /**
  * Create a new HTTP server.
@@ -246,6 +247,16 @@ void evhttp_set_default_content_type(struct evhttp *http,
 */
 EVENT2_EXPORT_SYMBOL
 void evhttp_set_allowed_methods(struct evhttp* http, ev_uint16_t methods);
+
+/**
+  Sets the HTTP extended methods supported by this server
+
+  @param http the http server on which to add support to the methods
+  @param ext_methods method list
+*/
+EVENT2_EXPORT_SYMBOL
+void evhttp_set_extended_methods(struct evhttp* http,
+    const struct evhttp_extended_methods *ext_methods);
 
 /**
    Set a callback for a specified URI
@@ -487,6 +498,18 @@ enum evhttp_cmd_type {
 	EVHTTP_REQ_PATCH   = 1 << 8
 };
 
+#define EVHTTP_REQ_MAX EVHTTP_REQ_PATCH
+
+/** structure to allow users to define their own HTTP methods
+ * @see evhttp_set_extended_methods */
+struct evhttp_extended_methods {
+	const char * method;
+	ev_uint16_t type;
+	ev_uint16_t flags;
+};
+
+#define EVHTTP_METHOD_HAS_BODY 0x0001
+
 /** a request object can represent either a request or a reply */
 enum evhttp_request_kind { EVHTTP_REQUEST, EVHTTP_RESPONSE };
 
@@ -660,6 +683,15 @@ void evhttp_request_own(struct evhttp_request *req);
 /** Returns 1 if the request is owned by the user */
 EVENT2_EXPORT_SYMBOL
 int evhttp_request_is_owned(struct evhttp_request *req);
+
+/**
+ * Sets extended method list
+ *
+ * @see evhttp_set_extended_methods
+ */
+EVENT2_EXPORT_SYMBOL
+void evhttp_connection_set_extended_methods(struct evhttp_connection *evcon,
+	const struct evhttp_extended_methods *ext_methods);
 
 /**
  * Returns the connection object associated with the request or NULL

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -73,7 +73,7 @@ struct evkeyvalq;
 struct evhttp_bound_socket;
 struct evconnlistener;
 struct evdns_base;
-struct evhttp_extended_methods;
+struct evhttp_extended_method;
 
 /**
  * Create a new HTTP server.
@@ -256,7 +256,7 @@ void evhttp_set_allowed_methods(struct evhttp* http, ev_uint16_t methods);
 */
 EVENT2_EXPORT_SYMBOL
 void evhttp_set_extended_methods(struct evhttp* http,
-    const struct evhttp_extended_methods *ext_methods);
+    const struct evhttp_extended_method *ext_methods);
 
 /**
    Set a callback for a specified URI
@@ -502,10 +502,10 @@ enum evhttp_cmd_type {
 
 /** structure to allow users to define their own HTTP methods
  * @see evhttp_set_extended_methods */
-struct evhttp_extended_methods {
+struct evhttp_extended_method {
 	const char * method;
 	ev_uint16_t type;
-	ev_uint16_t flags;
+	ev_uint16_t flags;	/* Available flag : EVHTTP_METHOD_HAS_BODY */
 };
 
 #define EVHTTP_METHOD_HAS_BODY 0x0001
@@ -691,7 +691,7 @@ int evhttp_request_is_owned(struct evhttp_request *req);
  */
 EVENT2_EXPORT_SYMBOL
 void evhttp_connection_set_extended_methods(struct evhttp_connection *evcon,
-	const struct evhttp_extended_methods *ext_methods);
+	const struct evhttp_extended_method *ext_methods);
 
 /**
  * Returns the connection object associated with the request or NULL

--- a/test/regress_http.c
+++ b/test/regress_http.c
@@ -70,6 +70,13 @@ static struct event_base *exit_base;
 
 static char const BASIC_REQUEST_BODY[] = "This is funny";
 
+/* extended Method */
+#define EVHTTP_REQ_CUSTOM	((EVHTTP_REQ_MAX) << 1)
+static const struct evhttp_extended_methods ext_methods[] = {
+	{"CUSTOM", EVHTTP_REQ_CUSTOM, 0/*EVHTTP_METHOD_HAS_BODY*/},
+	{NULL, 0, 0}
+};
+
 #define IMPL_HTTP_REQUEST_ERROR_CB(name, expecting_error)                    \
 	static void                                                              \
 	http_request_error_cb_with_##name##_(enum evhttp_request_error error,    \
@@ -89,6 +96,7 @@ static void http_chunked_cb(struct evhttp_request *req, void *arg);
 static void http_post_cb(struct evhttp_request *req, void *arg);
 static void http_put_cb(struct evhttp_request *req, void *arg);
 static void http_delete_cb(struct evhttp_request *req, void *arg);
+static void http_custom_cb(struct evhttp_request *req, void *arg);
 static void http_delay_cb(struct evhttp_request *req, void *arg);
 static void http_large_delay_cb(struct evhttp_request *req, void *arg);
 static void http_badreq_cb(struct evhttp_request *req, void *arg);
@@ -132,6 +140,9 @@ http_setup(ev_uint16_t *pport, struct event_base *base, int ipv6)
 	if (http_bind(myhttp, pport, ipv6) < 0)
 		return NULL;
 
+	/* add support for extended HTTP methods */
+	evhttp_set_extended_methods(myhttp, ext_methods);
+
 	/* Register a callback for certain types of requests */
 	evhttp_set_cb(myhttp, "/test", http_basic_cb, base);
 	evhttp_set_cb(myhttp, "/large", http_large_cb, base);
@@ -140,6 +151,7 @@ http_setup(ev_uint16_t *pport, struct event_base *base, int ipv6)
 	evhttp_set_cb(myhttp, "/postit", http_post_cb, base);
 	evhttp_set_cb(myhttp, "/putit", http_put_cb, base);
 	evhttp_set_cb(myhttp, "/deleteit", http_delete_cb, base);
+	evhttp_set_cb(myhttp, "/custom", http_custom_cb, base);
 	evhttp_set_cb(myhttp, "/delay", http_delay_cb, base);
 	evhttp_set_cb(myhttp, "/largedelay", http_large_delay_cb, base);
 	evhttp_set_cb(myhttp, "/badrequest", http_badreq_cb, base);
@@ -765,6 +777,78 @@ http_delete_test(void *arg)
 		evutil_closesocket(fd);
 }
 
+/*
+ * HTTP CUSTOM test,  just piggyback on the basic test
+ */
+
+static void
+http_custom_cb(struct evhttp_request *req, void *arg)
+{
+	struct evbuffer *evb = evbuffer_new();
+	int empty = evhttp_find_header(evhttp_request_get_input_headers(req), "Empty") != NULL;
+
+	/* Expecting a CUSTOM request */
+	if (evhttp_request_get_command(req) != EVHTTP_REQ_CUSTOM) {
+		fprintf(stdout, "FAILED (custom type)\n");
+		exit(1);
+	}
+
+	event_debug(("%s: called\n", __func__));
+	evbuffer_add_printf(evb, BASIC_REQUEST_BODY);
+
+	/* allow sending of an empty reply */
+	evhttp_send_reply(req, HTTP_OK, "Everything is fine",
+	    !empty ? evb : NULL);
+
+	evbuffer_free(evb);
+}
+
+static void
+http_custom_test(void *arg)
+{
+	struct basic_test_data *data = arg;
+	struct bufferevent *bev;
+	evutil_socket_t fd = -1;
+	const char *http_request;
+	ev_uint16_t port = 0;
+
+	test_ok = 0;
+
+	http = http_setup(&port, data->base, 0);
+	/* Allow custom */
+	evhttp_set_allowed_methods(http, EVHTTP_REQ_CUSTOM);
+
+	tt_assert(http);
+	fd = http_connect("127.0.0.1", port);
+	tt_int_op(fd, >=, 0);
+
+	/* Stupid thing to send a request */
+	bev = bufferevent_socket_new(data->base, fd, 0);
+	bufferevent_setcb(bev, http_readcb, http_writecb,
+	    http_errorcb, data->base);
+
+	http_request =
+	    "CUSTOM /custom HTTP/1.1\r\n"
+	    "Host: somehost\r\n"
+	    "Connection: close\r\n"
+	    "\r\n";
+
+	bufferevent_write(bev, http_request, strlen(http_request));
+
+	event_base_dispatch(data->base);
+
+	bufferevent_free(bev);
+	evutil_closesocket(fd);
+	fd = -1;
+
+	evhttp_free(http);
+
+	tt_int_op(test_ok, ==, 2);
+ end:
+	if (fd >= 0)
+		evutil_closesocket(fd);
+}
+
 static void
 http_sent_cb(struct evhttp_request *req, void *arg)
 {
@@ -869,10 +953,10 @@ static void
 http_allowed_methods_test(void *arg)
 {
 	struct basic_test_data *data = arg;
-	struct bufferevent *bev1, *bev2, *bev3;
-	evutil_socket_t fd1=-1, fd2=-1, fd3=-1;
+	struct bufferevent *bev1, *bev2, *bev3, *bev4;
+	evutil_socket_t fd1=-1, fd2=-1, fd3=-1, fd4=-1;
 	const char *http_request;
-	char *result1=NULL, *result2=NULL, *result3=NULL;
+	char *result1=NULL, *result2=NULL, *result3=NULL, *result4=NULL;
 	ev_uint16_t port = 0;
 
 	exit_base = data->base;
@@ -883,8 +967,8 @@ http_allowed_methods_test(void *arg)
 	fd1 = http_connect("127.0.0.1", port);
 	tt_int_op(fd1, >=, 0);
 
-	/* GET is out; PATCH is in. */
-	evhttp_set_allowed_methods(http, EVHTTP_REQ_PATCH);
+	/* GET is out; PATCH & CUSTOM are in. */
+	evhttp_set_allowed_methods(http, EVHTTP_REQ_PATCH | EVHTTP_REQ_CUSTOM);
 
 	/* Stupid thing to send a request */
 	bev1 = bufferevent_socket_new(data->base, fd1, 0);
@@ -938,9 +1022,28 @@ http_allowed_methods_test(void *arg)
 
 	event_base_dispatch(data->base);
 
+	fd4 = http_connect("127.0.0.1", port);
+	tt_int_op(fd4, >=, 0);
+
+	bev4 = bufferevent_socket_new(data->base, fd4, 0);
+	bufferevent_enable(bev4, EV_READ|EV_WRITE);
+	bufferevent_setcb(bev4, NULL, NULL,
+	    http_allowed_methods_eventcb, &result4);
+
+	http_request =
+	    "CUSTOM /test HTTP/1.1\r\n"
+	    "Host: somehost\r\n"
+	    "Connection: close\r\n"
+	    "\r\n";
+
+	bufferevent_write(bev4, http_request, strlen(http_request));
+
+	event_base_dispatch(data->base);
+
 	bufferevent_free(bev1);
 	bufferevent_free(bev2);
 	bufferevent_free(bev3);
+	bufferevent_free(bev4);
 
 	evhttp_free(http);
 
@@ -956,6 +1059,10 @@ http_allowed_methods_test(void *arg)
 	tt_assert(result3);
 	tt_assert(!strncmp(result3, "HTTP/1.1 501 ", strlen("HTTP/1.1 501 ")));
 
+	/* Custom method (and allowed) */
+	tt_assert(result4);
+	tt_assert(!strncmp(result4, "HTTP/1.1 200 ", strlen("HTTP/1.1 200 ")));
+
  end:
 	if (result1)
 		free(result1);
@@ -963,12 +1070,16 @@ http_allowed_methods_test(void *arg)
 		free(result2);
 	if (result3)
 		free(result3);
+	if (result4)
+		free(result4);
 	if (fd1 >= 0)
 		evutil_closesocket(fd1);
 	if (fd2 >= 0)
 		evutil_closesocket(fd2);
 	if (fd3 >= 0)
 		evutil_closesocket(fd3);
+	if (fd4 >= 0)
+		evutil_closesocket(fd4);
 }
 
 static void http_request_no_action_done(struct evhttp_request *, void *);
@@ -991,6 +1102,8 @@ http_connection_test_(struct basic_test_data *data, int persistent,
 	}
 	tt_assert(http);
 
+	evhttp_set_allowed_methods(http, EVHTTP_REQ_GET | EVHTTP_REQ_CUSTOM);
+
 	evcon = evhttp_connection_base_new(data->base, dnsbase, address, port);
 	tt_assert(evcon);
 	evhttp_connection_set_family(evcon, family);
@@ -1000,6 +1113,9 @@ http_connection_test_(struct basic_test_data *data, int persistent,
 	exit_base = data->base;
 
 	tt_assert(evhttp_connection_get_server(evcon) == NULL);
+
+	/* add support for CUSTOM method */
+	evhttp_connection_set_extended_methods(evcon, ext_methods);
 
 	/*
 	 * At this point, we want to schedule a request to the HTTP
@@ -1052,6 +1168,21 @@ http_connection_test_(struct basic_test_data *data, int persistent,
 
 	/* We give ownership of the request to the connection */
 	if (evhttp_make_request(evcon, req, EVHTTP_REQ_GET, "/test") == -1) {
+		tt_abort_msg("Couldn't make request");
+	}
+
+	event_base_dispatch(data->base);
+
+	/* make a CUSTOM request */
+	test_ok = 0;
+
+	req = evhttp_request_new(http_request_empty_done, data->base);
+
+	/* our CUSTOM method doesn't have Body */
+	evhttp_add_header(evhttp_request_get_output_headers(req), "Empty", "itis");
+
+	/* We give ownership of the request to the connection */
+	if (evhttp_make_request(evcon, req, EVHTTP_REQ_CUSTOM, "/test") == -1) {
 		tt_abort_msg("Couldn't make request");
 	}
 
@@ -4119,6 +4250,7 @@ struct testcase_t http_testcases[] = {
 	HTTP(post),
 	HTTP(put),
 	HTTP(delete),
+	HTTP(custom),
 	HTTP(allowed_methods),
 	HTTP(failure),
 	HTTP(connection),

--- a/test/regress_http.c
+++ b/test/regress_http.c
@@ -72,7 +72,7 @@ static char const BASIC_REQUEST_BODY[] = "This is funny";
 
 /* extended Method */
 #define EVHTTP_REQ_CUSTOM	((EVHTTP_REQ_MAX) << 1)
-static const struct evhttp_extended_methods ext_methods[] = {
+static const struct evhttp_extended_method ext_methods[] = {
 	{"CUSTOM", EVHTTP_REQ_CUSTOM, 0/*EVHTTP_METHOD_HAS_BODY*/},
 	{NULL, 0, 0}
 };


### PR DESCRIPTION
allow anyone to add its custom HTTP methods
```
#define EVHTTP_REQ_NOTIFY        ((EVHTTP_REQ_MAX) << 1)
#define EVHTTP_REQ_SUBSCRIBE ((EVHTTP_REQ_NOTIFY) << 1)
static const struct evhttp_extended_methods ext_methods[] = {
  {"NOTIFY", EVHTTP_REQ_NOTIFY, EVHTTP_METHOD_HAS_BODY},
  {"SUBSCRIBE", EVHTTP_REQ_SUBSCRIBE, EVHTTP_METHOD_HAS_BODY},
  {NULL, 0, 0}
};
     
...
evhttp_set_extended_methods(http, ext_methods);
...
evhttp_connection_set_extended_methods(evconn, ext_methods);
```

