### PR TITLE
Fixed Unicode issue in error messages.

### DIFF
--- a/evutil.c
+++ b/evutil.c
@@ -1708,10 +1708,10 @@ evutil_socket_error_to_string(int errcode)
 		goto done;
 	}
 
-	if (0 != FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
+	if (0 != FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM |
 			       FORMAT_MESSAGE_IGNORE_INSERTS |
 			       FORMAT_MESSAGE_ALLOCATE_BUFFER,
-			       NULL, errcode, 0, (LPTSTR)&msg, 0, NULL))
+			       NULL, errcode, 0, (char *)&msg, 0, NULL))
 		chomp (msg);	/* because message has trailing newline */
 	else {
 		size_t len = 50;


### PR DESCRIPTION
When an application is compiled with `UNICODE` turned on, the error messages produced by LibEvent are single-characters only, because `FormatMessageW` was used, with a `char` buffer.

This change uses the `FormatMessageA` function to get the error message; the assumption being that all error messages can be represented in the local codepage for the application. The only other solution would be to decide on having all error messages in utf-8, and including a transcode from windows' Unicode to utf-8 representation, using the `WideCharToMultiByte` function.