### PR TITLE
Switching protocol response support

### DIFF
--- a/http-internal.h
+++ b/http-internal.h
@@ -96,6 +96,9 @@ struct evhttp_connection {
 	void (*closecb)(struct evhttp_connection *, void *);
 	void *closecb_arg;
 
+	void (*switch_protocb)(struct bufferevent *, void *);
+	void *switch_protocb_arg;
+
 	struct event_callback read_more_deferred_cb;
 
 	struct event_base *base;

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -53,6 +53,7 @@ struct evhttp_connection;
  */
 
 /* Response codes */
+#define HTTP_SWITCHING_PROTOCOLS	101	/**< switching to another protocol */
 #define HTTP_OK			200	/**< request completed ok */
 #define HTTP_NOCONTENT		204	/**< request does not have content */
 #define HTTP_MOVEPERM		301	/**< the uri moved permanently */
@@ -463,6 +464,24 @@ void evhttp_send_reply_chunk_with_cb(struct evhttp_request *, struct evbuffer *,
 */
 EVENT2_EXPORT_SYMBOL
 void evhttp_send_reply_end(struct evhttp_request *req);
+
+/**
+   Complete a reply, by sending 101 SWITCHING PROTOCOL.
+
+   Allows one to switch protocol and continue communication with the client
+   directly through the connection esteblished by handshake request.
+
+   evhttp_request object will be freed but the connection returned by this
+   function remains alive and it's caller responsibility to free it at
+   approptiate time.
+
+   @param req a request object
+   @param cb a callback to call when connection can be use for communication by
+   new protocol
+   @param arg a pointer to callback argument
+*/
+EVENT2_EXPORT_SYMBOL
+void evhttp_send_switch_protocol(struct evhttp_request *req, void (*cb)(struct bufferevent *, void *), void *arg);
 
 /*
  * Interfaces for making requests


### PR DESCRIPTION
Allows to get underlying bufferevent for further comunication using
another protocol right after 101 SWITCHING PROTOCOLS response sent.

Intent behind this pull request is to be able to handle websocket upgrede request in a server written with evhttp and use underlying bufferevent for websocket communication.