### PR TITLE
The Windows socket type is defined as SOCKET.

### DIFF
--- a/Makefile.nmake
+++ b/Makefile.nmake
@@ -25,6 +25,9 @@ CFLAGS=/IWIN32-Code /IWIN32-Code/nmake /Iinclude /Icompat /DHAVE_CONFIG_H /I. $(
 # For optimization and warnings
 CFLAGS=$(CFLAGS) /Ox /W3 /wd4996 /nologo
 
+# Add BUILD_CFLAGS from the environment
+CFLAGS=$(CFLAGS) $(BUILD_CFLAGS)
+
 # XXXX have a debug mode
 
 LIBFLAGS=/nologo
@@ -47,7 +50,6 @@ SSL_LIBS=
 
 ALL_OBJS=$(CORE_OBJS) $(WIN_OBJS) $(EXTRA_OBJS) $(SSL_OBJS)
 STATIC_LIBS=libevent_core.lib libevent_extras.lib libevent.lib $(SSL_LIBS)
-
 
 all: static_libs tests
 

--- a/buildall.bat
+++ b/buildall.bat
@@ -1,0 +1,26 @@
+nmake -f Makefile.nmake clean
+
+set BUILD_CFLAGS=/MT
+nmake -f Makefile.nmake
+mkdir lib\MT\Release
+move libev*.lib lib\MT\Release
+nmake -f Makefile.nmake clean
+
+set BUILD_CFLAGS=/MTd
+nmake -f Makefile.nmake
+mkdir lib\MT\Debug
+move libev*.lib lib\MT\Debug
+nmake -f Makefile.nmake clean
+
+set BUILD_CFLAGS=/MD
+nmake -f Makefile.nmake
+mkdir lib\MD\Release
+move libev*.lib lib\MD\Release
+nmake -f Makefile.nmake clean
+
+set BUILD_CFLAGS=/MDd
+nmake -f Makefile.nmake
+mkdir lib\MD\Debug
+move libev*.lib lib\MD\Debug
+nmake -f Makefile.nmake clean
+

--- a/include/event2/util.h
+++ b/include/event2/util.h
@@ -300,9 +300,9 @@ extern "C" {
 
 /**
  * A type wide enough to hold the output of "socket()" or "accept()".  On
- * Windows, this is an intptr_t; elsewhere, it is an int. */
+ * Windows, this is an SOCKET; elsewhere, it is an int. */
 #ifdef _WIN32
-#define evutil_socket_t intptr_t
+#define evutil_socket_t SOCKET
 #else
 #define evutil_socket_t int
 #endif

--- a/test/Makefile.nmake
+++ b/test/Makefile.nmake
@@ -14,6 +14,9 @@ CFLAGS=/I.. /I../WIN32-Code /I../WIN32-Code/nmake /I../include /I../compat /DHAV
 
 CFLAGS=$(CFLAGS) /Ox /W3 /wd4996 /nologo
 
+# Add BUILD_CFLAGS from the environment
+CFLAGS=$(CFLAGS) $(BUILD_CFLAGS)
+
 REGRESS_OBJS=regress.obj regress_buffer.obj regress_http.obj regress_dns.obj \
 	regress_testutils.obj \
         regress_rpc.obj regress.gen.obj \


### PR DESCRIPTION
Under the hood it's an unsigned rather than a signed type and whilst C
compilers are largely happy with this C++ compilers tend to be fussy
about class function signatures which makes C++ usage of libevent
problematic.