### PR TITLE
Support unix domains in the http client

### DIFF
--- a/http-internal.h
+++ b/http-internal.h
@@ -64,6 +64,9 @@ struct evhttp_connection {
 	char *bind_address;		/* address to use for binding the src */
 	unsigned short bind_port;	/* local port for binding the src */
 
+#ifndef _WIN32
+	char *unixdomain;
+#endif
 	char *address;			/* address to connect to */
 	unsigned short port;
 


### PR DESCRIPTION
There are no standard for encoding a unix socket in an url. nginx uses:

http://unix:/path/to/unix/socket:/httppath

The second colon is needed to delimit where the unix path ends and where
the rest of the url continues.