### PR TITLE
Add callback support for error pages

### DIFF
--- a/http-internal.h
+++ b/http-internal.h
@@ -163,8 +163,12 @@ struct evhttp {
 	   don't match. */
 	void (*gencb)(struct evhttp_request *req, void *);
 	void *gencbarg;
+
 	struct bufferevent* (*bevcb)(struct event_base *, void *);
 	void *bevcbarg;
+
+	int (*errorcb)(struct evhttp_request *, struct evbuffer *, int, const char *, void *);
+	void *errorcbarg;
 
 	struct event_base *base;
 };

--- a/http.c
+++ b/http.c
@@ -2657,31 +2657,80 @@ evhttp_send_done(struct evhttp_connection *evcon, void *arg)
 void
 evhttp_send_error(struct evhttp_request *req, int error, const char *reason)
 {
-
-#define ERR_FORMAT "<HTML><HEAD>\n" \
-	    "<TITLE>%d %s</TITLE>\n" \
-	    "</HEAD><BODY>\n" \
-	    "<H1>%s</H1>\n" \
-	    "</BODY></HTML>\n"
+#define ERR_FORMAT "<html><head>" \
+	"<title>%d %s</title>" \
+	"</head><body>" \
+	"<h1>%d %s</h1>%s" \
+	"</body></html>"
 
 	struct evbuffer *buf = evbuffer_new();
+	const char *heading = evhttp_response_phrase_internal(error);
+	struct evhttp *http = req->evcon->http_server;
+
 	if (buf == NULL) {
 		/* if we cannot allocate memory; we just drop the connection */
 		evhttp_connection_free(req->evcon);
 		return;
 	}
-	if (reason == NULL) {
-		reason = evhttp_response_phrase_internal(error);
-	}
 
 	evhttp_response_code_(req, error, reason);
 
-	evbuffer_add_printf(buf, ERR_FORMAT, error, reason, reason);
+	/* Output error using callback for connection's evhttp, if available */
+	if ((http == NULL) ||
+	    (http->errorcb == NULL) ||
+	    ((*http->errorcb)(req, buf, error, reason, http->errorcbarg) < 0) ||
+	    (evbuffer_get_length(buf) == 0)) {
+		/* Drain any output from the callback */
+		evbuffer_drain(buf, evbuffer_get_length(buf));
+
+		/* Output the error in the default format */
+		evbuffer_add_printf(buf, ERR_FORMAT,
+		   error, heading, error, heading,
+		   (reason != NULL ? reason : ""));
+        }
 
 	evhttp_send_page_(req, buf);
 
 	evbuffer_free(buf);
 #undef ERR_FORMAT
+}
+
+/*
+ * Returns an error page.
+ */
+
+void
+evhttp_send_notfound(struct evhttp_request *req, const char *url)
+{
+#define REASON_FORMAT "<p>The requested URL %s was not found on this server.</p>"
+	char   *escaped_url = NULL;
+	char   *reason = NULL;
+	size_t  reason_len;
+
+	url = (url != NULL ? url : req->uri);
+	if (url != NULL) {
+		escaped_url = evhttp_htmlescape(url);
+	}
+
+	if (escaped_url != NULL) {
+		reason_len = strlen(REASON_FORMAT)+strlen(escaped_url)+1;
+		reason = mm_malloc(reason_len);
+	}
+
+	if ((escaped_url != NULL) && (reason != NULL)) {
+		evutil_snprintf(reason, reason_len,
+		    REASON_FORMAT, escaped_url);
+	}
+
+	evhttp_send_error(req, HTTP_NOTFOUND, reason);
+
+	if (reason != NULL) {
+		mm_free(reason);
+	}
+	if (escaped_url != NULL) {
+		mm_free(escaped_url);
+	}
+#undef REASON_FORMAT
 }
 
 /* Requires that headers and response code are already set up */
@@ -3328,38 +3377,7 @@ evhttp_handle_request(struct evhttp_request *req, void *arg)
 		(*http->gencb)(req, http->gencbarg);
 		return;
 	} else {
-		/* We need to send a 404 here */
-#define ERR_FORMAT "<html><head>" \
-		    "<title>404 Not Found</title>" \
-		    "</head><body>" \
-		    "<h1>Not Found</h1>" \
-		    "<p>The requested URL %s was not found on this server.</p>"\
-		    "</body></html>\n"
-
-		char *escaped_html;
-		struct evbuffer *buf;
-
-		if ((escaped_html = evhttp_htmlescape(req->uri)) == NULL) {
-			evhttp_connection_free(req->evcon);
-			return;
-		}
-
-		if ((buf = evbuffer_new()) == NULL) {
-			mm_free(escaped_html);
-			evhttp_connection_free(req->evcon);
-			return;
-		}
-
-		evhttp_response_code_(req, HTTP_NOTFOUND, "Not Found");
-
-		evbuffer_add_printf(buf, ERR_FORMAT, escaped_html);
-
-		mm_free(escaped_html);
-
-		evhttp_send_page_(req, buf);
-
-		evbuffer_free(buf);
-#undef ERR_FORMAT
+		evhttp_send_notfound(req, NULL);
 	}
 }
 
@@ -3783,6 +3801,15 @@ evhttp_set_bevcb(struct evhttp *http,
 {
 	http->bevcb = cb;
 	http->bevcbarg = cbarg;
+}
+
+void
+evhttp_set_errorcb(struct evhttp *http,
+    int (*cb)(struct evhttp_request *, struct evbuffer *, int, const char *, void *),
+    void *cbarg)
+{
+	http->errorcb    = cb;
+	http->errorcbarg = cbarg;
 }
 
 /*

--- a/http.c
+++ b/http.c
@@ -2687,50 +2687,12 @@ evhttp_send_error(struct evhttp_request *req, int error, const char *reason)
 		evbuffer_add_printf(buf, ERR_FORMAT,
 		   error, heading, error, heading,
 		   (reason != NULL ? reason : ""));
-        }
+	}
 
 	evhttp_send_page_(req, buf);
 
 	evbuffer_free(buf);
 #undef ERR_FORMAT
-}
-
-/*
- * Returns an error page.
- */
-
-void
-evhttp_send_notfound(struct evhttp_request *req, const char *url)
-{
-#define REASON_FORMAT "<p>The requested URL %s was not found on this server.</p>"
-	char   *escaped_url = NULL;
-	char   *reason = NULL;
-	size_t  reason_len;
-
-	url = (url != NULL ? url : req->uri);
-	if (url != NULL) {
-		escaped_url = evhttp_htmlescape(url);
-	}
-
-	if (escaped_url != NULL) {
-		reason_len = strlen(REASON_FORMAT)+strlen(escaped_url)+1;
-		reason = mm_malloc(reason_len);
-	}
-
-	if ((escaped_url != NULL) && (reason != NULL)) {
-		evutil_snprintf(reason, reason_len,
-		    REASON_FORMAT, escaped_url);
-	}
-
-	evhttp_send_error(req, HTTP_NOTFOUND, reason);
-
-	if (reason != NULL) {
-		mm_free(reason);
-	}
-	if (escaped_url != NULL) {
-		mm_free(escaped_url);
-	}
-#undef REASON_FORMAT
 }
 
 /* Requires that headers and response code are already set up */
@@ -3376,9 +3338,8 @@ evhttp_handle_request(struct evhttp_request *req, void *arg)
 	if (http->gencb) {
 		(*http->gencb)(req, http->gencbarg);
 		return;
-	} else {
-		evhttp_send_notfound(req, NULL);
-	}
+	} else
+		evhttp_send_error(req, HTTP_NOTFOUND, NULL);
 }
 
 /* Listener callback when a connection arrives at a server. */

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -298,7 +298,7 @@ void evhttp_set_bevcb(struct evhttp *http,
     struct bufferevent *(*cb)(struct event_base *, void *), void *arg);
 
 /**
-   Set a callback to output the text for any error pages sent for requests of
+   Set a callback to output the HTML for any error pages sent for requests of
    a given evhttp object.
 
    You can use this to override the default error pages sent, allowing such
@@ -413,16 +413,6 @@ void evhttp_set_timeout_tv(struct evhttp *http, const struct timeval* tv);
 EVENT2_EXPORT_SYMBOL
 void evhttp_send_error(struct evhttp_request *req, int error,
     const char *reason);
-
-/**
- * Send an HTTP_NOTFOUND error message to the client.
- *
- * @param req a request object
- * @param url the url to display in the error message. If this is NULL, the 
- *    request's URL will be used.
- */
-EVENT2_EXPORT_SYMBOL
-void evhttp_send_notfound(struct evhttp_request *req, const char *url);
 
 /**
  * Send an HTML reply to the client.

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -298,6 +298,33 @@ void evhttp_set_bevcb(struct evhttp *http,
     struct bufferevent *(*cb)(struct event_base *, void *), void *arg);
 
 /**
+   Set a callback to output the text for any error pages sent for requests of
+   a given evhttp object.
+
+   You can use this to override the default error pages sent, allowing such
+   things as multi-lingual support or customization to match other pages.
+
+   The callback should use the supplied buffer to output the text for an
+   error page. If the callback returns a negative value or doesn't output 
+   anything to the buffer, the default error page will be sent instead. The
+   buffer will be automatically be sent when the callback returns, so the
+   callback shouldn't do so itself.
+
+   Microsoft Internet Explorer may display its own error pages if ones sent by
+   an HTTP server are smaller than certain sizes, depending on the status code.
+   To reliably suppress this feature an error page should be at least 512
+   bytes in size.
+
+   @param http the evhttp server object for which to set the callback
+   @param cb the callback to invoke to format error pages
+   @param arg an context argument for the callback
+ */
+EVENT2_EXPORT_SYMBOL
+void evhttp_set_errorcb(struct evhttp *http,
+    int (*cb)(struct evhttp_request *req, struct evbuffer *buffer, int error, const char *reason, void *cbarg),
+    void *cbarg);
+
+/**
    Adds a virtual host to the http server.
 
    A virtual host is a newly initialized evhttp object that has request
@@ -386,6 +413,16 @@ void evhttp_set_timeout_tv(struct evhttp *http, const struct timeval* tv);
 EVENT2_EXPORT_SYMBOL
 void evhttp_send_error(struct evhttp_request *req, int error,
     const char *reason);
+
+/**
+ * Send an HTTP_NOTFOUND error message to the client.
+ *
+ * @param req a request object
+ * @param url the url to display in the error message. If this is NULL, the 
+ *    request's URL will be used.
+ */
+EVENT2_EXPORT_SYMBOL
+void evhttp_send_notfound(struct evhttp_request *req, const char *url);
 
 /**
  * Send an HTML reply to the client.

--- a/sample/http-server.c
+++ b/sample/http-server.c
@@ -306,7 +306,7 @@ send_document_cb(struct evhttp_request *req, void *arg)
 	evhttp_send_reply(req, 200, "OK", evb);
 	goto done;
 err:
-	evhttp_send_notfound(req, NULL);
+	evhttp_send_error(req, HTTP_NOTFOUND, NULL);
 	if (fd>=0)
 		close(fd);
 done:

--- a/sample/http-server.c
+++ b/sample/http-server.c
@@ -306,7 +306,7 @@ send_document_cb(struct evhttp_request *req, void *arg)
 	evhttp_send_reply(req, 200, "OK", evb);
 	goto done;
 err:
-	evhttp_send_error(req, 404, "Document was not found");
+	evhttp_send_notfound(req, NULL);
 	if (fd>=0)
 		close(fd);
 done:

--- a/test/regress_http.c
+++ b/test/regress_http.c
@@ -4224,6 +4224,189 @@ http_request_own_test(void *arg)
 	test_ok = 1;
 }
 
+/*
+ * Error callback tests
+ */
+
+#define ARRAY_SIZE(x) (sizeof(x)/sizeof((x)[0]))
+
+#define ERRCBFLAG_GENCB  (0x01)
+#define ERRCBFLAG_ERRCB  (0x02)
+#define ERRCBFLAG_BOTHCB (ERRCBFLAG_GENCB | ERRCBFLAG_ERRCB)
+
+struct error_callback_test {
+	unsigned char flags;
+	enum evhttp_cmd_type type;
+	int response_code;
+	int length;
+} error_callback_tests[] = {
+	{0,		   EVHTTP_REQ_GET,  HTTP_NOTFOUND,	  89}, /* 0 */
+	{0,		   EVHTTP_REQ_POST, HTTP_NOTIMPLEMENTED, 101}, /* 1 */
+	{ERRCBFLAG_GENCB,  EVHTTP_REQ_GET,  HTTP_NOTFOUND,	  89}, /* 2 */
+	{ERRCBFLAG_GENCB,  EVHTTP_REQ_POST, HTTP_NOTIMPLEMENTED, 101}, /* 3 */
+	{ERRCBFLAG_ERRCB,  EVHTTP_REQ_GET,  HTTP_NOTFOUND,	   3}, /* 4 */
+	{ERRCBFLAG_ERRCB,  EVHTTP_REQ_POST, HTTP_NOTIMPLEMENTED, 101}, /* 5 */
+	{ERRCBFLAG_BOTHCB, EVHTTP_REQ_GET,  HTTP_NOTFOUND,	   3}, /* 6 */
+	{ERRCBFLAG_BOTHCB, EVHTTP_REQ_POST, HTTP_NOTIMPLEMENTED,   3}, /* 7 */
+	{ERRCBFLAG_ERRCB,  EVHTTP_REQ_GET,  HTTP_NOTFOUND,	  89}, /* 8 */
+	{ERRCBFLAG_ERRCB,  EVHTTP_REQ_GET,  HTTP_NOTFOUND,	  89}, /* 9 */
+};
+
+struct error_callback_state
+{
+	struct basic_test_data *data;
+	int test_index;
+	struct error_callback_test *test;
+	int test_failed;
+};
+
+static void
+http_error_callback_gencb(struct evhttp_request *req, void *arg)
+{
+	struct error_callback_state *state_info = arg;
+
+	switch (state_info->test_index) {
+	case 2:
+	case 6:
+		evhttp_send_error(req, HTTP_NOTFOUND, NULL);
+		break;
+	default:
+		evhttp_send_error(req, HTTP_INTERNAL, NULL);
+		break;
+	}
+}
+
+static int
+http_error_callback_errorcb(struct evhttp_request *req, struct evbuffer *buf,
+    int error, const char *reason, void *arg)
+{
+	struct error_callback_state *state_info = arg;
+	int return_code = -1;
+
+	switch (state_info->test_index) {
+	case 4:
+	case 6:
+	case 7:
+		evbuffer_add_printf(buf, "%d", error);
+		return_code = 0;
+		break;
+	case 8: /* Add nothing to buffer and then return 0 to trigger default */
+		return_code = 0;
+		break;
+	case 9: /* Add text to buffer but then return -1 to trigger default */
+		evbuffer_add_printf(buf, "%d", error);
+		return_code = -1;
+		break;
+	default:
+		/* Do nothing */
+		break;
+	}
+
+	return return_code;
+}
+
+static void
+http_error_callback_test_done(struct evhttp_request *req, void *arg)
+{
+	struct evkeyvalq *headers;
+	const char *header_text;
+	struct error_callback_state *state_info = arg;
+	struct error_callback_test *test_info;
+
+	test_info = state_info->test;
+	
+	tt_assert(req);
+	tt_int_op(evhttp_request_get_command(req), ==,
+	    test_info->type);
+	tt_int_op(evhttp_request_get_response_code(req), ==,
+	    test_info->response_code);
+
+	headers = evhttp_request_get_input_headers(req);
+	tt_assert(headers);
+	header_text  = evhttp_find_header(headers, "Content-Type");
+	tt_assert_msg(header_text, "Missing Content-Type");
+	tt_str_op(header_text, ==, "text/html");
+	tt_int_op(evbuffer_get_length(evhttp_request_get_input_buffer(req)),
+	    ==, test_info->length);
+
+	event_base_loopexit(state_info->data->base, NULL);
+	return;
+
+end:
+	state_info->test_failed = 1;
+	event_base_loopexit(state_info->data->base, NULL);
+}
+
+static void
+http_error_callback_test(void *arg)
+{
+	struct basic_test_data *data = arg;
+	ev_uint16_t port = 0;
+	struct evhttp_connection *evcon = NULL;
+	struct evhttp_request *req = NULL;
+	char long_str[8192];
+	struct error_callback_state state_info;
+
+	test_ok = 0;
+
+	http = http_setup(&port, data->base, 0);
+	evhttp_set_allowed_methods(http,
+	    EVHTTP_REQ_GET |
+	    EVHTTP_REQ_HEAD |
+	    EVHTTP_REQ_PUT |
+	    EVHTTP_REQ_DELETE);
+
+	evcon = evhttp_connection_base_new(data->base, NULL, "127.0.0.1", port);
+	tt_assert(evcon);
+
+	/* also bind to local host */
+	evhttp_connection_set_local_address(evcon, "127.0.0.1");
+
+	/* Initialise the state info */
+	state_info.data 	= data;
+	state_info.test		= error_callback_tests;
+	state_info.test_failed	= 0;
+
+	/* Perform all the tests */
+	for (state_info.test_index = 0;
+	     (state_info.test_index < ARRAY_SIZE(error_callback_tests)) &&
+		 (!state_info.test_failed);
+	     state_info.test_index++)
+	{
+		evhttp_set_gencb(http,
+		    ((state_info.test->flags & ERRCBFLAG_GENCB) != 0 ?
+			http_error_callback_gencb : NULL),
+		    &state_info);
+		evhttp_set_errorcb(http,
+		    ((state_info.test->flags & ERRCBFLAG_ERRCB) != 0 ?
+			http_error_callback_errorcb : NULL),
+		    &state_info);
+
+		req = evhttp_request_new(http_error_callback_test_done,
+		    &state_info);
+		tt_assert(req);
+		if (evhttp_make_request(evcon, req, state_info.test->type,
+			"/missing") == -1) {
+			tt_abort_msg("Couldn't make request");
+			exit(1);
+		}
+		event_base_dispatch(data->base);
+
+		if (!state_info.test_failed)
+			test_ok++;
+		else
+			tt_abort_printf(("Sub-test %d failed",
+			    state_info.test_index));
+		state_info.test++;
+	}
+
+end:
+	if (evcon)
+		evhttp_connection_free(evcon);
+	if (http)
+		evhttp_free(http);
+}
+
 #define HTTP_LEGACY(name)						\
 	{ #name, run_legacy_test_fn, TT_ISOLATED|TT_LEGACY, &legacy_setup, \
 		    http_##name##_test }
@@ -4314,6 +4497,7 @@ struct testcase_t http_testcases[] = {
 
 	HTTP(write_during_read),
 	HTTP(request_own),
+	HTTP(error_callback),
 
 #ifdef EVENT__HAVE_OPENSSL
 	HTTPS(basic),


### PR DESCRIPTION
# General

The existing error pages are very basic and don't allow for multi-lingual support or for conformity with other pages in a web site. The aim of the callback functionality is to allow custom error pages to be supported for calls to 'evhttp_send_error()' by both calling applications and Libevent itself.

Backward-compatibility has be been retained as much as possible. If backward compatibility wasn't retained, it would be possible to both simplify and increase flexibility of the functions. If the HTTP_NOTFOUND error wasn't treated as a special case then a new function added in this change is redundant and it would still be possible to use the callback functionality to display an error page with the URL if so desired.
# 'evhttp_send_error()' in http.c

A backward-incompatible change has been made to the title of error pages sent by this function. The original version of the function used the reason argument as part of the title. That might have unforeseen side-effects if it contains HTML tags. Therefore the title has been changed to always use the standard status text.

To save each call to the function escaping the reason argument it was initially changed to be HTML escaped. This change has been reverted to continue to allow HTML tags to be used within the reason argument.

The function could be expanded to take a 'printf(()'-style format string and variable arguments, to save building the reason argument before every call to the function, but this would break backward compatibility.
# 'evhttp_send_notfound()' in http.c

The error page for HTTP_NOTFOUND is the only error page that displays a reason as standard. Taking the 'http-server' sample as an example, it is also a common requirement to deal with missing files. Rather than have different versions of the HTTP_NOTFOUND error page displayed by calling applications and Libevent, this function was added to standardize and simplify sending such an error page.

If no URL is specified, the request's URL is used. This includes any GET parameters, to retain backward compatibility.
# Microsoft Internet Explorer

The existing error pages are not reliably displayed by Internet Explorer because they are smaller than the threshold that triggers the 'Show friendly HTTP error messages' feature, part of IE since at least version 5. Padding the error messages to exceed 512 bytes would reliably suppress this feature. To retain backward compatibility, the error pages have not been padded but it might be desirable to add this to 'evhttp_send_error()' so that callbacks don't have to do so themselves. One solution would be to append an HTML comment that explains why the padding is there. Another is simply to pad with spaces. The latter would allow for precise control of how many bytes are sent but might be confusing to anyone viewing the source of an error page.
# 'http-server' Sample

An example of the error callback can be found in this [version](https://github.com/libevent/libevent/files/123607/http-server.zip) of the 'http-server' sample. It will output error pages with very bright backgrounds, the error code using a very large font size and the reason.
