### PR TITLE
Fix compile problems for win32

### DIFF
--- a/test/regress_ssl.c
+++ b/test/regress_ssl.c
@@ -56,7 +56,14 @@
 #include <openssl/pem.h>
 
 #include <string.h>
+#ifdef _WIN32
+#include <io.h>
+#define read _read
+#define write _write
+#define ssize_t long
+#else
 #include <unistd.h>
+#endif
 
 /* A short pre-generated key, to save the cost of doing an RSA key generation
  * step during the unit tests.  It's only 512 bits long, and it is published


### PR DESCRIPTION
Windows doesn't have unistd.h, but have the required
functionality in io.h
