### PR TITLE
21 http extended method

### DIFF
--- a/http-internal.h
+++ b/http-internal.h
@@ -118,7 +118,7 @@ struct evhttp_cb {
 
 	char *what;
 
-	void (*cb)(struct evhttp_request *req, void *);
+	evhttp_cb *cb;
 	void *cbarg;
 };
 

--- a/http-internal.h
+++ b/http-internal.h
@@ -32,7 +32,7 @@ struct addrinfo;
 struct evhttp_request;
 
 /* Indicates an unknown request method. */
-#define EVHTTP_REQ_UNKNOWN_ (1<<15)
+#define EVHTTP_REQ_UNKNOWN_ (1<<31)
 
 enum evhttp_connection_state {
 	EVCON_DISCONNECTED,	/**< not currently connected not trying either*/
@@ -166,7 +166,7 @@ struct evhttp {
 
 	/* Bitmask of all HTTP methods that we accept and pass to user
 	 * callbacks. */
-	ev_uint16_t allowed_methods;
+	ev_uint32_t allowed_methods;
 
 	/* Fallback callback if all the other callbacks for this connection
 	   don't match. */

--- a/http-internal.h
+++ b/http-internal.h
@@ -108,6 +108,8 @@ struct evhttp_connection {
 	struct event_base *base;
 	struct evdns_base *dns_base;
 	int ai_family;
+
+	evhttp_ext_method_cb *ext_method_cmp;
 };
 
 /* A callback for an http server */
@@ -178,6 +180,8 @@ struct evhttp {
 	void *newreqcbarg;
 
 	struct event_base *base;
+
+	evhttp_ext_method_cb *ext_method_cmp;
 };
 
 /* XXX most of these functions could be static. */

--- a/http.c
+++ b/http.c
@@ -4101,7 +4101,7 @@ evhttp_set_ext_method_cmp(struct evhttp *http,
 
 int
 evhttp_set_cb(struct evhttp *http, const char *uri,
-    void (*cb)(struct evhttp_request *, void *), void *cbarg)
+    evhttp_cb *cb, void *cbarg)
 {
 	struct evhttp_cb *http_cb;
 

--- a/http.c
+++ b/http.c
@@ -4036,7 +4036,7 @@ evhttp_set_default_content_type(struct evhttp *http,
 }
 
 void
-evhttp_set_allowed_methods(struct evhttp* http, ev_uint16_t methods)
+evhttp_set_allowed_methods(struct evhttp* http, ev_uint32_t methods)
 {
 	http->allowed_methods = methods;
 }

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -270,6 +270,7 @@ EVENT2_EXPORT_SYMBOL
 void evhttp_set_ext_method_cmp(struct evhttp *http,
 	evhttp_ext_method_cb *cmp);
 
+typedef void evhttp_cb(struct evhttp_request *, void *);
 /**
    Set a callback for a specified URI
 
@@ -281,7 +282,7 @@ void evhttp_set_ext_method_cmp(struct evhttp *http,
 */
 EVENT2_EXPORT_SYMBOL
 int evhttp_set_cb(struct evhttp *http, const char *path,
-    void (*cb)(struct evhttp_request *, void *), void *cb_arg);
+    evhttp_cb *cb, void *cb_arg);
 
 /** Removes the callback for a specified URI */
 EVENT2_EXPORT_SYMBOL

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -246,7 +246,7 @@ void evhttp_set_default_content_type(struct evhttp *http,
   @param methods bit mask constructed from evhttp_cmd_type values
 */
 EVENT2_EXPORT_SYMBOL
-void evhttp_set_allowed_methods(struct evhttp* http, ev_uint16_t methods);
+void evhttp_set_allowed_methods(struct evhttp* http, ev_uint32_t methods);
 
 /**
    Set a callback for a specified URI

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -73,6 +73,7 @@ struct evkeyvalq;
 struct evhttp_bound_socket;
 struct evconnlistener;
 struct evdns_base;
+struct evhttp_ext_method;
 
 /**
  * Create a new HTTP server.
@@ -247,6 +248,27 @@ void evhttp_set_default_content_type(struct evhttp *http,
 */
 EVENT2_EXPORT_SYMBOL
 void evhttp_set_allowed_methods(struct evhttp* http, ev_uint32_t methods);
+
+typedef int evhttp_ext_method_cb(struct evhttp_ext_method *);
+/**
+  Sets the callback function which allows HTTP extended methods
+  to be supported by this server.
+
+  The callback should :
+   - if method field is NULL : set method field according to type field
+   - else : set type and flags fields according to method string
+   - return 0 for success (known method / type)
+   - return -1 for error (unknown method / type)
+
+  evhttp_set_allowed_methods still needs to be called.
+
+  @param http the http server on which to add support to the methods
+  @param cmp the extended method callback
+  @see evhttp_ext_method
+*/
+EVENT2_EXPORT_SYMBOL
+void evhttp_set_ext_method_cmp(struct evhttp *http,
+	evhttp_ext_method_cb *cmp);
 
 /**
    Set a callback for a specified URI
@@ -552,6 +574,24 @@ enum evhttp_cmd_type {
 	EVHTTP_REQ_MOVE    = 1 << 15,
 };
 
+#define EVHTTP_REQ_MAX EVHTTP_REQ_MOVE
+
+/** structure to allow users to define their own HTTP methods
+ * @see evhttp_set_ext_method_cmp
+ * @see evhttp_connection_set_ext_method_cmp */
+
+/**
+ * @brief stucture that is passed to (and modified by) the
+ * extended method callback function
+ */
+struct evhttp_ext_method {
+	const char *method;
+	ev_uint32_t type;	/* @see enum evhttp_cmd_type */
+	ev_uint16_t flags;	/* Available flag : EVHTTP_METHOD_HAS_BODY */
+};
+
+#define EVHTTP_METHOD_HAS_BODY 0x0001
+
 /** a request object can represent either a request or a reply */
 enum evhttp_request_kind { EVHTTP_REQUEST, EVHTTP_RESPONSE };
 
@@ -741,6 +781,15 @@ void evhttp_request_own(struct evhttp_request *req);
 /** Returns 1 if the request is owned by the user */
 EVENT2_EXPORT_SYMBOL
 int evhttp_request_is_owned(struct evhttp_request *req);
+
+/**
+ * Sets extended method cmp callback for this http connection.
+ *
+ * @see evhttp_set_ext_method_cmp
+ */
+EVENT2_EXPORT_SYMBOL
+void evhttp_connection_set_ext_method_cmp(struct evhttp_connection *evcon,
+	evhttp_ext_method_cb *cmp);
 
 /**
  * Returns the connection object associated with the request or NULL

--- a/whatsnew-2.2.txt
+++ b/whatsnew-2.2.txt
@@ -1,5 +1,37 @@
 ...
 
+* Support for custom HTTP methods
+
+The Libevent HTTP code now supports defining custom HTTP methods.
+It is done through a callback :
+/* defines an extended HTTP method "CUSTOM"
+ * without body */
+#define EVHTTP_REQ_CUSTOM      ((EVHTTP_REQ_MAX) << 1)
+
+static int ext_method_cb(struct evhttp_ext_method *p)
+{
+       if (p == NULL)
+               return -1;
+       if (p->method) {
+               if(strcmp(p->method, "CUSTOM") == 0) {
+                       p->type = EVHTTP_REQ_CUSTOM;
+                       p->flags = 0;   /*EVHTTP_METHOD_HAS_BODY*/
+                       return 0;
+               }
+       } else {
+               if(p->type == EVHTTP_REQ_CUSTOM) {
+                       p->method = "CUSTOM";
+                       return 0;
+               }
+       }
+       return -1;
+}
+
+evhttp_set_ext_method_cmp(myhttp, ext_method_cb);
+and / or
+evhttp_connection_set_ext_method_cmp(evcon, ext_method_cb);
+
+
 * Building libevent as a sub-project using GNU Auto* tools
 
 Some projects will choose to include libevent in their source distribution,


### PR DESCRIPTION
better have this in a PR for discussing.

1) Tests are missing.

2) I'm still not convinced by the wording.
Why not call the function "ext_methods_cb" or "ext_methods_func"
That's not a compare only callback.
