### PR TITLE
Fix bufferevent_pair to properly set BEV_EVENT_{READING,WRITING}

### DIFF
--- a/bufferevent_pair.c
+++ b/bufferevent_pair.c
@@ -325,7 +325,12 @@ be_pair_flush(struct bufferevent *bev, short iotype,
 		be_pair_transfer(bev, partner, 1);
 
 	if (mode == BEV_FINISHED) {
-		bufferevent_run_eventcb_(partner, iotype|BEV_EVENT_EOF, 0);
+		short what = BEV_EVENT_EOF;
+		if (iotype & EV_READ)
+			what |= BEV_EVENT_WRITING;
+		if (iotype & EV_WRITE)
+			what |= BEV_EVENT_READING;
+		bufferevent_run_eventcb_(partner, what, 0);
 	}
 	decref_and_unlock(bev);
 	return 0;


### PR DESCRIPTION
Here's some fun. From `bufferevent.h`:

```
#define BEV_EVENT_READING	0x01	/**< error encountered while reading */
#define BEV_EVENT_WRITING	0x02	/**< error encountered while writing */
```

And from `event.h`:

```
/** Wait for a socket or FD to become readable */
#define EV_READ		0x02
/** Wait for a socket or FD to become writeable */
#define EV_WRITE	0x04
```

Library users have to be very careful to get this right; it turns out, the library itself got this wrong in the `bufferevent_pair` code. It appears that in most of the code, only `BEV_EVENT_FINISHED` will indicate whether it's read or write; on error or timeout, it appears that "both" is assumed and not set in the callback. I read through all the other places where `BEV_EVENT_FINISHED` is passed to an event callback; it appears that the pair code is the only spot that got it wrong.

I tried to match style on the test; open to moving it about.