### PR TITLE
Check for Mac OS X 10.4 kqueue bug properly

### DIFF
--- a/kqueue.c
+++ b/kqueue.c
@@ -154,7 +154,7 @@ kq_init(struct event_base *base)
 	if (kevent(kq,
 		kqueueop->changes, 1, kqueueop->events, NEVENT, NULL) != 1 ||
 	    (int)kqueueop->events[0].ident != -1 ||
-	    kqueueop->events[0].flags != EV_ERROR) {
+	    !(kqueueop->events[0].flags & EV_ERROR)) {
 		event_warn("%s: detected broken kqueue; not using.", __func__);
 		goto err;
 	}

--- a/kqueue.c
+++ b/kqueue.c
@@ -47,6 +47,10 @@
 #include <inttypes.h>
 #endif
 
+#if defined(__APPLE__)
+#include <AvailabilityMacros.h>
+#endif
+
 /* Some platforms apparently define the udata field of struct kevent as
  * intptr_t, whereas others define it as void*.  There doesn't seem to be an
  * easy way to tell them apart via autoconf, so we need to use OS macros. */
@@ -141,6 +145,7 @@ kq_init(struct event_base *base)
 		goto err;
 	kqueueop->events_size = kqueueop->changes_size = NEVENT;
 
+#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_5
 	/* Check for Mac OS X kqueue bug. */
 	memset(&kqueueop->changes[0], 0, sizeof kqueueop->changes[0]);
 	kqueueop->changes[0].ident = -1;
@@ -158,6 +163,7 @@ kq_init(struct event_base *base)
 		event_warn("%s: detected broken kqueue; not using.", __func__);
 		goto err;
 	}
+#endif
 
 	base->evsigsel = &kqsigops;
 


### PR DESCRIPTION
`EV_ERROR` is a bit in `struct kevent::flags`. Other bits may be set too.

When it's not possible to run on Mac OS X 10.4, it's not necessary to test for the `kqueue` bug. If `MAC_OS_X_VERSION_MIN_REQUIRED` is the minimum runtime OS version that's being targeted. If it's set higher than 10.4, then compiled code is not expected to run on 10.4.

Fixes #376.
