### PR TITLE
Fix evhttp_uriencode() regression.

### DIFF
--- a/http.c
+++ b/http.c
@@ -3079,7 +3079,7 @@ evhttp_uriencode(const char *uri, ev_ssize_t len, int space_as_plus)
 	}
 
 
-	if (len >= 0 && uri + len < uri) {
+	if (len >= 0) {
 		if (uri + len < uri) {
 			return (NULL);
 		}


### PR DESCRIPTION
http_uriencode_test() (in test/regress_http.c) has been failed after
72afe4c as "hello\0world" is encoded to "hello" instead of
"hello%00world". This is because of a misplaced overflow check which
causes the non-negative "size" specified in parameter being ignored in
within-bound URI.