### PR TITLE
add request failure verify

### DIFF
--- a/http.c
+++ b/http.c
@@ -4069,6 +4069,11 @@ evhttp_request_set_on_complete_cb(struct evhttp_request *req,
 	req->on_complete_cb_arg = cb_arg;
 }
 
+int
+evhttp_request_get_response(const struct evhttp_request *req) {
+	return (req->response_code==0?-1:0);
+}
+
 /*
  * Allows for inspection of the request URI
  */

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -811,6 +811,14 @@ void evhttp_cancel_request(struct evhttp_request *req);
  */
 struct evhttp_uri;
 
+/** 
+   When happening connect refuse,call this to see the request was failure or not in request callback.
+   Return -1,the request can retry(for example:push it back to queue) later on; 
+   Return 0,the request was sent and receive response,so we can do subsequent things.
+*/
+EVENT2_EXPORT_SYMBOL
+int evhttp_request_get_response(const struct evhttp_request *req);
+
 /** Returns the request URI */
 EVENT2_EXPORT_SYMBOL
 const char *evhttp_request_get_uri(const struct evhttp_request *req);


### PR DESCRIPTION
For example:

the peer can't connect or never listen port or others....

req=evhttp_request_new(&requset_post_cb,NULL);
...
evhttp_make_request();
....
void requset_post_cb(struct evhttp_request *req, void *arg)
{
     //To here,how to know the request was sent and response was received when connect refuse.
    //When connect refuse,the callback of evhttp_connection_set_closecb() can't be called,
    //So we don't know the request's state.
    //Of  course,we can read source code,but it cost much time.
}
