### PR TITLE
Don't call BIO_number_{read|written} on NULL BIOs.

### DIFF
--- a/bufferevent_openssl.c
+++ b/bufferevent_openssl.c
@@ -542,10 +542,10 @@ conn_closed(struct bufferevent_openssl *bev_ssl, int when, int errcode, int ret)
 static void
 init_bio_counts(struct bufferevent_openssl *bev_ssl)
 {
-	bev_ssl->counts.n_written =
-	    BIO_number_written(SSL_get_wbio(bev_ssl->ssl));
-	bev_ssl->counts.n_read =
-	    BIO_number_read(SSL_get_rbio(bev_ssl->ssl));
+	BIO *wbio = SSL_get_wbio(bev_ssl->ssl);
+	bev_ssl->counts.n_written = wbio ? BIO_number_written(wbio) : 0;
+	BIO *rbio = SSL_get_rbio(bev_ssl->ssl);
+	bev_ssl->counts.n_read = rbio ? BIO_number_read(rbio) : 0;
 }
 
 static inline void


### PR DESCRIPTION
OpenSSL doesn't document the behaviour of these functions when given a
NULL BIO, and it happens to return zero at the moment. But don't depend
on that.