### PR TITLE
C90 doesn't like declarations intermingled with statements

### DIFF
--- a/bufferevent_openssl.c
+++ b/bufferevent_openssl.c
@@ -540,9 +540,11 @@ conn_closed(struct bufferevent_openssl *bev_ssl, int when, int errcode, int ret)
 static void
 init_bio_counts(struct bufferevent_openssl *bev_ssl)
 {
-	BIO *wbio = SSL_get_wbio(bev_ssl->ssl);
+	BIO *rbio, *wbio;
+
+	wbio = SSL_get_wbio(bev_ssl->ssl);
 	bev_ssl->counts.n_written = wbio ? BIO_number_written(wbio) : 0;
-	BIO *rbio = SSL_get_rbio(bev_ssl->ssl);
+	rbio = SSL_get_rbio(bev_ssl->ssl);
 	bev_ssl->counts.n_read = rbio ? BIO_number_read(rbio) : 0;
 }
 


### PR DESCRIPTION
So move all of the declarations to the top of the offending function.

When you configure with `--enable-gcc-warnings` you get:

```
bufferevent_openssl.c: In function ‘init_bio_counts’:
bufferevent_openssl.c:545:2: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
  BIO *rbio = SSL_get_rbio(bev_ssl->ssl);
  ^~~
cc1: all warnings being treated as errors
```