### PR TITLE
Add support for binding the source address on a socket-based bufferevent

### DIFF
--- a/bufferevent_async.c
+++ b/bufferevent_async.c
@@ -628,7 +628,7 @@ bufferevent_async_connect_(struct bufferevent *bev, evutil_socket_t fd,
 		/* Well, the user will have to bind() */
 		return -1;
 	}
-	if (bind(fd, (struct sockaddr *)&ss, sizeof(ss)) < 0 &&
+	if (evutil_socket_bind(fd, (const struct sockaddr *)&ss, sizeof(ss)) &&
 	    WSAGetLastError() != WSAEINVAL)
 		return -1;
 

--- a/bufferevent_sock.c
+++ b/bufferevent_sock.c
@@ -498,6 +498,37 @@ bufferevent_connect_getaddrinfo_cb(int result, struct evutil_addrinfo *ai,
 }
 
 int
+bufferevent_socket_bind(struct bufferevent *bev,
+    const struct sockaddr *addr, int socklen)
+{
+	struct bufferevent_private *bufev_p =
+	    EVUTIL_UPCAST(bev, struct bufferevent_private, bev);
+
+	evutil_socket_t fd;
+	int r = 0;
+	int result = -1;
+
+	bufferevent_incref_and_lock_(bev);
+
+	if (!bufev_p || !addr)
+		goto done;
+
+	fd = bufferevent_getfd(bev);
+	if (fd < 0)
+		goto done;
+
+	r = evutil_socket_bind(fd, addr, socklen);
+	if (r < 0)
+		goto done;
+
+	result = 0;
+
+done:
+	bufferevent_decref_and_unlock_(bev);
+	return result;
+}
+
+int
 bufferevent_socket_connect_hostname(struct bufferevent *bev,
     struct evdns_base *evdns_base, int family, const char *hostname, int port)
 {

--- a/evdns.c
+++ b/evdns.c
@@ -2516,7 +2516,7 @@ evdns_nameserver_add_impl_(struct evdns_base *base, const struct sockaddr *addre
 
 	if (base->global_outgoing_addrlen &&
 	    !evutil_sockaddr_is_loopback_(address)) {
-		if (bind(ns->socket,
+		if (evutil_socket_bind(ns->socket,
 			(struct sockaddr*)&base->global_outgoing_address,
 			base->global_outgoing_addrlen) < 0) {
 			log(EVDNS_LOG_WARN,"Couldn't bind to outgoing address");

--- a/evutil.c
+++ b/evutil.c
@@ -249,7 +249,7 @@ evutil_ersatz_socketpair_(int family, int type, int protocol,
 	listen_addr.sin_family = AF_INET;
 	listen_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 	listen_addr.sin_port = 0;	/* kernel chooses port.	 */
-	if (bind(listener, (struct sockaddr *) &listen_addr, sizeof (listen_addr))
+	if (evutil_socket_bind(listener, (const struct sockaddr *) &listen_addr, sizeof(listen_addr))
 		== -1)
 		goto tidy_up_and_fail;
 	if (listen(listener, 1) == -1)
@@ -369,6 +369,13 @@ evutil_make_listen_socket_reuseable(evutil_socket_t sock)
 #else
 	return 0;
 #endif
+}
+
+int
+evutil_socket_bind(evutil_socket_t sock, const struct sockaddr *sa,
+    int socklen)
+{
+	return bind(sock, sa, socklen);
 }
 
 int

--- a/http.c
+++ b/http.c
@@ -4351,7 +4351,7 @@ bind_socket_ai(struct evutil_addrinfo *ai, int reuse)
 	}
 
 	if (ai != NULL) {
-		r = bind(fd, ai->ai_addr, (ev_socklen_t)ai->ai_addrlen);
+		r = evutil_socket_bind(fd, ai->ai_addr, (ev_socklen_t)ai->ai_addrlen);
 		if (r == -1)
 			goto out;
 	}

--- a/include/event2/bufferevent.h
+++ b/include/event2/bufferevent.h
@@ -211,6 +211,18 @@ struct bufferevent *bufferevent_socket_new(struct event_base *base, evutil_socke
 EVENT2_EXPORT_SYMBOL
 int bufferevent_socket_connect(struct bufferevent *, const struct sockaddr *, int);
 
+/**
+   Bind a local address to a socket-based bufferevent.
+
+   @param bufev an existing bufferevent allocated with
+       bufferevent_socket_new().
+   @param addr the address we should connect to
+   @param socklen the length of the address
+   @return 0 on success, -1 on failure.
+ */
+EVENT2_EXPORT_SYMBOL
+int bufferevent_socket_bind(struct bufferevent *, const struct sockaddr *, int);
+
 struct evdns_base;
 /**
    Resolve the hostname 'hostname' and connect to it as with

--- a/include/event2/util.h
+++ b/include/event2/util.h
@@ -401,6 +401,17 @@ int evutil_make_socket_nonblocking(evutil_socket_t sock);
 EVENT2_EXPORT_SYMBOL
 int evutil_make_listen_socket_reuseable(evutil_socket_t sock);
 
+/** Do platform-specific operations to bind a socket to a local address.
+
+    @param sock The socket to make reusable
+    @param sa The sockaddr_in or sockaddr_in6 to bind to
+    @param socklen The length of the address sa points to
+    @return 0 on success, -1 on failure
+ */
+EVENT2_EXPORT_SYMBOL
+int evutil_socket_bind(evutil_socket_t sock, const struct sockaddr *sa,
+    int socklen);
+
 /** Do platform-specific operations to make a listener port reusable.
 
     Specifically, we want to make sure that multiple programs which also

--- a/listener.c
+++ b/listener.c
@@ -246,7 +246,7 @@ evconnlistener_new_bind(struct event_base *base, evconnlistener_cb cb,
 	}
 
 	if (sa) {
-		if (bind(fd, sa, socklen)<0)
+		if (evutil_socket_bind(fd, sa, socklen) < 0)
 			goto err;
 	}
 

--- a/sample/dns-example.c
+++ b/sample/dns-example.c
@@ -201,7 +201,7 @@ main(int c, char **v) {
 		my_addr.sin_family = AF_INET;
 		my_addr.sin_port = htons(10053);
 		my_addr.sin_addr.s_addr = INADDR_ANY;
-		if (bind(sock, (struct sockaddr*)&my_addr, sizeof(my_addr))<0) {
+		if (evutil_socket_bind(sock, (struct sockaddr*)&my_addr, sizeof(my_addr)) <0 ) {
 			perror("bind");
 			exit(1);
 		}

--- a/test/regress_dns.c
+++ b/test/regress_dns.c
@@ -394,7 +394,7 @@ dns_server(void)
 	my_addr.sin_family = AF_INET;
 	my_addr.sin_port = 0; /* kernel picks */
 	my_addr.sin_addr.s_addr = htonl(0x7f000001UL);
-	if (bind(sock, (struct sockaddr*)&my_addr, sizeof(my_addr)) < 0) {
+	if (evutil_socket_bind(sock, (struct sockaddr*)&my_addr, sizeof(my_addr)) < 0) {
 		tt_abort_perror("bind");
 	}
 	slen = sizeof(ss);
@@ -1997,7 +1997,7 @@ test_getaddrinfo_async_cancel_stress(void *ptr)
 		tt_abort_perror("socket");
 	}
 	evutil_make_socket_nonblocking(fd);
-	if (bind(fd, (struct sockaddr*)&sin, sizeof(sin))<0) {
+	if (evutil_socket_bind(fd, (struct sockaddr*)&sin, sizeof(sin)) < 0) {
 		tt_abort_perror("bind");
 	}
 	server = evdns_add_server_port_with_base(base, fd, 0, gaic_server_cb,

--- a/test/regress_testutils.c
+++ b/test/regress_testutils.c
@@ -111,7 +111,7 @@ regress_get_dnsserver(struct event_base *base,
 	my_addr.sin_family = AF_INET;
 	my_addr.sin_port = htons(*portnum);
 	my_addr.sin_addr.s_addr = htonl(0x7f000001UL);
-	if (bind(sock, (struct sockaddr*)&my_addr, sizeof(my_addr)) < 0) {
+	if (evutil_socket_bind(sock, (struct sockaddr*)&my_addr, sizeof(my_addr)) < 0) {
 		evutil_closesocket(sock);
 		tt_abort_perror("bind");
 	}


### PR DESCRIPTION
A couple of convenience functions so users don't have to grovel around
too much in the internals of a bufferevent, getting the associated
file descriptor from it, etc.