### PR TITLE
Restore SO_LINGER usage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -715,8 +715,7 @@ AC_CHECK_MEMBERS([struct in6_addr.s6_addr32, struct in6_addr.s6_addr16, struct s
 #endif
 ])
 
-AC_CHECK_TYPES([struct so_linger],
-[#define HAVE_SO_LINGER], ,
+AC_CHECK_TYPES([struct linger],,,
 [
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>

--- a/test/bench.c
+++ b/test/bench.c
@@ -136,7 +136,7 @@ run_once(void)
 int
 main(int argc, char **argv)
 {
-#ifdef HAVE_SETRLIMIT 
+#ifdef EVENT__HAVE_SETRLIMIT
 	struct rlimit rl;
 #endif
 	int i, c;
@@ -167,7 +167,7 @@ main(int argc, char **argv)
 		}
 	}
 
-#ifdef HAVE_SETRLIMIT
+#ifdef EVENT__HAVE_SETRLIMIT
 	rl.rlim_cur = rl.rlim_max = num_pipes * 2 + 50;
 	if (setrlimit(RLIMIT_NOFILE, &rl) == -1) {
 		perror("setrlimit");

--- a/test/bench_cascade.c
+++ b/test/bench_cascade.c
@@ -139,7 +139,7 @@ run_once(int num_pipes)
 int
 main(int argc, char **argv)
 {
-#ifdef HAVE_SETRLIMIT
+#ifdef EVENT__HAVE_SETRLIMIT
 	struct rlimit rl;
 #endif
 	int i, c;
@@ -162,7 +162,7 @@ main(int argc, char **argv)
 		}
 	}
 
-#ifdef HAVE_SETRLIMIT 
+#ifdef EVENT__HAVE_SETRLIMIT
 	rl.rlim_cur = rl.rlim_max = num_pipes * 2 + 50;
 	if (setrlimit(RLIMIT_NOFILE, &rl) == -1) {
 		perror("setrlimit");

--- a/test/bench_httpclient.c
+++ b/test/bench_httpclient.c
@@ -113,13 +113,13 @@ errorcb(struct bufferevent *b, short what, void *arg)
 static void
 frob_socket(evutil_socket_t sock)
 {
-#ifdef HAVE_SO_LINGER
+#ifdef EVENT__HAVE_STRUCT_LINGER
 	struct linger l;
 #endif
 	int one = 1;
 	if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void*)&one, sizeof(one))<0)
 		perror("setsockopt(SO_REUSEADDR)");
-#ifdef HAVE_SO_LINGER
+#ifdef EVENT__HAVE_STRUCT_LINGER
 	l.l_onoff = 1;
 	l.l_linger = 0;
 	if (setsockopt(sock, SOL_SOCKET, SO_LINGER, (void*)&l, sizeof(l))<0)


### PR DESCRIPTION
Accidentally disabled by 0dda56a48e94 due to confusion between `struct linger` vs. `SO_LINGER`  and `#define` vs. `AC_DEFINE`. Try adding synthetic `#error test` to confirm.