### PR TITLE
Unsilence test/regress if invoked via `make check`

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -99,10 +99,10 @@ run_tests () {
 	fi
 
 	test -x $TEST_DIR/regress || return
-	announce_n " regress: "
+	announce " regress: [multiple tests]"
 	if test "$TEST_OUTPUT_FILE" = "/dev/null" ;
 	then
-		$TEST_DIR/regress --quiet $REGRESS_ARGS
+		$TEST_DIR/regress $REGRESS_ARGS
 	else
 		$TEST_DIR/regress $REGRESS_ARGS >>"$TEST_OUTPUT_FILE"
 	fi
@@ -114,10 +114,10 @@ run_tests () {
 		FAILED=yes
 	fi
 
-	announce_n " regress_debug: "
+	announce " regress_debug: [multiple tests]"
 	if test "$TEST_OUTPUT_FILE" = "/dev/null" ;
 	then
-		EVENT_DEBUG_MODE=1 $TEST_DIR/regress --quiet $REGRESS_ARGS
+		EVENT_DEBUG_MODE=1 $TEST_DIR/regress $REGRESS_ARGS
 	else
 		EVENT_DEBUG_MODE=1 $TEST_DIR/regress $REGRESS_ARGS >>"$TEST_OUTPUT_FILE"
 	fi


### PR DESCRIPTION
`regress` runs multiple tests. If some produce warnings it becomes confusing given other tests have no qualms printing `OKAY`.

```
$ ./configure
$ gmake check
[...]
gmake[4]: Entering directory '/path/to/libevent-release-2.1.8-stable'
test/test.sh -b EPOLL
Running tests:
EPOLL
Skipping test
PASS: test_runner_epoll
test/test.sh -b SELECT
Running tests:
SELECT
 test-eof: OKAY
 test-closed: [warn] event_base_new_with_config: no event mechanism available
OKAY
 test-weof: OKAY
 test-time: OKAY
 test-changelist: OKAY
 test-fdleak: OKAY
 test-dumpevents: OKAY
 regress: [warn] Trying to disable lock functions after they have been set up will probaby not work.
[warn] Trying to disable lock functions after they have been set up will probaby not work.
[warn] Trying to disable lock functions after they have been set up will probaby not work.
[warn] Trying to disable lock functions after they have been set up will probaby not work.
[...]
```
