### PR TITLE
Improve sample https-client default SSL certificate path

### DIFF
--- a/sample/dns-example.c
+++ b/sample/dns-example.c
@@ -154,12 +154,12 @@ main(int c, char **v) {
 		const char *ns;
 	};
 	struct options o;
-	char opt;
+	int opt;
 	struct event_base *event_base = NULL;
 	struct evdns_base *evdns_base = NULL;
 
 	memset(&o, 0, sizeof(o));
-	
+
 	if (c < 2) {
 		fprintf(stderr, "syntax: %s [-x] [-v] [-c resolv.conf] [-s ns] hostname\n", v[0]);
 		fprintf(stderr, "syntax: %s [-T]\n", v[0]);


### PR DESCRIPTION
Also fix one minor compiler warning in dns-example.