### PR TITLE
Fix RPATH for APPLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 #       cmake -G "Visual Studio 10" ..
 #       start libevent.sln
 #
-if (WIN32)
+if (WIN32 OR APPLE)
     cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 else()
     cmake_minimum_required(VERSION 2.8.0 FATAL_ERROR)


### PR DESCRIPTION
By setting the CMake minimum version to 3.1 CMake automatically
adds the correct magic to make the library relocatable on
the filesystem (instead of burning the location of the library
at link time into the binary).

ex:
```
otool -L bin/http-connect
bin/http-connect:
	@rpath/libevent_extra.2.2.0.dylib (compatibility version 2.2.0, current version 0.0.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.8)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)
```