### PR TITLE
avoid linking all libevent_core with -lcrypto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -877,10 +877,6 @@ if (NOT EVENT__DISABLE_SAMPLES)
         time-test)
 
     if (NOT EVENT__DISABLE_OPENSSL AND OPENSSL_LIBRARIES)
-        set(CMAKE_REQUIRED_LIBRARIES ${OPENSSL_LIBRARIES})
-        CHECK_FUNCTION_EXISTS_EX(ERR_remove_thread_state EVENT__HAVE_ERR_REMOVE_THREAD_STATE)
-        set(CMAKE_REQUIRED_LIBRARIES "")
-
         # Special sample with more than one file.
         add_executable(https-client
             sample/https-client.c

--- a/configure.ac
+++ b/configure.ac
@@ -791,10 +791,6 @@ fi
 
 # check if we have and should use openssl
 AM_CONDITIONAL(OPENSSL, [test "$enable_openssl" != "no" && test "$have_openssl" = "yes"])
-if test "x$enable_openssl" = "xyes"; then
-	AC_SEARCH_LIBS([ERR_remove_thread_state], [crypto eay32],
-		[AC_DEFINE(HAVE_ERR_REMOVE_THREAD_STATE, 1, [Define to 1 if you have ERR_remove_thread_stat().])])
-fi
 
 # Add some more warnings which we use in development but not in the
 # released versions.  (Some relevant gcc versions can't handle these.)

--- a/event-config.h.cmake
+++ b/event-config.h.cmake
@@ -523,9 +523,6 @@
 
 #cmakedefine EVENT__NEED_DLLIMPORT
 
-/* Define to 1 if you have ERR_remove_thread_stat(). */
-#cmakedefine EVENT__HAVE_ERR_REMOVE_THREAD_STATE
-
 /* Define if waitpid() supports WNOWAIT */
 #cmakedefine EVENT__HAVE_WAITPID_WITH_WNOWAIT
 

--- a/sample/https-client.c
+++ b/sample/https-client.c
@@ -484,7 +484,12 @@ cleanup:
 	EVP_cleanup();
 	ERR_free_strings();
 
+#if OPENSSL_VERSION_NUMBER < 0x10000000L
+	ERR_remove_state(0);
+#else
 	ERR_remove_thread_state(NULL);
+#endif
+
 	CRYPTO_cleanup_all_ex_data();
 
 	sk_SSL_COMP_free(SSL_COMP_get_compression_methods());

--- a/sample/https-client.c
+++ b/sample/https-client.c
@@ -484,11 +484,7 @@ cleanup:
 	EVP_cleanup();
 	ERR_free_strings();
 
-#ifdef EVENT__HAVE_ERR_REMOVE_THREAD_STATE
 	ERR_remove_thread_state(NULL);
-#else
-	ERR_remove_state(0);
-#endif
 	CRYPTO_cleanup_all_ex_data();
 
 	sk_SSL_COMP_free(SSL_COMP_get_compression_methods());


### PR DESCRIPTION
This reverts commit c4e9d9bd662de7f575f2172c160795d452ebe709.

Calling `AC_SEARCH_LIBS()` modifies `LIBS`: `-lcrypto` incorrectly
ends up in `LIBS`, and thus linked to by `libevent_core.so` etc.

Checking for `ERR_remove_thread_state` should no longer be needed
because it was introduced in openssl 1.0.0, and the previous line
0.9.8 had support discontinued at the end of 2015.

https://wiki.openssl.org/index.php/Manual:ERR_remove_state(3)
https://www.openssl.org/blog/blog/2014/12/23/the-new-release-strategy/