### PR TITLE
http: Make it possible to pass in a pre-existing connection

### DIFF
--- a/http.c
+++ b/http.c
@@ -2576,6 +2576,7 @@ evhttp_connection_base_bufferevent_new(struct event_base *base, struct evdns_bas
 		 * can start sending requests on.
 		 */
 		evcon->state = EVCON_IDLE;
+		evcon->flags |= EVHTTP_CON_OUTGOING;
 	}
 
 	return (evcon);

--- a/http.c
+++ b/http.c
@@ -2570,6 +2570,14 @@ evhttp_connection_base_bufferevent_new(struct event_base *base, struct evdns_bas
 	evcon->dns_base = dnsbase;
 	evcon->ai_family = AF_UNSPEC;
 
+	if (bev != NULL && bufferevent_getfd(bev) != -1) {
+		/* We were passed a bev with file descriptor set.
+		 * Assume that this is an already-open connection that we
+		 * can start sending requests on.
+		 */
+		evcon->state = EVCON_IDLE;
+	}
+
 	return (evcon);
 
  error:

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -652,8 +652,10 @@ enum evhttp_request_kind { EVHTTP_REQUEST, EVHTTP_RESPONSE };
  * @param dnsbase the dns_base to use for resolving host names; if not
  *     specified host name resolution will block.
  * @param bev a bufferevent to use for connecting to the server; if NULL, a
- *     socket-based bufferevent will be created.  This buffrevent will be freed
- *     when the connection closes.  It must have no fd set on it.
+ *     socket-based bufferevent will be created.  This bufferevent will be freed
+ *     when the connection closes.  If a fd is already set on the bufferevent,
+ *     it will be assumed that this connection is already open and ready to
+ *     send requests.
  * @param address the address to which to connect
  * @param port the port to connect to
  * @return an evhttp_connection object that can be used for making requests or


### PR DESCRIPTION
This patch adds functionality to pass a pre-existing connection as a bufferevent to `evhttp_connection_base_bufferevent_new`. As far as I know, this was not possible before.

When the bufferevent has an existing fd, the evcon starts in state `EVCON_IDLE` so that requests can be made immediately.

I am using this in Bitcoin Core for doing HTTP requests over a UNIX socket (https://github.com/bitcoin/bitcoin/pull/9919).

It could also be useful in sandboxed environments such as CloudABI that cannot directly make connections but can pass around fds.