### PR TITLE
more readable way of adding the --disable-clock-gettime option for co…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -143,7 +143,6 @@ AC_SEARCH_LIBS([socket], [socket])
 AC_SEARCH_LIBS([inet_aton], [resolv])
 if test "x$enable_clock_gettime" = "xyes"; then
   AC_SEARCH_LIBS([clock_gettime], [rt])
-  AC_CHECK_FUNCS([clock_gettime])
 fi
 AC_SEARCH_LIBS([sendfile], [sendfile])
 
@@ -336,6 +335,10 @@ dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
 AC_C_INLINE
 AC_HEADER_TIME
+
+if test "x$enable_clock_gettime" = "xyes"; then
+  AC_CHECK_FUNC(clock_gettime)
+fi
 
 dnl Checks for library functions.
 AC_CHECK_FUNCS([ \


### PR DESCRIPTION
…nfigure

reference commit: adc402ba5f0e15f4c77505852507f33b50f37ab6

Adding option to ignore clock_gettime: --disable-clock-gettime

macOS 10.12 introduced  to libsystem. This means, built
on OS X 10.12 application would crash on earlier versions of OS X
because it will try to call clock_gettime. This options is useful to
make backwards compatible macOS apps.