### PR TITLE
Fix race condition when deleting a running event

### DIFF
--- a/event.c
+++ b/event.c
@@ -2233,7 +2233,7 @@ event_del_internal(struct event *ev)
 	 * user-supplied argument. */
 	base = ev->ev_base;
 #ifndef _EVENT_DISABLE_THREAD_SUPPORT
-	if (base->current_event == ev && !EVBASE_IN_THREAD(base)) {
+	while (base->current_event == ev && !EVBASE_IN_THREAD(base)) {
 		++base->current_event_waiters;
 		EVTHREAD_COND_WAIT(base->current_event_cond, base->th_base_lock);
 	}


### PR DESCRIPTION
When deleting a running event from a foreign event base, we wait on
a condition variable. In a rare case, the foreign event base may
notify us, then enters another events dispatching, and fires the
event again. However, when we are awake, we don't check if the
event is fired again, and leave the event running, and return.
We may free the resources, which maybe accessed by the event.
Finally, the event may touch the freed memory, IOW, use-after-free
happens.