### PR TITLE
Fix data race with access to ev_res.

### DIFF
--- a/event.c
+++ b/event.c
@@ -1641,10 +1641,12 @@ event_process_active_single_queue(struct event_base *base,
 			break;
 		case EV_CLOSURE_EVENT: {
 			void (*evcb_callback)(evutil_socket_t, short, void *);
+			short res;
 			EVUTIL_ASSERT(ev != NULL);
 			evcb_callback = *ev->ev_callback;
+			res = ev->ev_res;
 			EVBASE_RELEASE_LOCK(base, th_base_lock);
-			evcb_callback(ev->ev_fd, ev->ev_res, ev->ev_arg);
+			evcb_callback(ev->ev_fd, res, ev->ev_arg);
 		}
 		break;
 		case EV_CLOSURE_CB_SELF: {


### PR DESCRIPTION
This issue was detected in release-2.1.8-stable using ThreadSanitizer, and resolved by capturing the value of ev_res in a local variable while the event is locked, then passing that captured variable to the callback.

Verified with `make verify`, and with ThreadSanitizer.

It isn't clear to me whether the other two fields that are passed to the callback, ev_fd and ev_arg, also need to be captured with the event locked. ThreadSanitizer didn't complain about this code after this change;
 there are plenty of other data races in 2.1.8, which I may be able to create fixes for.