### PR TITLE
test: avoid regress hanging in macOS

### DIFF
--- a/test/regress.c
+++ b/test/regress.c
@@ -3445,7 +3445,7 @@ struct testcase_t main_testcases[] = {
 
 	BASIC(active_by_fd, TT_FORK|TT_NEED_BASE|TT_NEED_SOCKETPAIR),
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__APPLE__)
 	LEGACY(fork, TT_ISOLATED),
 #endif
 #ifdef EVENT__HAVE_PTHREADS


### PR DESCRIPTION
still a regression as it doesn't happen with 2.0.22 in the same system (macOS 10.12.6), but at least will make it easier to see there are 3 failing regressions (2.0.22 had 1)