### PR TITLE
configure: avoid false positive in DragonFlyBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -517,6 +517,12 @@ if test "x$ac_cv_header_sys_event_h" = "xyes"; then
 	if test "x$havekqueue" = "xyes" ; then
 		AC_MSG_CHECKING(for working kqueue)
 		AC_TRY_RUN(
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/event.h>
@@ -532,7 +538,7 @@ main(int argc, char **argv)
 	int fd[[2]];
 	struct kevent ev;
 	struct timespec ts;
-	char buf[[8000]];
+	char buf[[80000]];
 
 	if (pipe(fd) == -1)
 		exit(1);


### PR DESCRIPTION
by default, the max buffer size is 16K and histeresis is at 50%, so
a bigger read is needed to unlock writes than you would expect from
other BSD (512 bytes)

this doesn't introduce any regression on FreeBSD 11.1, OpenBSD 6.1, NetBSD 7.1,
macOS 10.12.6 and of course DragonFlyBSD 4.8.1, and most of them show
a max pipe size of 64K, so the read call should drain them all regardless
of how conservative they are on the free pipe space they will require
(usually 512 bytes) before kevent reports the fd as ready for write.

I couldn't find a reference to which bug this code was trying to look for
and it seems to be there from the beginning of git history so it might be
no longer relevant.