### PR TITLE
autotools: confirm openssl is working before using

### DIFF
--- a/m4/libevent_openssl.m4
+++ b/m4/libevent_openssl.m4
@@ -39,6 +39,10 @@ case "$enable_openssl" in
 	done
 	;;
     esac
+    CPPFLAGS_SAVE=$CPPFLAGS
+    CPPFLAGS+=$OPENSSL_INCS
+    AC_CHECK_HEADERS([openssl/ssl.h], [], [have_openssl=no])
+    CPPFLAGS=$CPPFLAGS_SAVE
     AC_SUBST(OPENSSL_INCS)
     AC_SUBST(OPENSSL_LIBS)
     case "$have_openssl" in


### PR DESCRIPTION
latest versions of macOS provide pkg-config and libraries for an ancient
version of openssl as part of the system, but no headers