### PR TITLE
test: fix 32bit linux regress

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,7 +458,6 @@ else()
     set(EVENT__SIZEOF_SSIZE_T ${EVENT__SIZEOF_INT})
 endif()
 
-
 CHECK_TYPE_SIZE(socklen_t EVENT__SIZEOF_SOCKLEN_T)
 if(NOT EVENT__SIZEOF_SOCKLEN_T)
   set(EVENT__socklen_t "unsigned int")
@@ -490,6 +489,7 @@ endif()
 # we're just getting lazy now.
 CHECK_TYPE_SIZE("uintptr_t" EVENT__HAVE_UINTPTR_T)
 CHECK_TYPE_SIZE("void *" EVENT__SIZEOF_VOID_P)
+CHECK_TYPE_SIZE("time_t" EVENT__SIZEOF_TIME_T)
 
 # Tests file offset bits.
 # TODO: Add AIX test for if -D_LARGE_FILES is needed.

--- a/WIN32-Code/nmake/event2/event-config.h
+++ b/WIN32-Code/nmake/event2/event-config.h
@@ -324,6 +324,13 @@
 #define EVENT__SIZEOF_VOID_P 4
 #endif
 
+/* The size of `time_t`, as computed by sizeof. */
+#ifdef _WIN64
+#define EVENT__SIZEOF_TIME_T 8
+#else
+#define EVENT__SIZEOF_TIME_T 4
+#endif
+
 /* Define to 1 if you have the ANSI C header files. */
 #define EVENT__STDC_HEADERS 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -658,6 +658,7 @@ AC_CHECK_SIZEOF(short)
 AC_CHECK_SIZEOF(size_t)
 AC_CHECK_SIZEOF(void *)
 AC_CHECK_SIZEOF(off_t)
+AC_CHECK_SIZEOF(time_t)
 
 AC_CHECK_TYPES([struct in6_addr, struct sockaddr_in6, sa_family_t, struct addrinfo, struct sockaddr_storage], , ,
 [#define _GNU_SOURCE

--- a/test/regress_util.c
+++ b/test/regress_util.c
@@ -1412,10 +1412,12 @@ static struct date_rfc1123_case {
 	{  1289433600, "Thu, 11 Nov 2010 00:00:00 GMT"},
 	{  1323648000, "Mon, 12 Dec 2011 00:00:00 GMT"},
 #ifndef _WIN32
+#if EVENT__SIZEOF_TIME_T > 4
 	/** In win32 case we have max   "23:59:59 January 18, 2038, UTC" for time32 */
 	{  4294967296, "Sun, 07 Feb 2106 06:28:16 GMT"} /* 2^32 */,
 	/** In win32 case we have max "23:59:59, December 31, 3000, UTC" for time64 */
 	{253402300799, "Fri, 31 Dec 9999 23:59:59 GMT"} /* long long future no one can imagine */,
+#endif /* time_t != 32bit */
 	{  1456704000, "Mon, 29 Feb 2016 00:00:00 GMT"} /* leap year */,
 #endif
 	{  1435708800, "Wed, 01 Jul 2015 00:00:00 GMT"} /* leap second */,


### PR DESCRIPTION
both values overflow in a 32bit time_t and therefore result in that test obviously failing