### PR TITLE
Remove redundant include getopt.h (QNX)

### DIFF
--- a/WIN32-Code/nmake/event2/event-config.h
+++ b/WIN32-Code/nmake/event2/event-config.h
@@ -265,7 +265,7 @@
 /* #define EVENT__HAVE_UINT8_T 1 */
 
 /* Define to 1 if you have the <unistd.h> header file. */
-/* #define EVENT__HAVE_UNISTD_H 1 */
+#define EVENT__HAVE_UNISTD_H 1
 
 /* Define to 1 if you have the `vasprintf' function. */
 /* #undef EVENT__HAVE_VASPRINTF */

--- a/WIN32-Code/unistd.h
+++ b/WIN32-Code/unistd.h
@@ -1,5 +1,5 @@
-#ifndef __GETOPT_H__
-#define __GETOPT_H__
+#ifndef __UNISTD_H__
+#define __UNISTD_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,22 +11,10 @@ extern int optopt;		/* character checked for validity */
 extern int optreset;		/* reset getopt */
 extern char *optarg;		/* argument associated with option */
 
-struct option
-{
-  const char *name;
-  int has_arg;
-  int *flag;
-  int val;
-};
-
-#define no_argument       0
-#define required_argument 1
-#define optional_argument 2
-
-int getopt_long(int, char**, const char*, const struct option*, int*);
+int getopt(int, char**, const char*);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* __GETOPT_H__ */
+#endif /* __UNISTD_H__ */

--- a/sample/dns-example.c
+++ b/sample/dns-example.c
@@ -19,7 +19,6 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
-#include <getopt.h>
 #else
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/test/bench.c
+++ b/test/bench.c
@@ -56,11 +56,6 @@
 #include <unistd.h>
 #endif
 #include <errno.h>
-
-#ifdef _WIN32
-#include <getopt.h>
-#endif
-
 #include <event.h>
 #include <evutil.h>
 

--- a/test/bench_cascade.c
+++ b/test/bench_cascade.c
@@ -48,7 +48,6 @@
 #include <unistd.h>
 #endif
 #include <errno.h>
-#include <getopt.h>
 #include <event.h>
 #include <evutil.h>
 


### PR DESCRIPTION
Aside from being redundant, it is absent in QNX 6.5, according to this report (not mine, I cannot run the testsuite):
https://mail-index.netbsd.org/pkgsrc-users/2017/09/20/msg025601.html

(getopt is in unistd.h)