### PR TITLE
Define __EXT_POSIX2 for QNX

### DIFF
--- a/evconfig-private.h.cmake
+++ b/evconfig-private.h.cmake
@@ -32,4 +32,7 @@
 /* Define to 1 if you need to in order for `stat' and other things to work. */
 #cmakedefine _POSIX_SOURCE 1
 
+/* Enable POSIX.2 extensions on QNX */
+#cmakedefine __EXT_POSIX2 1
+
 #endif

--- a/evconfig-private.h.in
+++ b/evconfig-private.h.in
@@ -45,4 +45,9 @@
 #undef _POSIX_SOURCE
 #endif
 
+/* Enable POSIX.2 extensions on QNX */
+#ifndef __EXT_POSIX2
+#define __EXT_POSIX2
+#endif
+
 #endif


### PR DESCRIPTION
POSIX 1003.2 extensions
It's necessary for getopt.

Reported here: https://mail-index.netbsd.org/pkgsrc-users/2017/09/20/msg025601.html (not mine, I can't test)