### PR TITLE
Fix missed case in 5ff8eb26371c4dc56f384b2de35bea2d87814779

### DIFF
--- a/http.c
+++ b/http.c
@@ -3448,6 +3448,7 @@ evhttp_handle_request(struct evhttp_request *req, void *arg)
 
 	/* Generic call back */
 	if (http->gencb) {
+		bufferevent_disable(req->evcon->bufev, EV_READ);
 		(*http->gencb)(req, http->gencbarg);
 		return;
 	} else {


### PR DESCRIPTION
The catch-all callback needs the same treatment.