### PR TITLE
Fix generation of LibeventConfig.cmake for the installation tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1324,11 +1324,11 @@ file(RELATIVE_PATH
      "${EVENT_INSTALL_CMAKE_DIR}"
      "${CMAKE_INSTALL_PREFIX}/include")
 
-# Note the EVENT_CMAKE_DIR is defined in LibeventConfig.cmake.in,
+# Note the LIBEVENT_CMAKE_DIR is defined in LibeventConfig.cmake.in,
 # we escape it here so it's evaluated when it is included instead
-# so that the include dirs are givenrelative to where the
+# so that the include dirs are given relative to where the
 # config file is located.
-set(EVENT__INCLUDE_DIRS "\${EVENT_CMAKE_DIR}/${REL_INCLUDE_DIR}")
+set(EVENT_INSTALL_INCLUDE_DIR "\${LIBEVENT_CMAKE_DIR}/${REL_INCLUDE_DIR}")
 
 configure_file(${PROJECT_SOURCE_DIR}/cmake/LibeventConfig.cmake.in
                ${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/LibeventConfig.cmake


### PR DESCRIPTION
Now `LIBEVENT_INCLUDE_DIRS` is properly initialized in `LibeventConfig.cmake` which is generated for the installation tree. Previously `LIBEVENT_INCLUDE_DIRS` was just empty due to the usage of the wrong variables.

`LibeventConfig.cmake.in` uses `LIBEVENT_CMAKE_DIR` and `EVENT_INSTALL_INCLUDE_DIR` variables. That's why the following variables have been replaced in `CMakeLists.txt` for proper `LibeventConfig.cmake` generation:
* `LIBEVENT_CMAKE_DIR` is replaced with `EVENT_CMAKE_DIR`;
* `EVENT_INSTALL_INCLUDE_DIR` is replaced with `EVENT__INCLUDE_DIRS`.

Related typos are fixed.