### PR TITLE
Immediately stop trying to accept more connections if listener disabled

### DIFF
--- a/listener.c
+++ b/listener.c
@@ -424,6 +424,11 @@ listener_read_cb(evutil_socket_t fd, short what, void *p)
 			return;
 		}
 		--lev->refcnt;
+		if (!lev->enabled) {
+			/* the callback could have disabled the listener */
+			UNLOCK(lev);
+			return;
+		}
 	}
 	err = evutil_socket_geterror(fd);
 	if (EVUTIL_ERR_ACCEPT_RETRIABLE(err)) {


### PR DESCRIPTION
This is a refined version of the logic previously in https://github.com/libevent/libevent/pull/578

The rationale is that the consumer of sockets may wish to temporarily delay accepting for some reason (e.g. being out of file-descriptors). The kernel will then queue them up. The kernel queue is bounded and programs like NodeJS will actually try to quickly accept and then close (as the current behaviour before this PR).

However, it seems that libevent should allow the user to choose whether to accept and respond correctly if the listener is disabled.