### PR TITLE
Make tcp backlog configurable for http bind.

### DIFF
--- a/http.c
+++ b/http.c
@@ -3498,8 +3498,14 @@ accept_socket_cb(struct evconnlistener *listener, evutil_socket_t nfd, struct so
 int
 evhttp_bind_socket(struct evhttp *http, const char *address, ev_uint16_t port)
 {
+	return evhttp_bind_socket_with_backlog(http, address, port, 128);
+}
+
+int
+evhttp_bind_socket_with_backlog(struct evhttp *http, const char *address, ev_uint16_t port, int backlog)
+{
 	struct evhttp_bound_socket *bound =
-		evhttp_bind_socket_with_handle(http, address, port);
+		evhttp_bind_socket_with_handle_and_backlog(http, address, port, backlog);
 	if (bound == NULL)
 		return (-1);
 	return (0);
@@ -3508,13 +3514,18 @@ evhttp_bind_socket(struct evhttp *http, const char *address, ev_uint16_t port)
 struct evhttp_bound_socket *
 evhttp_bind_socket_with_handle(struct evhttp *http, const char *address, ev_uint16_t port)
 {
+	return evhttp_bind_socket_with_handle_and_backlog(http, address, port, 128);
+}
+struct evhttp_bound_socket *
+evhttp_bind_socket_with_handle_and_backlog(struct evhttp *http, const char *address, ev_uint16_t port, int backlog)
+{
 	evutil_socket_t fd;
 	struct evhttp_bound_socket *bound;
 
 	if ((fd = bind_socket(address, port, 1 /*reuse*/)) == -1)
 		return (NULL);
 
-	if (listen(fd, 128) == -1) {
+	if (listen(fd, backlog) == -1) {
 		event_sock_warn(fd, "%s: listen", __func__);
 		evutil_closesocket(fd);
 		return (NULL);

--- a/http.c
+++ b/http.c
@@ -3516,6 +3516,7 @@ evhttp_bind_socket_with_handle(struct evhttp *http, const char *address, ev_uint
 {
 	return evhttp_bind_socket_with_handle_and_backlog(http, address, port, 128);
 }
+
 struct evhttp_bound_socket *
 evhttp_bind_socket_with_handle_and_backlog(struct evhttp *http, const char *address, ev_uint16_t port, int backlog)
 {

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -113,8 +113,8 @@ int evhttp_bind_socket(struct evhttp *http, const char *address, ev_uint16_t por
  * @return 0 on success, -1 on failure.
  * @see evhttp_accept_socket()
  */
-EVENT2_EXPORT_SYMBOL
-int evhttp_bind_socket_with_backlog(struct evhttp *http, const char *address, ev_uint16_t port, int backlog);
+int evhttp_bind_socket_with_backlog(
+	struct evhttp *http, const char *address, ev_uint16_t port, int backlog);
 
 /**
  * Like evhttp_bind_socket(), but returns a handle for referencing the socket.
@@ -128,8 +128,8 @@ int evhttp_bind_socket_with_backlog(struct evhttp *http, const char *address, ev
  * @return Handle for the socket on success, NULL on failure.
  * @see evhttp_bind_socket(), evhttp_del_accept_socket()
  */
-EVENT2_EXPORT_SYMBOL
-struct evhttp_bound_socket *evhttp_bind_socket_with_handle_and_backlog(struct evhttp *http, const char *address, ev_uint16_t port, int backlog);
+struct evhttp_bound_socket *evhttp_bind_socket_with_handle_and_backlog(
+	struct evhttp *http, const char *address, ev_uint16_t port, int backlog);
 
 /**
  * Like evhttp_bind_socket(), but returns a handle for referencing the socket.

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -101,6 +101,37 @@ EVENT2_EXPORT_SYMBOL
 int evhttp_bind_socket(struct evhttp *http, const char *address, ev_uint16_t port);
 
 /**
+ * Binds an HTTP server on the specified address and port.
+ *
+ * Can be called multiple times to bind the same http server
+ * to multiple different ports.
+ *
+ * @param http a pointer to an evhttp object
+ * @param address a string containing the IP address to listen(2) on
+ * @param port the port number to listen on
+ * @param backlog specifies max tcp backlog for the connection
+ * @return 0 on success, -1 on failure.
+ * @see evhttp_accept_socket()
+ */
+EVENT2_EXPORT_SYMBOL
+int evhttp_bind_socket_with_backlog(struct evhttp *http, const char *address, ev_uint16_t port, int backlog);
+
+/**
+ * Like evhttp_bind_socket(), but returns a handle for referencing the socket.
+ *
+ * The returned pointer is not valid after \a http is freed.
+ *
+ * @param http a pointer to an evhttp object
+ * @param address a string containing the IP address to listen(2) on
+ * @param port the port number to listen on
+ * @param backlog specifies max tcp backlog for the connection
+ * @return Handle for the socket on success, NULL on failure.
+ * @see evhttp_bind_socket(), evhttp_del_accept_socket()
+ */
+EVENT2_EXPORT_SYMBOL
+struct evhttp_bound_socket *evhttp_bind_socket_with_handle_and_backlog(struct evhttp *http, const char *address, ev_uint16_t port, int backlog);
+
+/**
  * Like evhttp_bind_socket(), but returns a handle for referencing the socket.
  *
  * The returned pointer is not valid after \a http is freed.


### PR DESCRIPTION
Hi,

We found it useful to increase the backlog on one of our production services. In order to do this I made tcp back log configurable. I thought others might find this useful so made a pull request. The change itself is fairly straight forward, the thing I dislike the most is the somewhat unwieldy name, but I couldn't come up with anything better.