### PR TITLE
Mitigating numeric type issues found by Veracode

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -1534,7 +1534,7 @@ evbuffer_find_eol_char(struct evbuffer_ptr *it)
 	return (-1);
 }
 
-static inline int
+static inline size_t
 evbuffer_strspn(
 	struct evbuffer_ptr *ptr, const char *chrset)
 {

--- a/event.c
+++ b/event.c
@@ -2314,7 +2314,7 @@ event_priority_set(struct event *ev, int pri)
 
 	if (ev->ev_flags & EVLIST_ACTIVE)
 		return (-1);
-	if (pri < 0 || pri >= ev->ev_base->nactivequeues)
+	if (pri < 0 || pri >= ev->ev_base->nactivequeues || (pri >> (sizeof(ev_uint8_t)*8-1)) != 0)
 		return (-1);
 
 	ev->ev_pri = pri;


### PR DESCRIPTION
A Veracode (https://www.veracode.com/) scan yielded the following two issues that seem to be valid (although relatively minor) in the code:

Numeric Truncation Error - event.c:2320

Description: There may be a variable truncation in this expression. The maximum or minimum value of the right hand side may be larger or smaller than the maximum or minimum value the variable type of the left hand side can hold. Numeric truncation can also occur when the compiler adheres to integer promotion rules in an arithmetic operation and downcasts the result. Integer truncations can cause security vulnerabilities such as buffer overflows and data corruption, depending on how the numeric value is used.

Remediation: Ensure that no casts, implicit or explicit, take place that move from a larger size primitive to a smaller size primitive.

Signed to Unsigned Conversion Error - buffer.c:1623

Description: This assignment creates a type mismatch by populating an unsigned variable with a signed value. The signed integer will be implicitly cast to an unsigned integer, converting negative values into positive ones. If an attacker can control the signed value, it may be possible to trigger a buffer overflow if the value specifies the length of a memory write.

Remediation: Do not rely on implicit casts between signed and unsigned values because the result can take on an unexpected value and violate weak assumptions made elsewhere in the program.