### PR TITLE
Added evhttp max simultaneous connection limiting

### DIFF
--- a/http-internal.h
+++ b/http-internal.h
@@ -145,6 +145,8 @@ struct evhttp {
 
 	/* All live connections on this host. */
 	struct evconq connections;
+	int connection_max;
+	int connection_cnt;
 
 	TAILQ_HEAD(vhostsq, evhttp) virtualhosts;
 

--- a/http.c
+++ b/http.c
@@ -1222,6 +1222,7 @@ evhttp_connection_free(struct evhttp_connection *evcon)
 	if (evcon->http_server != NULL) {
 		struct evhttp *http = evcon->http_server;
 		TAILQ_REMOVE(&http->connections, evcon, next);
+		http->connection_cnt--;
 	}
 
 	if (event_initialized(&evcon->retry_ev)) {
@@ -3853,6 +3854,21 @@ evhttp_set_max_body_size(struct evhttp* http, ev_ssize_t max_body_size)
 }
 
 void
+evhttp_set_max_connections(struct evhttp* http, int max_connections)
+{
+	if (max_connections < 0)
+		http->connection_max = 0;
+	else
+		http->connection_max = max_connections;
+}
+
+int
+evhttp_get_connection_count(struct evhttp* http)
+{
+	return http->connection_cnt;
+}
+
+void
 evhttp_set_default_content_type(struct evhttp *http,
 	const char *content_type) {
 	http->default_content_type = content_type;
@@ -4291,8 +4307,30 @@ evhttp_get_request(struct evhttp *http, evutil_socket_t fd,
 	 */
 	evcon->http_server = http;
 	TAILQ_INSERT_TAIL(&http->connections, evcon, next);
+	http->connection_cnt++;
 
-	if (evhttp_associate_new_request_with_connection(evcon) == -1)
+	/* send "service unavailable" if we've reached the connection limit */
+	if (http->connection_max && http->connection_max < http->connection_cnt) {
+		struct evhttp_request *req;
+
+		if ((req = evhttp_request_new(evhttp_handle_request, http)) == NULL) {
+			evhttp_connection_free(evcon);
+			return;
+		}
+
+		req->evcon = evcon;	/* the request owns the connection */
+		req->flags |= EVHTTP_REQ_OWN_CONNECTION;
+		req->kind = EVHTTP_REQUEST;
+		/* note, req->remote_host not needed since we don't read */
+
+		TAILQ_INSERT_TAIL(&evcon->requests, req, next);
+
+		/* send error to client */
+		evcon->state = EVCON_WRITING;
+		bufferevent_enable(evcon->bufev, EV_READ); /* enable close events */
+		evhttp_send_error(req, HTTP_SERVUNAVAIL, NULL);
+
+	} else if (evhttp_associate_new_request_with_connection(evcon) == -1)
 		evhttp_connection_free(evcon);
 }
 

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -223,6 +223,24 @@ EVENT2_EXPORT_SYMBOL
 void evhttp_set_max_body_size(struct evhttp* http, ev_ssize_t max_body_size);
 
 /**
+ * Set the maximum number of simultaneous connections for this server.
+ * A value of zero or less disables the limit.
+ *
+ * @param http the http server on which to set the max connection limit
+ * @param max_connections the maximum number of simultaneous connections or 0
+ */
+EVENT2_EXPORT_SYMBOL
+void evhttp_set_max_connections(struct evhttp* http, int max_connections);
+
+/**
+ * Get the current number of connections.
+ *
+ * @return The current number of connections for this server.
+ */
+EVENT2_EXPORT_SYMBOL
+int evhttp_get_connection_count(struct evhttp* http);
+
+/**
   Set the value to use for the Content-Type header when none was provided. If
   the content type string is NULL, the Content-Type header will not be
   automatically added.


### PR DESCRIPTION
When the max connection limit is enabled and the limit is reached, the server will respond immediately with 503 ``Service Unavailable``.  This can be used to prevent servers from running out of file descriptors.  This is better than request limiting because clients may make more than one request over a single connection.  Blocking a request does not necessarily close the connection and free up a socket.