### PR TITLE
Added evhttp max connection TTL, Slowloris mitigation

### DIFF
--- a/http-internal.h
+++ b/http-internal.h
@@ -60,6 +60,7 @@ struct evhttp_connection {
 	struct bufferevent *bufev;
 
 	struct event retry_ev;		/* for retrying connects */
+	struct event expire_ev;		/* expire connections based on ttl */
 
 	char *bind_address;		/* address to use for binding the src */
 	ev_uint16_t bind_port;		/* local port for binding the src */
@@ -145,6 +146,9 @@ struct evhttp {
 
 	/* All live connections on this host. */
 	struct evconq connections;
+
+	/* Maximum connection time in seconds */
+	int connection_ttl;
 
 	TAILQ_HEAD(vhostsq, evhttp) virtualhosts;
 

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -235,6 +235,25 @@ void evhttp_set_default_content_type(struct evhttp *http,
 	const char *content_type);
 
 /**
+ * Set the maximum time in seconds for a connection to live on this server.
+ * A value of zero or less disables the limit.
+ *
+ * An event will fire on any connection that has lived too long that will
+ * close and remove the connection from the server.  This can be used to
+ * mitigate Slowloris DOS attacks which attempt to keep server connections open
+ * by slowly reading or writing data, avoiding connection read/write timeouts,
+ * keeping the connection open for as long as possible.  During a Slowloris
+ * attack, the server will slowly run out of file descriptors or hit it's max
+ * connection limit.  The TTL (Time to Live) limit drops any connections that
+ * have been open for too long.
+ *
+ * @param http the http server on which to set the max connection limit
+ * @param ttl the maximum time to live or 0 for no limit.
+ */
+EVENT2_EXPORT_SYMBOL
+void evhttp_set_connection_ttl(struct evhttp* http, int ttl);
+
+/**
   Sets the what HTTP methods are supported in requests accepted by this
   server, and passed to user callbacks.
 
@@ -777,6 +796,19 @@ void evhttp_connection_set_retries(struct evhttp_connection *evcon,
 EVENT2_EXPORT_SYMBOL
 void evhttp_connection_set_closecb(struct evhttp_connection *evcon,
     void (*)(struct evhttp_connection *, void *), void *);
+
+/**
+ * Set or reset the maximum time, from now, in seconds for the connection to
+ * live. A value of zero or less disables the limit.
+ *
+ * @param evcon the connection on which to set the limit.
+ * @param base the event base for the ttl event.
+ * @param ttl the maximum time to live or 0 for no limit.
+ * @return 0 on success, -1 on failure.
+ */
+EVENT2_EXPORT_SYMBOL
+int evhttp_connection_set_ttl(struct evhttp_connection *evcon,
+    struct event_base *base, int ttl);
 
 /** Get the remote address and port associated with this connection. */
 EVENT2_EXPORT_SYMBOL


### PR DESCRIPTION
This adds a configurable max connection TTL (Time to Live) limit.

An event will fire on this server approximately every 60 seconds where it will check for and remove any expired connections.  This can be used to mitigate [Slowloris DOS attacks](https://en.wikipedia.org/wiki/Slowloris_(computer_security)) which attempt to keep server connections open by slowly reading or writing data, avoiding normal connection timeouts and keeping the connection open for as long as possible.  During a Slowloris attack, the server will slowly run out of file descriptors or hit its max connection limit.  The TTL (Time to Live) limit drops any connections that have been open for too long.

Note, that this will likely conflict in ``http-internal.h`` with #592 because both add variables to the same place in ``struct evhttp``.