### PR TITLE
additional callbacks for streamed upload

### DIFF
--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -585,6 +585,26 @@ void evhttp_request_set_header_cb(struct evhttp_request *,
     int (*cb)(struct evhttp_request *, void *));
 
 /**
+ * Enable delivery of request body to requestor.
+ * @param cb will be called after every read of body data. Will never be called on an empty
+ *           response. May drain the input buffer; it will be drained
+ *           automatically on return.
+ * @param arg call back's argument.
+ */
+EVENT2_EXPORT_SYMBOL
+void evhttp_request_set_body_read_cb(struct evhttp_request *,
+    void (*cb)(struct evhttp_request *, void *),void* arg);
+
+/**
+ * Register callback for additional process request after receive headers.
+ * @param cb will be called after all headers received, before body read.
+ * @param arg call back's argument.
+ */
+EVENT2_EXPORT_SYMBOL
+void evhttp_request_set_body_start_cb(struct evhttp_request *,
+    void (*cb)(struct evhttp_request *, void *),void* arg);
+
+/**
  * The different error types supported by evhttp
  *
  * @see evhttp_request_set_error_cb()

--- a/include/event2/http_struct.h
+++ b/include/event2/http_struct.h
@@ -120,7 +120,7 @@ struct {
 	 * the regular callback.
 	 */
 	void (*chunk_cb)(struct evhttp_request *, void *);
-
+	void* chunk_cb_arg;
 	/*
 	 * Callback added for forked-daapd so they can collect ICY
 	 * (shoutcast) metadata from the http header. If return
@@ -142,6 +142,13 @@ struct {
 	 */
 	void (*on_complete_cb)(struct evhttp_request *, void *);
 	void *on_complete_cb_arg;
+	/*
+	 * Start body read callback - called after all headers parsed.
+	 * 
+	 * @see evhttp_request_set_body_start_cb()
+	 */
+	void (*body_start_cb)(struct evhttp_request *, void *);
+	void *body_start_cb_arg;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
This MR allow implement http server files upload without collect all data in memory.
Request `chunk_cb` reused with different name.