### PR TITLE
don't fail be_null_filter if bytes are copied

### DIFF
--- a/bufferevent_filter.c
+++ b/bufferevent_filter.c
@@ -160,7 +160,7 @@ be_null_filter(struct evbuffer *src, struct evbuffer *dst, ev_ssize_t lim,
 	       enum bufferevent_flush_mode state, void *ctx)
 {
 	(void)state;
-	if (evbuffer_remove_buffer(src, dst, lim) == 0)
+	if (evbuffer_remove_buffer(src, dst, lim) >= 0)
 		return BEV_OK;
 	else
 		return BEV_ERROR;


### PR DESCRIPTION
`evbuffer_remove_buffer()` returns the number of bytes read, but `be_null_filter` was incorrectly returning `BEV_ERROR` if any bytes were copied.

(`be_null_filter` is a little bit of a confusing name, but the docs say "You don’t need to specify both an input filter and an output filter: any filter you omit is replaced with one that passes data on without transforming it.")