### PR TITLE
flush the filter when re-enabled

### DIFF
--- a/bufferevent_filter.c
+++ b/bufferevent_filter.c
@@ -281,6 +281,7 @@ be_filter_enable(struct bufferevent *bev, short event)
 		bufferevent_unsuspend_read_(bevf->underlying,
 		    BEV_SUSPEND_FILT_READ);
 	}
+	be_filter_flush(bev, event, BEV_NORMAL);
 	return 0;
 }
 

--- a/bufferevent_filter.c
+++ b/bufferevent_filter.c
@@ -331,8 +331,21 @@ be_filter_process_input(struct bufferevent_filtered *bevf,
 		 evbuffer_get_length(bevf->underlying->input) &&
 		 !be_readbuf_full(bevf, state));
 
-	if (*processed_out)
+	if (*processed_out) {
 		BEV_RESET_GENERIC_READ_TIMEOUT(bev);
+
+		bufferevent_trigger_nolock_(bev, EV_READ, 0);
+		if (evbuffer_get_length(bevf->underlying->input) > 0 &&
+			be_readbuf_full(bevf, state)) {
+			/* data left in underlying buffer and filter input buffer
+			 * hit its read high watermark.
+			 * Schedule callback to avoid data gets stuck in underlying
+			 * input buffer.
+			 */
+			evbuffer_cb_set_flags(bev->input, bevf->inbuf_cb,
+				EVBUFFER_CB_ENABLED);
+		}
+	}
 
 	return res;
 }
@@ -459,23 +472,6 @@ be_filter_read_nolock_(struct bufferevent *underlying, void *me_)
 		/* XXXX use return value */
 		res = be_filter_process_input(bevf, state, &processed_any);
 		(void)res;
-
-		/* XXX This should be in process_input, not here.  There are
-		 * other places that can call process-input, and they should
-		 * force readcb calls as needed. */
-		if (processed_any) {
-			bufferevent_trigger_nolock_(bufev, EV_READ, 0);
-			if (evbuffer_get_length(underlying->input) > 0 &&
-				be_readbuf_full(bevf, state)) {
-				/* data left in underlying buffer and filter input buffer
-				 * hit its read high watermark.
-				 * Schedule callback to avoid data gets stuck in underlying
-				 * input buffer.
-				 */
-				evbuffer_cb_set_flags(bufev->input, bevf->inbuf_cb,
-					EVBUFFER_CB_ENABLED);
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
`bufferevent_filter` does not flush when re-enabled. This caused data to be stuck in the buffer.

The other bufferevent implementations all do this:
https://github.com/libevent/libevent/blob/master/bufferevent_async.c#L340
https://github.com/libevent/libevent/blob/master/bufferevent_openssl.c#L1168
https://github.com/libevent/libevent/blob/master/bufferevent_pair.c#L238

(also; wow those are similar. I wonder if those implementations should add `*_flush()` support, and `be_ops->flush()` should called automatically in `bufferevent_enable()`)