### PR TITLE
Avoid possible SEGVs in select()

### DIFF
--- a/evutil_time.c
+++ b/evutil_time.c
@@ -134,7 +134,10 @@ evutil_usleep_(const struct timeval *tv)
 	sleep(tv->tv_sec);
 	usleep(tv->tv_usec);
 #else
-	select(0, NULL, NULL, NULL, tv);
+	{
+		struct timeval tv2 = *tv;
+		select(0, NULL, NULL, NULL, &tv);
+	}
 #endif
 }
 


### PR DESCRIPTION
Per the POSIX definition of select():

http://pubs.opengroup.org/onlinepubs/009696699/functions/pselect.html

"Upon successful completion, the select() function may modify the object
pointed to by the timout argument."

If "struct timeval" pointer is a "static const", it could potentially
be allocated in a RO text segment.  The kernel would then try to copy
back the modified value (with the time remaining) into a read-only
address and SEGV.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>