### PR TITLE
Fixing doxygen docs for evdns_base_search_clear.

### DIFF
--- a/include/event2/dns.h
+++ b/include/event2/dns.h
@@ -478,6 +478,7 @@ int evdns_base_resolv_conf_parse(struct evdns_base *base, int flags, const char 
 EVENT2_EXPORT_SYMBOL
 int evdns_base_load_hosts(struct evdns_base *base, const char *hosts_fname);
 
+#ifdef _WIN32
 /**
   Obtain nameserver information using the Windows API.
 
@@ -488,7 +489,6 @@ int evdns_base_load_hosts(struct evdns_base *base, const char *hosts_fname);
   @return 0 if successful, or -1 if an error occurred
   @see evdns_resolv_conf_parse()
  */
-#ifdef _WIN32
 EVENT2_EXPORT_SYMBOL
 int evdns_base_config_windows_nameservers(struct evdns_base *);
 #define EVDNS_BASE_CONFIG_WINDOWS_NAMESERVERS_IMPLEMENTED

--- a/include/event2/dns.h
+++ b/include/event2/dns.h
@@ -478,7 +478,7 @@ int evdns_base_resolv_conf_parse(struct evdns_base *base, int flags, const char 
 EVENT2_EXPORT_SYMBOL
 int evdns_base_load_hosts(struct evdns_base *base, const char *hosts_fname);
 
-#ifdef _WIN32
+#if defined(EVENT_IN_DOXYGEN_) || defined(_WIN32)
 /**
   Obtain nameserver information using the Windows API.
 


### PR DESCRIPTION
When generating docs on linux, the doc for evdns_base_search_clear is not generated correctly. For example, http://www.wangafu.net/~nickm/libevent-2.1/doxygen/html/dns_8h.html#a9211bdca966e8f4ce3270b29c1d72122. It looks like the issue is due to a misplaced define guard.