### PR TITLE
[listener] Break out of while loop if accept was a success.

### DIFF
--- a/listener.c
+++ b/listener.c
@@ -429,6 +429,11 @@ listener_read_cb(evutil_socket_t fd, short what, void *p)
 			UNLOCK(lev);
 			return;
 		}
+
+        if (new_fd != -1) {
+           UNLOCK(lev);
+           return;
+        }
 	}
 	err = evutil_socket_geterror(fd);
 	if (EVUTIL_ERR_ACCEPT_RETRIABLE(err)) {

--- a/listener.c
+++ b/listener.c
@@ -430,10 +430,13 @@ listener_read_cb(evutil_socket_t fd, short what, void *p)
 			return;
 		}
 
-        if (new_fd != -1) {
-           UNLOCK(lev);
-           return;
-        }
+		/* break out of the while loop if this was successfully
+		   accepted. Otherwise we usually end up with a second
+		   attempt that will fail. */
+		if (new_fd != -1) {
+			UNLOCK(lev);
+			return;
+		}
 	}
 	err = evutil_socket_geterror(fd);
 	if (EVUTIL_ERR_ACCEPT_RETRIABLE(err)) {


### PR DESCRIPTION
We must break out of this while loop if the accept() did not return an error in order to avoid potential stalls.