### PR TITLE
Fixes: use-after-free / null deref bugs

### DIFF
--- a/bufferevent_pair.c
+++ b/bufferevent_pair.c
@@ -316,7 +316,8 @@ be_pair_flush(struct bufferevent *bev, short iotype,
 
 	incref_and_lock(bev);
 
-	partner = downcast(bev_p->partner);
+	if (!(partner = downcast(bev_p->partner)))
+		return -1;
 
 	if ((iotype & EV_READ) != 0)
 		be_pair_transfer(partner, bev, 1);

--- a/event-internal.h
+++ b/event-internal.h
@@ -42,6 +42,14 @@ extern "C" {
 #include "mm-internal.h"
 #include "defer-internal.h"
 
+#ifndef TAILQ_FOREACH_SAFE
+#define TAILQ_FOREACH_SAFE(var, head, field, tvar)        \
+    for ((var) = TAILQ_FIRST((head));                     \
+         (var) && ((tvar) = TAILQ_NEXT((var), field), 1); \
+         (var) = (tvar))
+#endif
+
+
 /* map union members back */
 
 /* mutually exclusive */


### PR DESCRIPTION
[bufferevent_pair]

- While bev_p->partner is checked, when libevent calls
`downcast(bev_p->partner)` it dereferences `pair->bev.bev`
 which can trigger a NULL deref in `be_pair_transfer` for
 the variable `partner`.

 Fix: check the return value of `downcast`

[event]

- Added `TAILQ_FOREACH_SAFE` macro that is applied to various functions
that iterate over a TAILQ in order to modify or free resources
associated with it, such as in the potential in the execution path of

```
  event_base_free_queues_ ->
    event_base_cancel_single_callback_ ->
        case EV_CLOSURE_EVENT_FINALIZE_FREE -> mm_free(ev)
```