### PR TITLE
When compiling on Linux and off_t is 8 bytes, use sendfile64()

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -2484,7 +2484,11 @@ evbuffer_write_sendfile(struct evbuffer *buffer, evutil_socket_t dest_fd,
 	return (len);
 #elif defined(SENDFILE_IS_LINUX)
 	/* TODO(niels): implement splice */
+#if defined(EVENT__HAVE_SENDFILE64) && EVENT__SIZEOF_OFF_T == 8
+	res = sendfile64(dest_fd, source_fd, &offset, chain->off);
+#else
 	res = sendfile(dest_fd, source_fd, &offset, chain->off);
+#endif
 	if (res == -1 && EVUTIL_ERR_RW_RETRIABLE(errno)) {
 		/* if this is EAGAIN or EINTR return 0; otherwise, -1 */
 		return (0);

--- a/configure.ac
+++ b/configure.ac
@@ -376,6 +376,7 @@ AC_CHECK_FUNCS([ \
   pipe2 \
   putenv \
   sendfile \
+  sendfile64 \
   setenv \
   setrlimit \
   sigaction \

--- a/event-config.h.cmake
+++ b/event-config.h.cmake
@@ -247,6 +247,9 @@
 /* Define to 1 if you have the `sendfile' function. */
 #cmakedefine EVENT__HAVE_SENDFILE 1
 
+/* Define to 1 if you have the `sendfile64' function. */
+#cmakedefine EVENT__HAVE_SENDFILE64 1
+
 /* Define to 1 if you have the `sigaction' function. */
 #cmakedefine EVENT__HAVE_SIGACTION 1
 


### PR DESCRIPTION
Even when using `./configure --enable-largefile` I'm seeing cases where
there are still compilation warnings which are unsettling:

```
/opt/samknows/build/libevent/libevent-2.1.8-stable/buffer.c:2500:2: warning: passing argument 3 of 'sendfile' from incompatible pointer type [enabled by default]
/opt/samknows/openwrt_wdr4900/final/staging_dir/toolchain-powerpc_gcc-4.6-linaro_uClibc-0.9.33.2/lib/gcc/powerpc-openwrt-linux-uclibcspe/4.6.4/../../../../powerpc-openwrt-linux-uclibcspe/sys-include/sys/sendfile.h:34:16: note: expected 'off_t *' but argument is of type 'int64_t *'
```

Don't really want 32-bits of value being deposited into a 64-bit variable,
so if our offsets are 64-bits wide, then force the use of the 64-bit API.