### PR TITLE
Fix out-of-tree builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -232,7 +232,7 @@ MAYBE_CORE =
 endif
 
 AM_CFLAGS = $(LIBEVENT_CFLAGS)
-AM_CPPFLAGS = -I$(srcdir)/compat -I$(srcdir)/include -I./include $(SYS_INCLUDES) $(LIBEVENT_CPPFLAGS)
+AM_CPPFLAGS = -I$(srcdir)/compat -I./include -I$(srcdir)/include $(SYS_INCLUDES) $(LIBEVENT_CPPFLAGS)
 AM_LDFLAGS = $(LIBEVENT_LDFLAGS)
 
 GENERIC_LDFLAGS = -version-info $(VERSION_INFO) $(RELEASE) $(NO_UNDEFINED) $(AM_LDFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -272,7 +272,6 @@ noinst_HEADERS +=				\
 	defer-internal.h			\
 	epolltable-internal.h			\
 	evbuffer-internal.h			\
-	evconfig-private.h			\
 	event-internal.h			\
 	evmap-internal.h			\
 	evrpc-internal.h			\


### PR DESCRIPTION
evconfig-private.h was being included by make dist. Since, for the quote form of the include directive, headers in the directory of the file with the #include line have priority over those named in -I options, the copy of evconfig-private.h from the source directory had priority over the one in the build directory.

You may want to check with your own automake expert, but AFAIK this is the correct fix. evconfig-private.h is both "noinst" and "nodist", but AFAIK you can't specify both. An autogenerated header that is both "noinst" and "nodist" can just be ignored and it will not be installed or distributed.