### PR TITLE
assert condition modify

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -1146,7 +1146,7 @@ evbuffer_drain(struct evbuffer *buf, size_t len)
 		}
 
 		buf->first = chain;
-		EVUTIL_ASSERT(remaining < chain->off);
+		EVUTIL_ASSERT(remaining <= chain->off);
 		chain->misalign += remaining;
 		chain->off -= remaining;
 	}


### PR DESCRIPTION
In the case of iocp, in the `for` loop above, there is a situation where `remaining == chain->off == 0`