### PR TITLE
Add function to access the underlying fd of an evhttp_connection

### DIFF
--- a/http.c
+++ b/http.c
@@ -4800,3 +4800,10 @@ evhttp_uri_set_fragment(struct evhttp_uri *uri, const char *fragment)
 	URI_SET_STR_(fragment);
 	return 0;
 }
+
+evutil_socket_t
+evhttp_connection_get_fd(struct evhttp_connection *evcon)
+{
+
+	return evcon->fd;
+}

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -1017,6 +1017,14 @@ void evhttp_uri_free(struct evhttp_uri *uri);
  */
 char *evhttp_uri_join(struct evhttp_uri *uri, char *buf, size_t limit);
 
+/**
+ * Get the underlying fd associated with the connection
+ *
+ * @param evcon the evhttp_connection object
+ * @return the underlying fd associated with the connection
+ */
+evutil_socket_t evhttp_connection_get_fd(struct evhttp_connection *evcon);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This exposes the underlying socket fd of the evhttp_connection.  This can be useful for setting or querying socket options.