### PR TITLE
Tell Travis to use quiet git clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ os:
 sudo: false
 dist: trusty
 
+git:
+  quiet: true
+
 env:
   matrix:
     - EVENT_BUILD_METHOD=cmake EVENT_CMAKE_OPTIONS="-DEVENT__COVERAGE=ON -DCMAKE_BUILD_TYPE=debug" COVERALLS=yes


### PR DESCRIPTION
Otherwise the logs show a bunch of pointless progress, which is
really only useful for interactive sessions.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>