### PR TITLE
Tell Travis to build with the current LTS release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os:
   - linux
   - osx
 sudo: false
-dist: trusty
+dist: xenial
 
 git:
   quiet: true


### PR DESCRIPTION
Trusty Tahr has been EOL'd for a while, so use Xenial to build instead.

This will include tools that are more likely to resemble what's in
other distros.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>