### PR TITLE
Fix bufferevent_new() without global init

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,5 +408,6 @@ fixing bugs:
  * johnsonlee
  * Philip Prindeville
  * Vis Virial
+ * Mike Bourgeous
 
 If we have forgotten your name, please contact us.

--- a/event.c
+++ b/event.c
@@ -1268,6 +1268,8 @@ event_base_get_npriorities(struct event_base *base)
 	int n;
 	if (base == NULL)
 		base = current_base;
+	if (base == NULL)
+		return 1;
 
 	EVBASE_ACQUIRE_LOCK(base, th_base_lock);
 	n = base->nactivequeues;


### PR DESCRIPTION
In older projects that use `bufferevent_new()` followed by `bufferevent_base_set()` instead of `bufferevent_socket_new()`, without calling the global `event_init()`, libevent 2.1.x introduced a segmentation fault in `event_base_get_npriorities()`.  These projects may not be able to switch to the new API due to the way they use libevent with threads (e.g. they need to avoid referring to the event base in another thread, or need to maintain compatibility with libevent 1.4).  See libevent/libevent#565.

This PR fixes that segmentation fault by returning 1 for the number of priorities if there is no event base available.  The `bufferevent_base_set()` function assigns the event base's middle priority to the bufferevent, so the 1 returned by `event_base_get_npriorities()` does not affect any code that uses `bufferevent_base_set()`.

---

### PR verification and testing

I tested my compiled version of libevent with my own code and the segmentation fault is gone.  Valgrind shows no errors.

#### Regression tests

I did not add a regression test because it does not appear that I can ensure that `event_init()` has not been called (or that `event_global_current_base_` is set to NULL).

Running the test suite on my Ubuntu 18.04 system gave these failures:

```
The following tests FAILED:
         18 - regress__changelist_EPOLL_debug (Failed)
         26 - regress__timerfd_changelist_EPOLL (Failed)
         35 - regress__SELECT (Failed)
```

When I run those tests individually with `ctest -R '^(regress__changelist_EPOLL_debug|regress__timerfd_changelist_EPOLL|regress__SELECT)$'` they sometimes pass and sometimes fail.


#### Linting

When I tried to run `./checkpatch.sh` I got this error:

```
usage: clang-format-diff [-h] [-i] [-p NUM] [-regex PATTERN] [-iregex PATTERN]
                         [-sort-includes] [-v] [-style STYLE] [-binary BINARY]
clang-format-diff: error: unrecognized arguments: --style={ Language:          Cpp,BasedOnStyle:      LLVM,,AccessModifierOffset: -4,,AlignAfterOpenBracket: DontAlign,AlignEscapedNewlinesLeft: true,,AlignTrailingComments: true,,AllowAllParametersOfDeclarationOnNextLine: true,AllowShortBlocksOnASingleLine: false,AllowShortCaseLabelsOnASingleLine: false,AllowShortFunctionsOnASingleLine: All,AllowShortIfStatementsOnASingleLine: false,AllowShortLoopsOnASingleLine: false,,AlwaysBreakAfterDefinitionReturnType: All,AlwaysBreakBeforeMultilineStrings: false,AlwaysBreakTemplateDeclarations: false,,,,,BreakBeforeBinaryOperators: false,BreakBeforeBraces: Custom,BraceWrapping: { AfterFunction: true },BreakBeforeTernaryOperators: true,BreakConstructorInitializersBeforeComma: true,,ColumnLimit:     80,,ContinuationIndentWidth: 4,,DerivePointerAlignment: false ,DisableFormat:   false,ExperimentalAutoDetectBinPacking: false ,ForEachMacros:   [ LIST_FOREACH, SIMPLEQ_FOREACH, CIRCLEQ_FOREACH, TAILQ_FOREACH, TAILQ_FOREACH_REVERSE, HT_FOREACH ],,IndentCaseLabels: false,IndentFunctionDeclarationAfterType: false,IndentWidth:     4,IndentWrappedFunctionNames: false,,KeepEmptyLinesAtTheStartOfBlocks: true,MaxEmptyLinesToKeep: 2,,PointerAlignment: Right ,,,SpaceBeforeAssignmentOperators: true,SpaceBeforeParens: ControlStatements,SpaceInEmptyParentheses: false,SpacesBeforeTrailingComments: 1,SpacesInAngles:  false,SpacesInCStyleCastParentheses: false,SpacesInParentheses: false,Standard:        Cpp03,TabWidth:        4,UseTab:          Always,SortIncludes:    false, }
```