### PR TITLE
event_exit and fatal_fn from tests: use _exit instead of exit

### DIFF
--- a/log.c
+++ b/log.c
@@ -91,11 +91,11 @@ event_exit(int errcode)
 {
 	if (fatal_fn) {
 		fatal_fn(errcode);
-		exit(errcode); /* should never be reached */
+		_exit(errcode); /* should never be reached */
 	} else if (errcode == EVENT_ERR_ABORT_)
 		abort();
 	else
-		exit(errcode);
+		_exit(errcode);
 }
 
 void

--- a/test/regress_util.c
+++ b/test/regress_util.c
@@ -494,9 +494,9 @@ fatalfn(int exitcode)
 	if (logsev != fatal_want_severity ||
 	    !logmsg ||
 	    strcmp(logmsg, fatal_want_message))
-		exit(0);
+		_exit(0);
 	else
-		exit(exitcode);
+		_exit(exitcode);
 }
 
 #ifndef _WIN32


### PR DESCRIPTION
With multiple threads, if event_exit is called (via
EVUTIL_ASSERT -> event_errx for example), it calls exit() (or fatal_fn which
in the test suite calls exit) which unloads shared libs before exiting. If
another thread is in one of these libs, it can crash and trigger false issues.

Saw this with

  CC="-fsanitize=address" make verify -j8

in dns/getaddrinfo_race_gotresolve_test, which reaches a check fail in

  0  EVUTIL_ASSERT(lock->count == 0);
  1  debug_lock_free()
  2  EVTHREAD_FREE_LOCK(base->th_base_lock, 0);
  3  event_base_free_(struct event_base *base, int run_finalizers)

because lock->count is 1, held_by the other thread which is in
event_base_dispatch().

The visible result is that ASAN reports a heap-use-after-free on the
other thread.