### PR TITLE
test: make sure pthread is defined

### DIFF
--- a/test/regress_thread.h
+++ b/test/regress_thread.h
@@ -28,6 +28,7 @@
 #define REGRESS_THREAD_H_INCLUDED_
 
 #ifdef EVENT__HAVE_PTHREADS
+#include <pthread.h>
 #define THREAD_T pthread_t
 #define THREAD_FN void *
 #define THREAD_RETURN() return (NULL)


### PR DESCRIPTION
avoid warnings with any modern C99 compiler due to implicit function
declaration for pthread_create