### PR TITLE
Adding support for large UDP responses

### DIFF
--- a/evdns.c
+++ b/evdns.c
@@ -141,6 +141,8 @@
 #define MAX_V4_ADDRS 32
 #define MAX_V6_ADDRS 32
 
+/* Default UDP Response max packet length */
+#define RFC_MAX_PACKET_LENGTH 512
 
 #define TYPE_A	       EVDNS_TYPE_A
 #define TYPE_CNAME     5
@@ -149,6 +151,7 @@
 #define TYPE_AAAA      EVDNS_TYPE_AAAA
 
 #define CLASS_INET     EVDNS_CLASS_INET
+#define CLASS_OPT      EVDNS_CLASS_OPT
 
 /* Persistent handle.  We keep this separate from 'struct request' since we
  * need some object to last for as long as an evdns_request is outstanding so
@@ -334,6 +337,9 @@ struct evdns_base {
 	int global_max_nameserver_timeout;
 	/* true iff we will use the 0x20 hack to prevent poisoning attacks. */
 	int global_randomize_case;
+
+	/* Maximum record length of a DNS packet, default is 512 bytes */
+	int global_max_record_len;
 
 	/* The first time that a nameserver fails, how long do we wait before
 	 * probing to see if it has returned?  */
@@ -1371,21 +1377,21 @@ static void
 nameserver_read(struct nameserver *ns) {
 	struct sockaddr_storage ss;
 	ev_socklen_t addrlen = sizeof(ss);
-	u8 packet[1500];
 	char addrbuf[128];
 	ASSERT_LOCKED(ns->base);
+	int max_record_len = ns->base->global_max_record_len;
+	u8 *packet = mm_malloc(max_record_len);
 
 	for (;;) {
-		const int r = recvfrom(ns->socket, (void*)packet,
-		    sizeof(packet), 0,
-		    (struct sockaddr*)&ss, &addrlen);
+		const int r = recvfrom(ns->socket, (void *)packet, max_record_len, 0,
+			(struct sockaddr *)&ss, &addrlen);
 		if (r < 0) {
 			int err = evutil_socket_geterror(ns->socket);
 			if (EVUTIL_ERR_RW_RETRIABLE(err))
-				return;
+				goto done;
 			nameserver_failed(ns,
 			    evutil_socket_error_to_string(err));
-			return;
+			goto done;
 		}
 		if (evutil_sockaddr_cmp((struct sockaddr*)&ss,
 			(struct sockaddr*)&ns->address, 0)) {
@@ -1394,12 +1400,14 @@ nameserver_read(struct nameserver *ns) {
 			    evutil_format_sockaddr_port_(
 				    (struct sockaddr *)&ss,
 				    addrbuf, sizeof(addrbuf)));
-			return;
+			goto done;
 		}
 
 		ns->timedout = 0;
 		reply_parse(ns->base, packet, r);
 	}
+done:
+	free(packet);
 }
 
 /* Read a packet from a DNS client on a server port s, parse it, and */
@@ -1666,10 +1674,20 @@ dnsname_to_labels(u8 *const buf, size_t buf_len, off_t j,
 /* length. The actual request may be smaller than the value returned */
 /* here */
 static size_t
-evdns_request_len(const size_t name_len) {
+evdns_request_len(const size_t name_len, const int max_record_len)
+{
+	int extended_dns_len = 0;
+	/* Length of a extended dns puesdo-Resource Record */
+	if (max_record_len > RFC_MAX_PACKET_LENGTH) {
+		extended_dns_len = 1 + /* length of domain name string, always 0 */
+						   2 + /* space for resource type */
+						   2 + /* space for UDP payload size */
+						   4 + /* space for extended RCODE flags */
+						   2;  /* space for length of RDATA, always 0 */
+	}
 	return 96 + /* length of the DNS standard header */
-		name_len + 2 +
-		4;  /* space for the resource type */
+		   name_len + 2 + 4 /* space for the resource type */ +
+		   extended_dns_len;
 }
 
 /* build a dns request packet into buf. buf should be at least as long */
@@ -1678,8 +1696,9 @@ evdns_request_len(const size_t name_len) {
 /* Returns the amount of space used. Negative on error. */
 static int
 evdns_request_data_build(const char *const name, const size_t name_len,
-    const u16 trans_id, const u16 type, const u16 class,
-    u8 *const buf, size_t buf_len) {
+	const u16 trans_id, const u16 type, const u16 class, u8 *const buf,
+	size_t buf_len, int max_record_len)
+{
 	off_t j = 0;  /* current offset into buf */
 	u16 t_;	 /* used by the macros */
 
@@ -1688,7 +1707,12 @@ evdns_request_data_build(const char *const name, const size_t name_len,
 	APPEND16(1);  /* one question */
 	APPEND16(0);  /* no answers */
 	APPEND16(0);  /* no authority */
-	APPEND16(0);  /* no additional */
+	if (max_record_len > RFC_MAX_PACKET_LENGTH) {
+		APPEND16(1); /* 1 additional record for the pseudo resource record used
+						by extended dns */
+	} else {
+		APPEND16(0); /* no additional */
+	}
 
 	j = dnsname_to_labels(buf, buf_len, j, name, name_len, NULL);
 	if (j < 0) {
@@ -1698,10 +1722,31 @@ evdns_request_data_build(const char *const name, const size_t name_len,
 	APPEND16(type);
 	APPEND16(class);
 
+
+	/* structure of the extended dns record
+	 * +------------+--------------+------------------------------+
+	 * | Field Name | Field Type   | Description                  |
+	 * +------------+--------------+------------------------------+
+	 * | NAME       | domain name  | MUST be 0 (root domain)      |
+	 * | TYPE       | u_int16_t    | OPT (41)                     |
+	 * | CLASS      | u_int16_t    | requestor's UDP payload size |
+	 * | TTL        | u_int32_t    | extended RCODE and flags     |
+	 * | RDLEN      | u_int16_t    | length of all RDATA          |
+	 * | RDATA      | octet stream | {attribute,value} pairs      |
+	 * +------------+--------------+------------------------------+ */
+	if (max_record_len > RFC_MAX_PACKET_LENGTH) {
+		buf[j++] = 0;			  /* NAME, always 0 */
+		APPEND16(CLASS_OPT);	  /* OPT type */
+		APPEND16(max_record_len); /* max UDP payload size */
+		APPEND16(0);			  /* No extended RCODE flags set */
+		APPEND16(0);			  /* No extended RCODE flags set */
+		APPEND16(0);			  /* RDATA is always 0 length */
+	}
+
 	return (int)j;
  overflow:
 	return (-1);
-}
+ }
 
 /* exported function */
 struct evdns_server_port *
@@ -1965,9 +2010,8 @@ evdns_server_request_format_response(struct server_request *req, int err)
 		}
 	}
 
-	if (j > 512) {
-overflow:
-		j = 512;
+	if (j > RFC_MAX_PACKET_LENGTH) {
+	overflow:
 		buf[2] |= 0x02; /* set the truncated bit. */
 	}
 
@@ -2749,11 +2793,14 @@ request_new(struct evdns_base *base, struct evdns_request *handle, int type,
 	    const char *name, int flags, evdns_callback_type callback,
 	    void *user_ptr) {
 
+	ASSERT_LOCKED(base);
+
 	const char issuing_now =
 	    (base->global_requests_inflight < base->global_max_requests_inflight) ? 1 : 0;
 
 	const size_t name_len = strlen(name);
-	const size_t request_max_len = evdns_request_len(name_len);
+	const int max_record_len = base->global_max_record_len;
+	const size_t request_max_len = evdns_request_len(name_len, max_record_len);
 	const u16 trans_id = issuing_now ? transaction_id_pick(base) : 0xffff;
 	/* the request data is alloced in a single block with the header */
 	struct request *const req =
@@ -2761,8 +2808,6 @@ request_new(struct evdns_base *base, struct evdns_request *handle, int type,
 	int rlen;
 	char namebuf[256];
 	(void) flags;
-
-	ASSERT_LOCKED(base);
 
 	if (!req) return NULL;
 
@@ -2796,8 +2841,8 @@ request_new(struct evdns_base *base, struct evdns_request *handle, int type,
 	req->request = ((u8 *) req) + sizeof(struct request);
 	/* denotes that the request data shouldn't be free()ed */
 	req->request_appended = 1;
-	rlen = evdns_request_data_build(name, name_len, trans_id,
-	    type, CLASS_INET, req->request, request_max_len);
+	rlen = evdns_request_data_build(name, name_len, trans_id, type, CLASS_INET,
+		req->request, request_max_len, max_record_len);
 	if (rlen < 0)
 		goto err1;
 
@@ -3513,6 +3558,9 @@ evdns_base_set_option_impl(struct evdns_base *base,
 		    val);
 		memcpy(&base->global_nameserver_probe_initial_timeout, &tv,
 		    sizeof(tv));
+	} else if (str_matches_option(option, "max-record-len:")) {
+		int max_record_len = strtoint(val);
+		base->global_max_record_len = max_record_len;
 	}
 	return 0;
 }
@@ -3940,6 +3988,7 @@ evdns_base_new(struct event_base *event_base, int flags)
 	base->global_max_nameserver_timeout = 3;
 	base->global_search_state = NULL;
 	base->global_randomize_case = 1;
+	base->global_max_record_len = RFC_MAX_PACKET_LENGTH;
 	base->global_getaddrinfo_allow_skew.tv_sec = 3;
 	base->global_getaddrinfo_allow_skew.tv_usec = 0;
 	base->global_nameserver_probe_initial_timeout.tv_sec = 10;

--- a/include/event2/dns.h
+++ b/include/event2/dns.h
@@ -422,8 +422,21 @@ void evdns_cancel_request(struct evdns_base *base, struct evdns_request *req);
 
   The currently available configuration options are:
 
-    ndots, timeout, max-timeouts, max-inflight, attempts, randomize-case,
-    bind-to, initial-probe-timeout, getaddrinfo-allow-skew.
+    ndots - Used to configure searching. Defaults to 1.
+    timeout - Timeout for DNS queries, defaults to 5.
+    max-timeouts - Maximum allowed timeouts for a namesever. Defaults to 3.
+    max-inflight - Max allowed pending DNS request at a time. Defaults to 64.
+    attempts - How many times to retry a DNS request before failure. Defaults to 3.
+    randomize-case - If nonzero, we randomize the case on outgoing DNS requests
+        and verify replies have the same case as the requests. Defaults to 1.
+    bind-to - If provided, we bind to the given address whenever we send
+        packets to a nameserver. Default disabled.
+    initial-probe-timeout - Sets timeout of first probe to check if a
+        nameserver has come back up. Default 10
+    getaddrinfo-allow-skew - How many seconds to wait for both IPv4 and IPv6
+        responses once one of them has been received. Defaults to 3 seconds.
+    max-record-len - Maximum size allowed for a UDP response. Uses DNS
+        extension to increased the allowed size past 512 bytes. Default is 512.
 
   In versions before Libevent 2.0.3-alpha, the option name needed to end with
   a colon.
@@ -602,6 +615,7 @@ typedef void (*evdns_request_callback_fn_type)(struct evdns_server_request *, vo
 #define EVDNS_QTYPE_ALL	 255
 
 #define EVDNS_CLASS_INET   1
+#define EVDNS_CLASS_OPT    41
 
 /* flags that can be set in answers; as part of the err parameter */
 #define EVDNS_FLAGS_AA	0x400

--- a/test/regress_dns.c
+++ b/test/regress_dns.c
@@ -599,6 +599,72 @@ end:
 
 	regress_clean_dnsserver();
 }
+
+static void
+dns_large_udp_test(void *arg)
+{
+	struct regress_dns_server_table table[ARRAY_SIZE(search_table)];
+	struct basic_test_data *data = arg;
+	struct event_base *base = data->base;
+	struct evdns_base *dns = NULL;
+	ev_uint16_t portnum = 0;
+	char buf[64];
+
+	struct generic_dns_callback_result r[8];
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(table); ++i) {
+		table[i] = search_table[i];
+		table[i].lower = 0;
+	}
+
+	tt_assert(regress_dnsserver(base, &portnum, table));
+	evutil_snprintf(buf, sizeof(buf), "127.0.0.1:%d", (int)portnum);
+
+	dns = evdns_base_new(base, 0);
+	tt_assert(!evdns_base_set_option(dns, "max-record-len", "4096"));
+	tt_assert(!evdns_base_nameserver_ip_add(dns, buf));
+
+	evdns_base_search_add(dns, "a.example.com");
+	evdns_base_search_add(dns, "b.example.com");
+	evdns_base_search_add(dns, "c.example.com");
+
+	n_replies_left = ARRAY_SIZE(r);
+	exit_base = base;
+
+	evdns_base_resolve_ipv4(dns, "host", 0, generic_dns_callback, &r[0]);
+	evdns_base_resolve_ipv4(dns, "host2", 0, generic_dns_callback, &r[1]);
+	evdns_base_resolve_ipv4(dns, "host", DNS_NO_SEARCH, generic_dns_callback, &r[2]);
+	evdns_base_resolve_ipv4(dns, "host2", DNS_NO_SEARCH, generic_dns_callback, &r[3]);
+	evdns_base_resolve_ipv4(dns, "host3", 0, generic_dns_callback, &r[4]);
+	evdns_base_resolve_ipv4(dns, "hostn.a.example.com", DNS_NO_SEARCH, generic_dns_callback, &r[5]);
+	evdns_base_resolve_ipv4(dns, "hostn.b.example.com", DNS_NO_SEARCH, generic_dns_callback, &r[6]);
+	evdns_base_resolve_ipv4(dns, "hostn.c.example.com", DNS_NO_SEARCH, generic_dns_callback, &r[7]);
+
+	event_base_dispatch(base);
+
+	tt_int_op(r[0].type, ==, DNS_IPv4_A);
+	tt_int_op(r[0].count, ==, 1);
+	tt_int_op(((ev_uint32_t*)r[0].addrs)[0], ==, htonl(0x0b16212c));
+	tt_int_op(r[1].type, ==, DNS_IPv4_A);
+	tt_int_op(r[1].count, ==, 1);
+	tt_int_op(((ev_uint32_t*)r[1].addrs)[0], ==, htonl(0xc8640064));
+	tt_int_op(r[2].result, ==, DNS_ERR_NOTEXIST);
+	tt_int_op(r[3].result, ==, DNS_ERR_NOTEXIST);
+	tt_int_op(r[4].result, ==, DNS_ERR_NOTEXIST);
+	tt_int_op(r[5].result, ==, DNS_ERR_NODATA);
+	tt_int_op(r[5].ttl, ==, 42);
+	tt_int_op(r[6].result, ==, DNS_ERR_NOTEXIST);
+	tt_int_op(r[6].ttl, ==, 42);
+	tt_int_op(r[7].result, ==, DNS_ERR_NODATA);
+	tt_int_op(r[7].ttl, ==, 0);
+
+end:
+	if (dns)
+		evdns_base_free(dns, 0);
+
+	regress_clean_dnsserver();
+}
 static void
 dns_search_empty_test(void *arg)
 {
@@ -2286,6 +2352,7 @@ struct testcase_t dns_testcases[] = {
 	{ "search_lower", dns_search_lower_test, TT_FORK|TT_NEED_BASE, &basic_setup, NULL },
 	{ "search_cancel", dns_search_cancel_test,
 	  TT_FORK|TT_NEED_BASE, &basic_setup, NULL },
+	{ "dns_large_udp", dns_large_udp_test, TT_FORK|TT_NEED_BASE, &basic_setup, NULL },
 	{ "retry", dns_retry_test, TT_FORK|TT_NEED_BASE|TT_NO_LOGS, &basic_setup, NULL },
 	{ "retry_disable_when_inactive", dns_retry_disable_when_inactive_test,
 	  TT_FORK|TT_NEED_BASE|TT_NO_LOGS, &basic_setup, NULL },


### PR DESCRIPTION
This adds support for DNS records larger than 512 bytes.

I ran into an issue where a domain was failing to resolve because their DNS record was larger than 512 bytes. It is enabled by setting the "max-record-len" option to greater than 512 bytes. By default nothing changes. I tested it with some common public DNS servers (google, cloudflare, Dyn) and they all seemed to work correctly.

Relevant RFC https://tools.ietf.org/html/rfc6891