### PR TITLE
Cast argument in sample "time-test.c" (ensure it compiles)

### DIFF
--- a/sample/time-test.c
+++ b/sample/time-test.c
@@ -43,7 +43,7 @@ static void
 timeout_cb(evutil_socket_t fd, short event, void *arg)
 {
 	struct timeval newtime, difference;
-	struct event *timeout = arg;
+	struct event *timeout = (struct event*) arg;
 	double elapsed;
 
 	evutil_gettimeofday(&newtime, NULL);


### PR DESCRIPTION
It won't compile without error with -fpermissive

The header mentions that this example is rather outdated, so the relevance of this change can be questioned.