### PR TITLE
test: make sure pthread is defined

### DIFF
--- a/test/regress_thread.h
+++ b/test/regress_thread.h
@@ -28,6 +28,7 @@
 #define REGRESS_THREAD_H_INCLUDED_
 
 #ifdef EVENT__HAVE_PTHREADS
+#include <pthread.h>
 #define THREAD_T pthread_t
 #define THREAD_FN void *
 #define THREAD_RETURN() return (NULL)


### PR DESCRIPTION
avoid warnings with any modern C99 compiler due to implicit function
declaration for pthread_create, as shown by the following :

test/regress_dns.c:2226:2: warning: implicit declaration of function
      'pthread_create' is invalid in C99 [-Wimplicit-function-declaration]
        THREAD_START(thread[0], race_base_run, &rp);
        ^
test/regress_thread.h:35:2: note: expanded from macro 'THREAD_START'
        pthread_create(&(threadvar), NULL, fn, arg)
        ^
test/regress_dns.c:2226:2: warning: this function declaration is not a prototype
      [-Wstrict-prototypes]
test/regress_thread.h:35:2: note: expanded from macro 'THREAD_START'
        pthread_create(&(threadvar), NULL, fn, arg)
        ^

$ clang --version
Apple LLVM version 9.1.0 (clang-902.0.39.2)
Target: x86_64-apple-darwin17.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin