### PR TITLE
Allow binding to ::1 on loopback in any case

### DIFF
--- a/http.c
+++ b/http.c
@@ -4421,6 +4421,17 @@ make_addrinfo(const char *address, ev_uint16_t port)
 	/* turn NULL hostname into INADDR_ANY, and skip looking up any address
 	 * types we don't have an interface to connect to. */
 	hints.ai_flags = EVUTIL_AI_PASSIVE|EVUTIL_AI_ADDRCONFIG;
+
+	/* Work around a strange getaddrinfo(..) oddity. If the only
+	   interface that supports IPv6 is the loopback one, getaddrinfo(..) will
+	   fail with the AI_ADDRCONFIG flag set, even when requesting info for
+	   ::1. See also this bug report in RedHat:
+	   https://bugzilla.redhat.com/show_bug.cgi?id=808147
+	   */
+	if (strcmp(address, "::1") == 0)
+		hints.ai_flags &= ~EVUTIL_AI_ADDRCONFIG;
+
+
 	evutil_snprintf(strport, sizeof(strport), "%d", port);
 	if ((ai_result = evutil_getaddrinfo(address, strport, &hints, &ai))
 	    != 0) {


### PR DESCRIPTION
 There is a strange bug / feature in `getaddrinfo(..)` that it fails if the only interface that supports IPv6 is the loopback interface, as this interface is being explicitly ignored when scanning for IPv6 support (see `check_pf.c` in glibc sources).
    
 See also this RedHat issue:    
 https://bugzilla.redhat.com/show_bug.cgi?id=808147
   
This is a workaround so that binding to `::1` still works in this scenario.
    
To test this, make sure that your system has all interfaces except `lo` configured to be IPv4-only and run the following program:
    
(Code adapted from SF issue for libevent number 361, see here: https://sourceforge.net/p/levent/bugs/361/)

```
 #include <event2/event.h>
 #include <event2/http.h>

int main()
{
    struct event_base* evb = event_base_new();
    struct evhttp* http = evhttp_new(evb);
    int res_ipv6 = evhttp_bind_socket(http, "::1", 5000);
    printf("%d\n", res_ipv6);
    return 0;
}
```
    
Result without this patch applied:
```
[warn] getaddrinfo: address family for nodename not supported
-1
```

(Expected) result with this patch applied:
```
0
```