### PR TITLE
Better masking definitions.

### DIFF
--- a/evdns.c
+++ b/evdns.c
@@ -864,17 +864,17 @@ reply_schedule_callback(struct request *const req, u32 ttl, u32 err, struct repl
 }
 
 
-#define _QR_MASK    0x8U
-#define _OP_MASK    0x78U
-#define _AA_MASK    0x04U
-#define _TC_MASK    0x02U
-#define _RD_MASK    0x01U
-#define _RA_MASK    0x008U
-#define _Z_MASK     0x004U
-#define _AD_MASK    0x002U
-#define _CD_MASK    0x001U
+#define _QR_MASK    0x8000U
+#define _OP_MASK    0x7800U
+#define _AA_MASK    0x0400U
+#define _TC_MASK    0x0200U
+#define _RD_MASK    0x0100U
+#define _RA_MASK    0x0080U
+#define _Z_MASK     0x0040U
+#define _AD_MASK    0x0020U
+#define _CD_MASK    0x0010U
 #define _RCODE_MASK 0x000fU
-#define _Z_MASK_DEPRECATED 0x007U
+#define _Z_MASK_DEPRECATED 0x0070U
 
 /* this processes a parsed reply packet */
 static void

--- a/evdns.c
+++ b/evdns.c
@@ -864,17 +864,17 @@ reply_schedule_callback(struct request *const req, u32 ttl, u32 err, struct repl
 }
 
 
-#define _QR_MASK    0x8000
-#define _OP_MASK    0x7800
-#define _AA_MASK    0x0400
-#define _TC_MASK    0x0200
-#define _RD_MASK    0x0100
-#define _RA_MASK    0x0080
-#define _Z_MASK     0x0040
-#define _AD_MASK    0x0020
-#define _CD_MASK    0x0010
-#define _RCODE_MASK 0x000f
-#define _Z_MASK_DEPRECATED 0x0070
+#define _QR_MASK    0x8U
+#define _OP_MASK    0x78U
+#define _AA_MASK    0x04U
+#define _TC_MASK    0x02U
+#define _RD_MASK    0x01U
+#define _RA_MASK    0x008U
+#define _Z_MASK     0x004U
+#define _AD_MASK    0x002U
+#define _CD_MASK    0x001U
+#define _RCODE_MASK 0x000fU
+#define _Z_MASK_DEPRECATED 0x007U
 
 /* this processes a parsed reply packet */
 static void


### PR DESCRIPTION
Currently, we do a lot of data munging with manual hex. This is ugly
and can lead to bugs. I defined the following:

_QR_MASK    0x8000
_OP_MASK    0x7800
_AA_MASK    0x0400
_TC_MASK    0x0200
_RD_MASK    0x0100
_RA_MASK    0x0080
_Z_MASK     0x0040
_AD_MASK    0x0020
_CD_MASK    0x0010
_RCODE_MASK 0x000f

So that we can more easily twiddle flags.