### PR TITLE
changelog: 2.1.9 typos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -50,7 +50,7 @@ Changes in version 2.1.9-beta (10 February 2019)
   o Fix crashing http server when callback do not reply in place (5b40744dg, b2581380g)
   o fix handling of close_notify (ssl) in http with openssl bufferevents (7e91622bg)
 
- evprc:
+ evrpc:
   o use *_new_with_arg() to match function prototype (a95cc9e3g)
   o avoid NULL dereference on request is not EVHTTP_REQ_POST (e05136c7g)
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -17,104 +17,104 @@ Changes in version 2.1.9-beta (10 February 2019)
 
 
  dist archive:
-  o Add cmake rules into dist archive (bf3a67cfg)
-  o Add missing print-winsock-errors.c into dist archive (822d6462g)
-  o Include openssl-compat.h into dist archive (08658136g)
+  o Add cmake rules into dist archive (bf3a67cf)
+  o Add missing print-winsock-errors.c into dist archive (822d6462)
+  o Include openssl-compat.h into dist archive (08658136)
 
  core:
-  o Merge branch 'check-O_NONBLOCK-in-debug' (a39898f3g, a8155c62g)
-  o Merge branch 'event-ET-#636-v2' (ca4b6404g)
+  o Merge branch 'check-O_NONBLOCK-in-debug' (a39898f3, a8155c62)
+  o Merge branch 'event-ET-#636-v2' (ca4b6404)
   o Fix visibility issues under (mostly on win32)
-    (349081e1g, 802be13ag, a1f28e2fg)
+    (349081e1g, 802be13ag, a1f28e2f)
   o Define __EXT_POSIX2 for QNX (a2176f2c)
-  o Cleanup __func__ detection (b3af7bddg)
+  o Cleanup __func__ detection (b3af7bdd)
   o Add convenience macros for user-triggered events (06ec5de6)
-  o Notify event base if there are no more events, so it can exit without delay (d9d1c09eg)
-  o Fix base unlocking in event_del() if event_base_set() runned in another thread (4f0f40e3g)
+  o Notify event base if there are no more events, so it can exit without delay (d9d1c09e)
+  o Fix base unlocking in event_del() if event_base_set() runned in another thread (4f0f40e3)
   o If precise_time is false, we should not set EVENT_BASE_FLAG_PRECISE_TIMER (27dee54d)
   o Fix race in access to ev_res from event loop with event_active() (43d92a6d)
   o Return from event_del() after the last event callback termination (876c7ac7)
 
  http:
-  o Merge branch 'http-EVHTTP_CON_READ_ON_WRITE_ERROR-fixes-v2' (eb7b472bg)
+  o Merge branch 'http-EVHTTP_CON_READ_ON_WRITE_ERROR-fixes-v2' (eb7b472b)
   o Preserve socket error from listen across closesocket cleanup (2ccd00a6)
-  o fix connection retries when there more then one request for connection (d30e7bbag)
-  o improve error path for bufferevent_{setfd,enable,disable}() (a8cc449eg)
-  o Fix conceivable UAF of the bufferevent in evhttp_connection_free() (6ac2ec25g)
-  o Merge branch 'http-request-line-parsing' (cdcfbafeg)
+  o fix connection retries when there more then one request for connection (d30e7bba)
+  o improve error path for bufferevent_{setfd,enable,disable}() (a8cc449e)
+  o Fix conceivable UAF of the bufferevent in evhttp_connection_free() (6ac2ec25)
+  o Merge branch 'http-request-line-parsing' (cdcfbafe)
   o Fix evhttp_connection_get_addr() fox incomming http connections (4215c003)
-  o fix leaks in evhttp_uriencode() (123362e9g)
+  o fix leaks in evhttp_uriencode() (123362e9)
   o CONNECT method only takes an authority (7d1ffe64)
-  o Allow bodies for GET/DELETE/OPTIONS/CONNECT (23eb38b9g)
+  o Allow bodies for GET/DELETE/OPTIONS/CONNECT (23eb38b9)
   o Do not crash when evhttp_send_reply_start() is called after a timeout. (826f1134)
-  o Fix crashing http server when callback do not reply in place (5b40744dg, b2581380g)
-  o fix handling of close_notify (ssl) in http with openssl bufferevents (7e91622bg)
+  o Fix crashing http server when callback do not reply in place (5b40744d, b2581380)
+  o fix handling of close_notify (ssl) in http with openssl bufferevents (7e91622b)
 
  evrpc:
-  o use *_new_with_arg() to match function prototype (a95cc9e3g)
-  o avoid NULL dereference on request is not EVHTTP_REQ_POST (e05136c7g)
+  o use *_new_with_arg() to match function prototype (a95cc9e3)
+  o avoid NULL dereference on request is not EVHTTP_REQ_POST (e05136c7)
 
  regression tests:
-  o Merge branch 'TT_RETRIABLE' (6ea1ec68g, f9b592aag)
+  o Merge branch 'TT_RETRIABLE' (6ea1ec68, f9b592aa)
 
  bufferevent:
-  o Merge branch 'iocp-fixes' (6bfac964g)
-  o Merge branch 'be-wm-overrun-v2' (3f692fffg)
+  o Merge branch 'iocp-fixes' (6bfac964)
+  o Merge branch 'be-wm-overrun-v2' (3f692fff)
   o bufferevent_socket_connect{,_hostname}() missing event callback and use ret code (1dde74ef)
   o don't fail be_null_filter if bytes are copied (b92b0792)
   o Call underlying bev ctrl GET_FD on filtered bufferevents (ebfac517)
 
  bufferevent_openssl/openssl:
-  o Merge branch 'ssl_bufferevent_wm_filter-fix' (30020a35g)
-  o be_openssl: avoid leaking of SSL structure (e86ccfe5g)
+  o Merge branch 'ssl_bufferevent_wm_filter-fix' (30020a35)
+  o be_openssl: avoid leaking of SSL structure (e86ccfe5)
   o Fix build with LibreSSL 2.7 (894ca48a)
-  o Add missing includes into openssl-compat.h (01bc36c1g)
+  o Add missing includes into openssl-compat.h (01bc36c1)
   o Explicitly call SSL_clear when reseting the fd. (29b7a516)
   o Unbreak build with LibreSSL after openssl 1.1 support added (230af9f0)
 
  samples:
-  o Merge branch 'sample-http-server' (b6309bccg)
+  o Merge branch 'sample-http-server' (b6309bcc)
   o sample/https-client: use host SSL certificate store by default (5c0132f3)
 
  listener:
   o ipv6only socket bind support (ba148796)
-  o Merge branch 'listener-immediate-close' (df2ed13fg)
-  o Merge branch 'evconnlistener-do-not-close-client-fd' (42e851bbg)
+  o Merge branch 'listener-immediate-close' (df2ed13f)
+  o Merge branch 'evconnlistener-do-not-close-client-fd' (42e851bb)
 
  evdns:
   o evdns: handle NULL filename explicitly (0033f5cc)
-  o Merge branch 'evdns_getaddrinfo-race-fix' (3237d697g)
+  o Merge branch 'evdns_getaddrinfo-race-fix' (3237d697)
   o Generating evdns_base_config_windows_nameservers docs on all platforms (3bd2ce43)
 
  utils:
-  o Merge branch 'evutil_found_ifaddr-dev' (b07e43e6g)
+  o Merge branch 'evutil_found_ifaddr-dev' (b07e43e6)
   o Avoid possible SEGVs in select() (in unit tests) (8818c86c)
   o Port `event_rpcgen.py` and `test/check-dumpevents.py` to Python 3. (532a8cc3)
 
  buffer:
   o Fix assert() condition in evbuffer_drain() for IOCP (d6326104)
-  o fix incorrect unlock of the buffer mutex (for deferred callbacks) (2b4d127dg)
-  o Fix wrong assert in evbuffer_drain() (9f4d0dceg)
+  o fix incorrect unlock of the buffer mutex (for deferred callbacks) (2b4d127d)
+  o Fix wrong assert in evbuffer_drain() (9f4d0dce)
 
  cmake:
   o fix checking of devpoll backend (like in autotools, by devpoll.h existence) (7f161902)
   o support static runtime (MSVC) (c8b3ec17, 61fb055a)
-  o do not build both (SHARED and STATIC) for MSVC/win32 (bc7f2fd9g)
-  o introduce EVENT__LIBRARY_TYPE option (eb10a738g)
+  o do not build both (SHARED and STATIC) for MSVC/win32 (bc7f2fd9)
+  o introduce EVENT__LIBRARY_TYPE option (eb10a738)
   o ensure windows dll's are installed as well as lib files (29590718)
   o Fix generation of LibeventConfig.cmake for the installation tree (7fa08c4b)
-  o fix pkgconfig generation (copy-paste typo) (cc554d87g)
-  o Merge branch 'cmake-missing-bits' (9806b126g)
+  o fix pkgconfig generation (copy-paste typo) (cc554d87)
+  o Merge branch 'cmake-missing-bits' (9806b126)
   o Fix detection of timerfd_create() in CMake. (e50af331)
-  o Merge branch 'cmake-configure-fixes-v2' (a0bfe2c4g)
-  o Do not add epoll_sub (syscall wrappers) for epoll in cmake (cea61de6g)
+  o Merge branch 'cmake-configure-fixes-v2' (a0bfe2c4)
+  o Do not add epoll_sub (syscall wrappers) for epoll in cmake (cea61de6)
   o Fix RPATH for APPLE (45b1f379)
 
  autotools:
-  o include win32 specific headers for socklen_t detection on win32/mingw (d7579fb9g)
-  o Ignore evconfig-private.h for autotools (37423849g)
+  o include win32 specific headers for socklen_t detection on win32/mingw (d7579fb9)
+  o Ignore evconfig-private.h for autotools (37423849)
   o config.h can't be prefixed unconditionally (63a054f8)
-  o Merge branch 'pull-628' (7e56c8b2g)
+  o Merge branch 'pull-628' (7e56c8b2)
   o Provide Makefile variables LIBEVENT_{CFLAGS,CPPFLAGS,LDFLAGS} (2f060c5f)
   o confirm openssl is working before using (b39ccf8e)
   o pass $(OPENSSL_INCS) for samples (FTBFS macOS) (c2495265)
@@ -122,10 +122,10 @@ Changes in version 2.1.9-beta (10 February 2019)
   o Fix tests with detached builds (c46ff439)
 
  build:
-  o Fix arc4random_addrandom() detecting and fallback (regression) (303d6d77g)
-  o Merge branch 'win32-fixes' (ebd12e6dg)
-  o Merge branch 'fix-openssl-linking' (e7bd9e03g)
-  o Merge branch 'fix-struct-linger' (8567f2f5g)
+  o Fix arc4random_addrandom() detecting and fallback (regression) (303d6d77)
+  o Merge branch 'win32-fixes' (ebd12e6d)
+  o Merge branch 'fix-openssl-linking' (e7bd9e03)
+  o Merge branch 'fix-struct-linger' (8567f2f5)
 
  CI:
   o travis-ci/appveyor now uses fast_finish+allow_failures


### PR DESCRIPTION
I tried looking up one commit of interest, failed to find it, then after a minute realized "wait ... there's no g in hex!"

By the way, thanks for preparing this release!