### PR TITLE
[draft] dtrace / USDT support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,9 @@ option(EVENT__DISABLE_CLOCK_GETTIME
 option(EVENT__FORCE_KQUEUE_CHECK
     "When crosscompiling forces running a test program that verifies that Kqueue works with pipes. Note that this requires you to manually run the test program on the cross compilation target to verify that it works. See cmake documentation for try_run for more details" OFF)
 
+option(EVENT__DISABLE_DTRACE
+    "Disable DTRACE hooks" OFF)
+
 # TODO: Add --disable-largefile     omit support for large files
 option(EVENT__COVERAGE
 "Enable running gcov to get a test coverage report (only works with GCC/CLang). Make sure to enable -DCMAKE_BUILD_TYPE=Debug as well." OFF)
@@ -923,6 +926,14 @@ if (WIN32)
     list(APPEND WIN32_GETOPT
          WIN32-Code/getopt.c
          WIN32-Code/getopt_long.c)
+endif()
+
+if (NOT EVENT__DISABLE_DTRACE)
+    CHECK_INCLUDE_FILE(sys/sdt.h EVENT__HAVE_DTRACE)
+
+    if (NOT EVENT__HAVE_DTRACE)
+        set (EVENT__DISABLE_DTRACE ON)
+    endif()
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ option(EVENT__DISABLE_CLOCK_GETTIME
 option(EVENT__FORCE_KQUEUE_CHECK
     "When crosscompiling forces running a test program that verifies that Kqueue works with pipes. Note that this requires you to manually run the test program on the cross compilation target to verify that it works. See cmake documentation for try_run for more details" OFF)
 
-option(EVENT__DISABLE_DTRACE
+option(EVENT__ENABLE_DTRACE
     "Disable DTRACE hooks" OFF)
 
 # TODO: Add --disable-largefile     omit support for large files
@@ -928,11 +928,12 @@ if (WIN32)
          WIN32-Code/getopt_long.c)
 endif()
 
-if (NOT EVENT__DISABLE_DTRACE)
+if (EVENT__ENABLE_DTRACE)
     CHECK_INCLUDE_FILE(sys/sdt.h EVENT__HAVE_DTRACE)
 
     if (NOT EVENT__HAVE_DTRACE)
-        set (EVENT__DISABLE_DTRACE ON)
+        set (EVENT__ENABLE_DTRACE OFF)
+        message(WARNING "DTRACE is disabled")
     endif()
 endif()
 

--- a/README.dtrace.md
+++ b/README.dtrace.md
@@ -19,25 +19,78 @@ You should see output histograms like:
 
 ```
 sudo bpftrace ./libevent.bt 
-Attaching 6 probes...
-Tracing libevent loop/dispatch latencies
-@loop_dispatch_lat[15208]: 
-[1]                    8 |                                                    |
-[2, 4)               323 |@@@@@@@@@@@@@@@@                                    |
-[4, 8)                19 |                                                    |
-[8, 16)               31 |@                                                   |
-[16, 32)            1009 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
-[32, 64)              10 |                                                    |
+event_base_loop inner-dispatch latency
+@dispatch_latency[94474611720864]:
+[1]                  157 |@@@@@                                               |
+[2, 4)               259 |@@@@@@@@@                                           |
+[4, 8)                16 |                                                    |
+[8, 16)               37 |@                                                   |
+[16, 32)            1382 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[32, 64)              28 |@                                                   |
+[64, 128)              3 |                                                    |
 
-event loop process_active latencies
-@loop_process_active_lat[15208]: 
-[8, 16)                9 |                                                    |
-[16, 32)             153 |@@@@@@@                                             |
-[32, 64)             174 |@@@@@@@@@                                           |
+event_base_loop inner-process_active latency
+@proc_active_latency[94474611720864]:
+[4, 8)                92 |@@@                                                 |
+[8, 16)              197 |@@@@@@@                                             |
+[16, 32)             160 |@@@@@                                               |
+[32, 64)              11 |                                                    |
 [64, 128)              8 |                                                    |
-[128, 256)            25 |@                                                   |
-[256, 512)            21 |@                                                   |
-[512, 1K)           1004 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
-[1K, 2K)               6 |                                                    |
-[2K, 4K)               1 |                                                    |
+[128, 256)             8 |                                                    |
+[256, 512)             7 |                                                    |
+[512, 1K)           1398 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[1K, 2K)               2 |                                                    |
 ```
+
+This displays a histogram of latencies of the event-dispatch call (e.g.,
+epoll()), and the process_active dispatch (user callbacks).
+
+Here we can see that 1382 epoll calls averaged aroudn 16ns latency to execute,
+while process_active had 1398 calls between 512-1000ns.
+
+
+Other Noteworthy Probes
+================================
+/usr/local/lib/libevent.so libevent.so:bev_suspend_read___enter
+/usr/local/lib/libevent.so libevent.so:bev_suspend_read___return
+/usr/local/lib/libevent.so libevent.so:bev_unsuspend_read___enter
+/usr/local/lib/libevent.so libevent.so:bev_unsuspend_read___return
+/usr/local/lib/libevent.so libevent.so:bev_suspend_write___enter
+/usr/local/lib/libevent.so libevent.so:bev_suspend_write___return
+/usr/local/lib/libevent.so libevent.so:bev_unsuspend_write___enter
+/usr/local/lib/libevent.so libevent.so:bev_unsuspend_write___return
+/usr/local/lib/libevent.so libevent.so:bev_run_deferred_callbacks___enter
+/usr/local/lib/libevent.so libevent.so:assign__enter
+/usr/local/lib/libevent.so libevent.so:assign__return
+/usr/local/lib/libevent.so libevent.so:process_active_single_queue__enter
+/usr/local/lib/libevent.so libevent.so:process_active_single_queue__return
+/usr/local/lib/libevent.so libevent.so:process_active_single_queue___usercb_start
+/usr/local/lib/libevent.so libevent.so:process_active_single_queue___usercb_end
+/usr/local/lib/libevent.so libevent.so:base_loop___enter
+/usr/local/lib/libevent.so libevent.so:base_loop___start
+/usr/local/lib/libevent.so libevent.so:base_loop___dispatch___start
+/usr/local/lib/libevent.so libevent.so:base_loop___dispatch___end
+/usr/local/lib/libevent.so libevent.so:base_loop___timeout_proc_start
+/usr/local/lib/libevent.so libevent.so:base_loop___timeout_proc_end
+/usr/local/lib/libevent.so libevent.so:base_loop___end
+/usr/local/lib/libevent.so libevent.so:timeout_process__enter
+/usr/local/lib/libevent.so libevent.so:base_loop___process_active___start
+/usr/local/lib/libevent.so libevent.so:process_active___enter
+/usr/local/lib/libevent.so libevent.so:process_active___return
+/usr/local/lib/libevent.so libevent.so:base_loop___process_active___end
+/usr/local/lib/libevent.so libevent.so:timeout_process__return
+/usr/local/lib/libevent.so libevent.so:base_loop___return
+/usr/local/lib/libevent.so libevent.so:new__enter
+/usr/local/lib/libevent.so libevent.so:new__return
+/usr/local/lib/libevent.so libevent.so:free__enter
+/usr/local/lib/libevent.so libevent.so:free__return
+
+
+NOTES
+==================================
+
+`___` == space
+`___enter` == function entry
+`___return` == function return
+`___start` == start of operation/call
+`___end` == end of operation/call

--- a/README.dtrace.md
+++ b/README.dtrace.md
@@ -1,0 +1,43 @@
+To enable libevent DTRACE probes, 
+
+*WARNING* This has only been tested on linux using perf tools and bpftrace.
+
+Prereqs
+==============================
+1. Use linux (testing).
+2. Install systemtab SDT dev for proper dtrace macros (`sudo apt install systemtap-sdt-dev`)
+3. Add the cmake option `-DEVENT__ENABLE_DTRACE=ON`
+4. (optional) Install iovisor bcc tools.
+
+Testing
+==============================
+1. Install `bpftrace` https://github.com/iovisor/bpftrace
+2. Start up anything that is linked to /usr/local/lib/libevent.so
+3. run: `bpftrace ./libevent.bt`
+
+You should see output histograms like:
+
+```
+sudo bpftrace ./libevent.bt 
+Attaching 6 probes...
+Tracing libevent loop/dispatch latencies
+@loop_dispatch_lat[15208]: 
+[1]                    8 |                                                    |
+[2, 4)               323 |@@@@@@@@@@@@@@@@                                    |
+[4, 8)                19 |                                                    |
+[8, 16)               31 |@                                                   |
+[16, 32)            1009 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[32, 64)              10 |                                                    |
+
+event loop process_active latencies
+@loop_process_active_lat[15208]: 
+[8, 16)                9 |                                                    |
+[16, 32)             153 |@@@@@@@                                             |
+[32, 64)             174 |@@@@@@@@@                                           |
+[64, 128)              8 |                                                    |
+[128, 256)            25 |@                                                   |
+[256, 512)            21 |@                                                   |
+[512, 1K)           1004 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[1K, 2K)               6 |                                                    |
+[2K, 4K)               1 |                                                    |
+```

--- a/bufferevent.c
+++ b/bufferevent.c
@@ -68,19 +68,19 @@ bufferevent_suspend_read_(struct bufferevent *bufev, bufferevent_suspend_flags w
 {
 	struct bufferevent_private *bufev_private = BEV_UPCAST(bufev);
 
+	BEV_LOCK(bufev);
 #ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, bev_suspend_read___enter, bufev, what);
+	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME, bev_suspend_read___enter, bufev->ev_base, bufev, what);
 #endif
 
-	BEV_LOCK(bufev);
 	if (!bufev_private->read_suspended)
 		bufev->be_ops->disable(bufev, EV_READ);
 	bufev_private->read_suspended |= what;
-	BEV_UNLOCK(bufev);
 
 #ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, bev_suspend_read___return, bufev, what);
+	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME, bev_suspend_read___return, bufev->ev_base, bufev, what);
 #endif
+	BEV_UNLOCK(bufev);
 }
 
 void
@@ -88,19 +88,19 @@ bufferevent_unsuspend_read_(struct bufferevent *bufev, bufferevent_suspend_flags
 {
 	struct bufferevent_private *bufev_private = BEV_UPCAST(bufev);
 
+	BEV_LOCK(bufev);
 #ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, bev_unsuspend_read___enter, bufev, what);
+	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME, bev_unsuspend_read___enter, bufev->ev_base, bufev, what);
 #endif
 
-	BEV_LOCK(bufev);
 	bufev_private->read_suspended &= ~what;
 	if (!bufev_private->read_suspended && (bufev->enabled & EV_READ))
 		bufev->be_ops->enable(bufev, EV_READ);
-	BEV_UNLOCK(bufev);
 
 #ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, bev_unsuspend_read___return, bufev, what);
+	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME, bev_unsuspend_read___return, bufev->ev_base, bufev, what);
 #endif
+	BEV_UNLOCK(bufev);
 }
 
 void
@@ -108,19 +108,19 @@ bufferevent_suspend_write_(struct bufferevent *bufev, bufferevent_suspend_flags 
 {
 	struct bufferevent_private *bufev_private = BEV_UPCAST(bufev);
 
+	BEV_LOCK(bufev);
 #ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, bev_suspend_write___enter, bufev, what);
+	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME, bev_suspend_write___enter, bufev->ev_base, bufev, what);
 #endif
 
-	BEV_LOCK(bufev);
 	if (!bufev_private->write_suspended)
 		bufev->be_ops->disable(bufev, EV_WRITE);
 	bufev_private->write_suspended |= what;
-	BEV_UNLOCK(bufev);
 
 #ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, bev_suspend_write___return, bufev, what);
+	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME, bev_suspend_write___return, bufev->ev_base, bufev, what);
 #endif
+	BEV_UNLOCK(bufev);
 }
 
 void
@@ -128,19 +128,19 @@ bufferevent_unsuspend_write_(struct bufferevent *bufev, bufferevent_suspend_flag
 {
 	struct bufferevent_private *bufev_private = BEV_UPCAST(bufev);
 
+	BEV_LOCK(bufev);
 #ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, bev_unsuspend_write___enter, bufev, what);
+	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME, bev_unsuspend_write___enter, bufev->ev_base, bufev, what);
 #endif
 
-	BEV_LOCK(bufev);
 	bufev_private->write_suspended &= ~what;
 	if (!bufev_private->write_suspended && (bufev->enabled & EV_WRITE))
 		bufev->be_ops->enable(bufev, EV_WRITE);
-	BEV_UNLOCK(bufev);
 
 #ifdef  EVENT__ENABLE_DTRACE
-	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, bev_unsuspend_write___return, bufev, what);
+	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME, bev_unsuspend_write___return, bufev->ev_base, bufev, what);
 #endif
+	BEV_UNLOCK(bufev);
 }
 
 /**
@@ -190,12 +190,12 @@ bufferevent_run_deferred_callbacks_locked(struct event_callback *cb, void *arg)
 	struct bufferevent_private *bufev_private = arg;
 	struct bufferevent *bufev = &bufev_private->bev;
 
+	BEV_LOCK(bufev);
 #ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME,
-			bev_run_deferred_callbacks___enter, cb, bufev);
+	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME,
+			bev_run_deferred_callbacks___enter, bufev->ev_base, cb, bufev);
 #endif
 
-	BEV_LOCK(bufev);
 	if ((bufev_private->eventcb_pending & BEV_EVENT_CONNECTED) &&
 	    bufev->errorcb) {
 		/* The "connected" happened before any reads or writes, so

--- a/bufferevent.c
+++ b/bufferevent.c
@@ -27,6 +27,7 @@
 
 #include "event2/event-config.h"
 #include "evconfig-private.h"
+#include "dtrace-internal.h"
 
 #include <sys/types.h>
 

--- a/bufferevent.c
+++ b/bufferevent.c
@@ -46,14 +46,6 @@
 #include <winsock2.h>
 #endif
 
-
-#ifdef EVENT__ENABLE_DTRACE
-#include <sys/sdt.h>
-#ifndef EVENT__DTRACE_PVDR_NAME
-#define EVENT__DTRACE_PVDR_NAME libevent.so
-#endif
-#endif
-
 #include "event2/util.h"
 #include "event2/buffer.h"
 #include "event2/buffer_compat.h"

--- a/bufferevent.c
+++ b/bufferevent.c
@@ -46,6 +46,14 @@
 #include <winsock2.h>
 #endif
 
+
+#ifdef EVENT__ENABLE_DTRACE
+#include <sys/sdt.h>
+#ifndef EVENT__DTRACE_PVDR_NAME
+#define EVENT__DTRACE_PVDR_NAME libevent.so
+#endif
+#endif
+
 #include "event2/util.h"
 #include "event2/buffer.h"
 #include "event2/buffer_compat.h"
@@ -67,44 +75,80 @@ void
 bufferevent_suspend_read_(struct bufferevent *bufev, bufferevent_suspend_flags what)
 {
 	struct bufferevent_private *bufev_private = BEV_UPCAST(bufev);
+
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, bev_suspend_read___enter, bufev, what);
+#endif
+
 	BEV_LOCK(bufev);
 	if (!bufev_private->read_suspended)
 		bufev->be_ops->disable(bufev, EV_READ);
 	bufev_private->read_suspended |= what;
 	BEV_UNLOCK(bufev);
+
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, bev_suspend_read___return, bufev, what);
+#endif
 }
 
 void
 bufferevent_unsuspend_read_(struct bufferevent *bufev, bufferevent_suspend_flags what)
 {
 	struct bufferevent_private *bufev_private = BEV_UPCAST(bufev);
+
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, bev_unsuspend_read___enter, bufev, what);
+#endif
+
 	BEV_LOCK(bufev);
 	bufev_private->read_suspended &= ~what;
 	if (!bufev_private->read_suspended && (bufev->enabled & EV_READ))
 		bufev->be_ops->enable(bufev, EV_READ);
 	BEV_UNLOCK(bufev);
+
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, bev_unsuspend_read___return, bufev, what);
+#endif
 }
 
 void
 bufferevent_suspend_write_(struct bufferevent *bufev, bufferevent_suspend_flags what)
 {
 	struct bufferevent_private *bufev_private = BEV_UPCAST(bufev);
+
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, bev_suspend_write___enter, bufev, what);
+#endif
+
 	BEV_LOCK(bufev);
 	if (!bufev_private->write_suspended)
 		bufev->be_ops->disable(bufev, EV_WRITE);
 	bufev_private->write_suspended |= what;
 	BEV_UNLOCK(bufev);
+
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, bev_suspend_write___return, bufev, what);
+#endif
 }
 
 void
 bufferevent_unsuspend_write_(struct bufferevent *bufev, bufferevent_suspend_flags what)
 {
 	struct bufferevent_private *bufev_private = BEV_UPCAST(bufev);
+
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, bev_unsuspend_write___enter, bufev, what);
+#endif
+
 	BEV_LOCK(bufev);
 	bufev_private->write_suspended &= ~what;
 	if (!bufev_private->write_suspended && (bufev->enabled & EV_WRITE))
 		bufev->be_ops->enable(bufev, EV_WRITE);
 	BEV_UNLOCK(bufev);
+
+#ifdef  EVENT__ENABLE_DTRACE
+	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, bev_unsuspend_write___return, bufev, what);
+#endif
 }
 
 /**
@@ -153,6 +197,11 @@ bufferevent_run_deferred_callbacks_locked(struct event_callback *cb, void *arg)
 {
 	struct bufferevent_private *bufev_private = arg;
 	struct bufferevent *bufev = &bufev_private->bev;
+
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME,
+			bev_run_deferred_callbacks___enter, cb, bufev);
+#endif
 
 	BEV_LOCK(bufev);
 	if ((bufev_private->eventcb_pending & BEV_EVENT_CONNECTED) &&

--- a/bufferevent.c
+++ b/bufferevent.c
@@ -27,7 +27,6 @@
 
 #include "event2/event-config.h"
 #include "evconfig-private.h"
-#include "dtrace-internal.h"
 
 #include <sys/types.h>
 
@@ -60,6 +59,7 @@
 #include "bufferevent-internal.h"
 #include "evbuffer-internal.h"
 #include "util-internal.h"
+#include "dtrace-internal.h"
 
 static void bufferevent_cancel_all_(struct bufferevent *bev);
 static void bufferevent_finalize_cb_(struct event_callback *evcb, void *arg_);
@@ -70,17 +70,15 @@ bufferevent_suspend_read_(struct bufferevent *bufev, bufferevent_suspend_flags w
 	struct bufferevent_private *bufev_private = BEV_UPCAST(bufev);
 
 	BEV_LOCK(bufev);
-#ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME, bev_suspend_read___enter, bufev->ev_base, bufev, what);
-#endif
+
+	EVENT__PROBE(bev_suspend_read___enter, 3, bufev->ev_base, bufev, what);
 
 	if (!bufev_private->read_suspended)
 		bufev->be_ops->disable(bufev, EV_READ);
 	bufev_private->read_suspended |= what;
 
-#ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME, bev_suspend_read___return, bufev->ev_base, bufev, what);
-#endif
+	EVENT__PROBE(bev_suspend_read___return, 3, bufev->ev_base, bufev, what);
+
 	BEV_UNLOCK(bufev);
 }
 
@@ -90,17 +88,15 @@ bufferevent_unsuspend_read_(struct bufferevent *bufev, bufferevent_suspend_flags
 	struct bufferevent_private *bufev_private = BEV_UPCAST(bufev);
 
 	BEV_LOCK(bufev);
-#ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME, bev_unsuspend_read___enter, bufev->ev_base, bufev, what);
-#endif
+
+	EVENT__PROBE(bev_unsuspend_read___enter, 3, bufev->ev_base, bufev, what);
 
 	bufev_private->read_suspended &= ~what;
 	if (!bufev_private->read_suspended && (bufev->enabled & EV_READ))
 		bufev->be_ops->enable(bufev, EV_READ);
 
-#ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME, bev_unsuspend_read___return, bufev->ev_base, bufev, what);
-#endif
+	EVENT__PROBE(bev_unsuspend_read___return, 3, bufev->ev_base, bufev, what);
+
 	BEV_UNLOCK(bufev);
 }
 
@@ -110,17 +106,15 @@ bufferevent_suspend_write_(struct bufferevent *bufev, bufferevent_suspend_flags 
 	struct bufferevent_private *bufev_private = BEV_UPCAST(bufev);
 
 	BEV_LOCK(bufev);
-#ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME, bev_suspend_write___enter, bufev->ev_base, bufev, what);
-#endif
+
+	EVENT__PROBE(bev_suspend_write___enter, 3, bufev->ev_base, bufev, what);
 
 	if (!bufev_private->write_suspended)
 		bufev->be_ops->disable(bufev, EV_WRITE);
 	bufev_private->write_suspended |= what;
 
-#ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME, bev_suspend_write___return, bufev->ev_base, bufev, what);
-#endif
+	EVENT__PROBE(bev_suspend_write___return, 3, bufev->ev_base, bufev, what);
+
 	BEV_UNLOCK(bufev);
 }
 
@@ -130,17 +124,15 @@ bufferevent_unsuspend_write_(struct bufferevent *bufev, bufferevent_suspend_flag
 	struct bufferevent_private *bufev_private = BEV_UPCAST(bufev);
 
 	BEV_LOCK(bufev);
-#ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME, bev_unsuspend_write___enter, bufev->ev_base, bufev, what);
-#endif
+
+	EVENT__PROBE(bev_unsuspend_write___enter, 3, bufev->ev_base, bufev, what);
 
 	bufev_private->write_suspended &= ~what;
 	if (!bufev_private->write_suspended && (bufev->enabled & EV_WRITE))
 		bufev->be_ops->enable(bufev, EV_WRITE);
 
-#ifdef  EVENT__ENABLE_DTRACE
-	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME, bev_unsuspend_write___return, bufev->ev_base, bufev, what);
-#endif
+	EVENT__PROBE(bev_unsuspend_write___return, 3, bufev->ev_base, bufev, what);
+
 	BEV_UNLOCK(bufev);
 }
 
@@ -192,10 +184,8 @@ bufferevent_run_deferred_callbacks_locked(struct event_callback *cb, void *arg)
 	struct bufferevent *bufev = &bufev_private->bev;
 
 	BEV_LOCK(bufev);
-#ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE3(EVENT__DTRACE_PVDR_NAME,
-			bev_run_deferred_callbacks___enter, bufev->ev_base, cb, bufev);
-#endif
+
+	EVENT__PROBE(bev_run_deferred_callbacks___enter, 3, bufev->ev_base, cb, bufev);
 
 	if ((bufev_private->eventcb_pending & BEV_EVENT_CONNECTED) &&
 	    bufev->errorcb) {
@@ -221,7 +211,11 @@ bufferevent_run_deferred_callbacks_locked(struct event_callback *cb, void *arg)
 		EVUTIL_SET_SOCKET_ERROR(err);
 		bufev->errorcb(bufev, what, bufev->cbarg);
 	}
+
+	EVENT__PROBE(bev_run_deferred_callbacks___return, 3, bufev->ev_base, cb, bufev);
+
 	bufferevent_decref_and_unlock_(bufev);
+	
 }
 
 static void

--- a/configure.ac
+++ b/configure.ac
@@ -125,6 +125,9 @@ AC_ARG_ENABLE([clock-gettime],
      AS_HELP_STRING(--disable-clock-gettime, do not use clock_gettime even if it is available),
   [], [enable_clock_gettime=yes])
 
+AC_ARG_ENABLE([dtrace],
+              AS_HELP_STRING(--enable-dtrace, enable dtrace support),
+              [], [enable_dtrace=no])
 
 AC_PROG_LIBTOOL
 
@@ -772,6 +775,12 @@ if test x$bwin32 != xtrue && test "$enable_thread_support" != "no"; then
 fi
 AM_CONDITIONAL(THREADS, [test "$enable_thread_support" != "no"])
 AM_CONDITIONAL(PTHREADS, [test "$have_pthreads" != "no" && test "$enable_thread_support" != "no"])
+
+# check if we should enable dtrace support in the library
+if test x$enable_dtrace = xyes; then
+    AC_DEFINE(ENABLE_DTRACE, 1,
+     [Define if libevent should be compiled with dtrace support])
+fi
 
 # check if we should compile locking into the library
 if test x$enable_thread_support = xno; then

--- a/dtrace-internal.h
+++ b/dtrace-internal.h
@@ -1,0 +1,23 @@
+#ifndef EVENT2_DTRACE_H_INCLUDED_
+#define EVENT2_DTRACE_H_INCLUDED_
+
+#ifdef EVENT__ENABLE_DTRACE
+
+#include <sys/sdt.h>
+
+#ifndef EVENT__DTRACE_PVDR_NAME
+#define EVENT__DTRACE_PVDR_NAME libevent.so
+#endif
+
+#define EVENT__PROBE(name, n, ...) \
+    EVENT__PROBE_1(EVENT__DTRACE_PVDR_NAME, name, n, ## __VA_ARGS__)
+
+#define EVENT__PROBE_1(lib, name, n, ...) \
+    DTRACE_PROBE ## n(lib, name, ## __VA_ARGS__)
+
+#define EVENT__PROBE0 DTRACE_PROBE
+#else
+#define EVENT_PROBE(name, n, ...)
+#endif
+
+#endif

--- a/dtrace-internal.h
+++ b/dtrace-internal.h
@@ -17,7 +17,7 @@
 
 #define EVENT__PROBE0 DTRACE_PROBE
 #else
-#define EVENT_PROBE(name, n, ...)
+#define EVENT__PROBE(name, n, ...)
 #endif
 
 #endif

--- a/event-config.h.cmake
+++ b/event-config.h.cmake
@@ -495,4 +495,6 @@
 /* Define to `int' if <sys/types.h> does not define. */
 #define EVENT__ssize_t @EVENT__ssize_t@
 
+#cmakedefine EVENT__DISABLE_DTRACE
+
 #endif /* \EVENT2_EVENT_CONFIG_H_INCLUDED_ */

--- a/event-config.h.cmake
+++ b/event-config.h.cmake
@@ -497,12 +497,4 @@
 
 #cmakedefine EVENT__ENABLE_DTRACE
 
-#ifdef EVENT__ENABLE_DTRACE
-#include <sys/sdt.h>
-#ifndef EVENT__DTRACE_PVDR_NAME
-#define EVENT__DTRACE_PVDR_NAME libevent.so
-#endif
-#endif
-
-
 #endif /* \EVENT2_EVENT_CONFIG_H_INCLUDED_ */

--- a/event-config.h.cmake
+++ b/event-config.h.cmake
@@ -497,4 +497,12 @@
 
 #cmakedefine EVENT__ENABLE_DTRACE
 
+#ifdef EVENT__ENABLE_DTRACE
+#include <sys/sdt.h>
+#ifndef EVENT__DTRACE_PVDR_NAME
+#define EVENT__DTRACE_PVDR_NAME libevent.so
+#endif
+#endif
+
+
 #endif /* \EVENT2_EVENT_CONFIG_H_INCLUDED_ */

--- a/event-config.h.cmake
+++ b/event-config.h.cmake
@@ -495,6 +495,6 @@
 /* Define to `int' if <sys/types.h> does not define. */
 #define EVENT__ssize_t @EVENT__ssize_t@
 
-#cmakedefine EVENT__DISABLE_DTRACE
+#cmakedefine EVENT__ENABLE_DTRACE
 
 #endif /* \EVENT2_EVENT_CONFIG_H_INCLUDED_ */

--- a/event.c
+++ b/event.c
@@ -27,13 +27,6 @@
 #include "event2/event-config.h"
 #include "evconfig-private.h"
 
-#ifdef EVENT__ENABLE_DTRACE
-#include <sys/sdt.h>
-#ifndef EVENT__DTRACE_PVDR_NAME 
-#define EVENT__DTRACE_PVDR_NAME libevent.so
-#endif
-#endif
-
 #ifdef _WIN32
 #include <winsock2.h>
 #define WIN32_LEAN_AND_MEAN

--- a/event.c
+++ b/event.c
@@ -2191,10 +2191,19 @@ event_assign(struct event *ev, struct event_base *base, evutil_socket_t fd, shor
 	ev->ev_ncalls = 0;
 	ev->ev_pncalls = NULL;
 
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE6(EVENT__DTRACE_PVDR_NAME, assign__enter,
+			ev, base, fd, events, callback, arg);
+#endif
+
 	if (events & EV_SIGNAL) {
 		if ((events & (EV_READ|EV_WRITE|EV_CLOSED)) != 0) {
 			event_warnx("%s: EV_SIGNAL is not compatible with "
 			    "EV_READ, EV_WRITE or EV_CLOSED", __func__);
+#ifdef EVENT__ENABLE_DTRACE
+			DTRACE_PROBE7(EVENT__DTRACE_PVDR_NAME, assign__return,
+				ev, base, fd, events, callback, arg, -1); 
+#endif
 			return -1;
 		}
 		ev->ev_closure = EV_CLOSURE_EVENT_SIGNAL;
@@ -2215,6 +2224,11 @@ event_assign(struct event *ev, struct event_base *base, evutil_socket_t fd, shor
 	}
 
 	event_debug_note_setup_(ev);
+
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE7(EVENT__DTRACE_PVDR_NAME, assign__return,
+		ev, base, fd, events, callback, arg, 0); 
+#endif
 
 	return 0;
 }

--- a/event.c
+++ b/event.c
@@ -29,6 +29,9 @@
 
 #ifdef EVENT__ENABLE_DTRACE
 #include <sys/sdt.h>
+#ifndef EVENT__DTRACE_PVDR_NAME 
+#define EVENT__DTRACE_PVDR_NAME libevent.so
+#endif
 #endif
 
 #ifdef _WIN32
@@ -1772,7 +1775,7 @@ event_process_active(struct event_base *base)
 	const int limit_after_prio = base->limit_callbacks_after_prio;
 
 #ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE1(libevent, process_active___enter, base);
+	DTRACE_PROBE1(EVENT__DTRACE_PVDR_NAME, process_active___enter, base);
 #endif
 
 	if (base->max_dispatch_time.tv_sec >= 0) {
@@ -1808,7 +1811,7 @@ done:
 	base->event_running_priority = -1;
 
 #ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE2(libevent, process_active___return, base, c);
+	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, process_active___return, base, c);
 #endif
 	return c;
 }
@@ -1981,7 +1984,7 @@ event_base_loop(struct event_base *base, int flags)
 		tv_p = &tv;
 
 #ifdef EVENT__ENABLE_DTRACE
-		DTRACE_PROBE1(libevent, base_loop___start, base);
+		DTRACE_PROBE1(EVENT__DTRACE_PVDR_NAME, base_loop___start, base);
 #endif
 
 		if (!N_ACTIVE_CALLBACKS(base) && !(flags & EVLOOP_NONBLOCK)) {
@@ -2007,13 +2010,13 @@ event_base_loop(struct event_base *base, int flags)
 		clear_time_cache(base);
 
 #ifdef EVENT__ENABLE_DTRACE
-		DTRACE_PROBE2(libevent, base_loop___dispatch___start, base, evsel->name);
+		DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, base_loop___dispatch___start, base, evsel->name);
 #endif
 
 		res = evsel->dispatch(base, tv_p);
 
 #ifdef EVENT__ENABLE_DTRACE
-		DTRACE_PROBE2(libevent, base_loop___dispatch___end, base, res);
+		DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, base_loop___dispatch___end, base, res);
 #endif
 
 		if (res == -1) {
@@ -2030,13 +2033,13 @@ event_base_loop(struct event_base *base, int flags)
 		if (N_ACTIVE_CALLBACKS(base)) {
 			int n;
 #ifdef EVENT__ENABLE_DTRACE
-			DTRACE_PROBE1(libevent, base_loop___process_active___start, base);
+			DTRACE_PROBE1(EVENT__DTRACE_PVDR_NAME, base_loop___process_active___start, base);
 #endif
 
 			n = event_process_active(base);
 
 #ifdef EVENT__ENABLE_DTRACE
-			DTRACE_PROBE2(libevent, base_loop___process_active___end, base, n);
+			DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, base_loop___process_active___end, base, n);
 #endif
 
 			if ((flags & EVLOOP_ONCE)
@@ -2047,7 +2050,7 @@ event_base_loop(struct event_base *base, int flags)
 			done = 1;
 
 #ifdef EVENT__ENABLE_DTRACE
-		DTRACE_PROBE1(libevent, base_loop___end, base);
+		DTRACE_PROBE1(EVENT__DTRACE_PVDR_NAME, base_loop___end, base);
 #endif
 	}
 	event_debug(("%s: asked to terminate loop.", __func__));

--- a/event.c
+++ b/event.c
@@ -1701,7 +1701,19 @@ event_process_active_single_queue(struct event_base *base,
 			evcb_callback = *ev->ev_callback;
 			res = ev->ev_res;
 			EVBASE_RELEASE_LOCK(base, th_base_lock);
+#ifdef EVENT__ENABLE_DTRACE
+			DTRACE_PROBE5(EVENT__DTRACE_PVDR_NAME, 
+					process_active_single_queue___usercb_start, 
+					base, ev, ev->ev_fd, res, ev->ev_arg);
+#endif
+
 			evcb_callback(ev->ev_fd, res, ev->ev_arg);
+
+#ifdef EVENT__ENABLE_DTRACE
+			DTRACE_PROBE5(EVENT__DTRACE_PVDR_NAME,
+					process_active_single_queue___usercb_end,
+					base, ev, ev->ev_fd, res, ev->ev_arg);
+#endif
 		}
 		break;
 		case EV_CLOSURE_CB_SELF: {

--- a/event.c
+++ b/event.c
@@ -2018,13 +2018,13 @@ event_base_loop(struct event_base *base, int flags)
 		timeout_process(base);
 
 		if (N_ACTIVE_CALLBACKS(base)) {
-            DTRACE_PROBE1(libevent, process_active_start, base);
+            DTRACE_PROBE2(libevent, process_active_start, N_ACTIVE_CALLBACKS(base), base);
 			int n = event_process_active(base);
 			if ((flags & EVLOOP_ONCE)
 			    && N_ACTIVE_CALLBACKS(base) == 0
 			    && n != 0)
 				done = 1;
-            DTRACE_PROBE1(libevent, process_active_end, base);
+            DTRACE_PROBE2(libevent, process_active_end, N_ACTIVE_CALLBACKS(base), base);
 		} else if (flags & EVLOOP_NONBLOCK)
 			done = 1;
 

--- a/event.c
+++ b/event.c
@@ -2033,7 +2033,7 @@ event_base_loop(struct event_base *base, int flags)
 			DTRACE_PROBE1(libevent, base_loop___process_active___start, base);
 #endif
 
-			event_process_active(base);
+			n = event_process_active(base);
 
 #ifdef EVENT__ENABLE_DTRACE
 			DTRACE_PROBE2(libevent, base_loop___process_active___end, base, n);

--- a/event.c
+++ b/event.c
@@ -27,7 +27,7 @@
 #include "event2/event-config.h"
 #include "evconfig-private.h"
 
-#ifndef EVENT__DISABLE_DTRACE 
+#ifdef EVENT__ENABLE_DTRACE
 #include <sys/sdt.h>
 #endif
 
@@ -1771,7 +1771,7 @@ event_process_active(struct event_base *base)
 	const int maxcb = base->max_dispatch_callbacks;
 	const int limit_after_prio = base->limit_callbacks_after_prio;
 
-#ifndef EVENT__DISABLE_DTRACE
+#ifdef EVENT__ENABLE_DTRACE
 	DTRACE_PROBE1(libevent, process_active___enter, base);
 #endif
 
@@ -1807,7 +1807,7 @@ event_process_active(struct event_base *base)
 done:
 	base->event_running_priority = -1;
 
-#ifndef EVENT__DISABLE_DTRACE
+#ifdef EVENT__ENABLE_DTRACE
 	DTRACE_PROBE2(libevent, process_active___return, base, c);
 #endif
 	return c;
@@ -1980,7 +1980,7 @@ event_base_loop(struct event_base *base, int flags)
 
 		tv_p = &tv;
 
-#ifndef EVENT__DISABLE_DTRACE
+#ifdef EVENT__ENABLE_DTRACE
 		DTRACE_PROBE1(libevent, base_loop___start, base);
 #endif
 
@@ -2006,13 +2006,13 @@ event_base_loop(struct event_base *base, int flags)
 
 		clear_time_cache(base);
 
-#ifndef EVENT__DISABLE_DTRACE
+#ifdef EVENT__ENABLE_DTRACE
 		DTRACE_PROBE2(libevent, base_loop___dispatch___start, base, evsel->name);
 #endif
 
 		res = evsel->dispatch(base, tv_p);
 
-#ifndef EVENT__DISABLE_DTRACE
+#ifdef EVENT__ENABLE_DTRACE
 		DTRACE_PROBE2(libevent, base_loop___dispatch___end, base, res);
 #endif
 
@@ -2028,13 +2028,14 @@ event_base_loop(struct event_base *base, int flags)
 		timeout_process(base);
 
 		if (N_ACTIVE_CALLBACKS(base)) {
-#ifndef EVENT__DISABLE_DTRACE
+			int n;
+#ifdef EVENT__ENABLE_DTRACE
 			DTRACE_PROBE1(libevent, base_loop___process_active___start, base);
 #endif
 
-			int n = event_process_active(base);
+			event_process_active(base);
 
-#ifndef EVENT__DISABLE_DTRACE
+#ifdef EVENT__ENABLE_DTRACE
 			DTRACE_PROBE2(libevent, base_loop___process_active___end, base, n);
 #endif
 
@@ -2045,7 +2046,7 @@ event_base_loop(struct event_base *base, int flags)
 		} else if (flags & EVLOOP_NONBLOCK)
 			done = 1;
 
-#ifndef EVENT__DISABLE_DTRACE
+#ifdef EVENT__ENABLE_DTRACE
 		DTRACE_PROBE1(libevent, base_loop___end, base);
 #endif
 	}

--- a/event.c
+++ b/event.c
@@ -1702,17 +1702,17 @@ event_process_active_single_queue(struct event_base *base,
 			res = ev->ev_res;
 			EVBASE_RELEASE_LOCK(base, th_base_lock);
 #ifdef EVENT__ENABLE_DTRACE
-			DTRACE_PROBE5(EVENT__DTRACE_PVDR_NAME, 
+			DTRACE_PROBE6(EVENT__DTRACE_PVDR_NAME, 
 					process_active_single_queue___usercb_start, 
-					base, ev, ev->ev_fd, res, ev->ev_arg);
+					base, ev, evcb_callback, ev->ev_fd, res, ev->ev_arg);
 #endif
 
 			evcb_callback(ev->ev_fd, res, ev->ev_arg);
 
 #ifdef EVENT__ENABLE_DTRACE
-			DTRACE_PROBE5(EVENT__DTRACE_PVDR_NAME,
+			DTRACE_PROBE6(EVENT__DTRACE_PVDR_NAME,
 					process_active_single_queue___usercb_end,
-					base, ev, ev->ev_fd, res, ev->ev_arg);
+					base, ev, evcb_callback, ev->ev_fd, res, ev->ev_arg);
 #endif
 		}
 		break;

--- a/event.c
+++ b/event.c
@@ -1772,7 +1772,7 @@ event_process_active(struct event_base *base)
 	const int limit_after_prio = base->limit_callbacks_after_prio;
 
 #ifndef EVENT__DISABLE_DTRACE
-	DTRACE_PROBE1(libevent, process_active::enter, base);
+	DTRACE_PROBE1(libevent, process_active___enter, base);
 #endif
 
 	if (base->max_dispatch_time.tv_sec >= 0) {
@@ -1808,7 +1808,7 @@ done:
 	base->event_running_priority = -1;
 
 #ifndef EVENT__DISABLE_DTRACE
-	DTRACE_PROBE2(libevent, process_active::return, base, c);
+	DTRACE_PROBE2(libevent, process_active___return, base, c);
 #endif
 	return c;
 }
@@ -1981,7 +1981,7 @@ event_base_loop(struct event_base *base, int flags)
 		tv_p = &tv;
 
 #ifndef EVENT__DISABLE_DTRACE
-		DTRACE_PROBE1(libevent, base_loop::start, base);
+		DTRACE_PROBE1(libevent, base_loop___start, base);
 #endif
 
 		if (!N_ACTIVE_CALLBACKS(base) && !(flags & EVLOOP_NONBLOCK)) {
@@ -2007,13 +2007,13 @@ event_base_loop(struct event_base *base, int flags)
 		clear_time_cache(base);
 
 #ifndef EVENT__DISABLE_DTRACE
-		DTRACE_PROBE2(libevent, base_loop::dispatch::start, base, evsel->name);
+		DTRACE_PROBE2(libevent, base_loop___dispatch___start, base, evsel->name);
 #endif
 
 		res = evsel->dispatch(base, tv_p);
 
 #ifndef EVENT__DISABLE_DTRACE
-		DTRACE_PROBE2(libevent, base_loop::dispatch::end, base, res);
+		DTRACE_PROBE2(libevent, base_loop___dispatch___end, base, res);
 #endif
 
 		if (res == -1) {
@@ -2029,13 +2029,13 @@ event_base_loop(struct event_base *base, int flags)
 
 		if (N_ACTIVE_CALLBACKS(base)) {
 #ifndef EVENT__DISABLE_DTRACE
-			DTRACE_PROBE1(libevent, base_loop::process_active::start, base);
+			DTRACE_PROBE1(libevent, base_loop___process_active___start, base);
 #endif
 
 			int n = event_process_active(base);
 
 #ifndef EVENT__DISABLE_DTRACE
-			DTRACE_PROBE2(libevent, base_loop::process_active::end, base, n);
+			DTRACE_PROBE2(libevent, base_loop___process_active___end, base, n);
 #endif
 
 			if ((flags & EVLOOP_ONCE)
@@ -2046,7 +2046,7 @@ event_base_loop(struct event_base *base, int flags)
 			done = 1;
 
 #ifndef EVENT__DISABLE_DTRACE
-		DTRACE_PROBE1(libevent, base_loop::end, base);
+		DTRACE_PROBE1(libevent, base_loop___end, base);
 #endif
 	}
 	event_debug(("%s: asked to terminate loop.", __func__));

--- a/event.c
+++ b/event.c
@@ -1647,6 +1647,12 @@ event_process_active_single_queue(struct event_base *base,
 
 	EVUTIL_ASSERT(activeq != NULL);
 
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE4(EVENT__DTRACE_PVDR_NAME,
+		process_active_single_queue__enter,
+		base, activeq, max_to_process, endtime);
+#endif
+
 	for (evcb = TAILQ_FIRST(activeq); evcb; evcb = TAILQ_FIRST(activeq)) {
 		struct event *ev=NULL;
 		if (evcb->evcb_flags & EVLIST_INIT) {
@@ -1754,6 +1760,12 @@ event_process_active_single_queue(struct event_base *base,
 		if (base->event_continue)
 			break;
 	}
+
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, 
+			process_active_single_queue__return, base, count); 
+#endif
+
 	return count;
 }
 

--- a/event.c
+++ b/event.c
@@ -2204,7 +2204,7 @@ event_assign(struct event *ev, struct event_base *base, evutil_socket_t fd, shor
 
 #ifdef EVENT__ENABLE_DTRACE
 	DTRACE_PROBE6(EVENT__DTRACE_PVDR_NAME, assign__enter,
-			ev, base, fd, events, callback, arg);
+			base, ev, fd, events, callback, arg);
 #endif
 
 	if (events & EV_SIGNAL) {
@@ -2213,7 +2213,7 @@ event_assign(struct event *ev, struct event_base *base, evutil_socket_t fd, shor
 			    "EV_READ, EV_WRITE or EV_CLOSED", __func__);
 #ifdef EVENT__ENABLE_DTRACE
 			DTRACE_PROBE7(EVENT__DTRACE_PVDR_NAME, assign__return,
-				ev, base, fd, events, callback, arg, -1); 
+				base, ev, fd, events, callback, arg, -1); 
 #endif
 			return -1;
 		}
@@ -2238,7 +2238,7 @@ event_assign(struct event *ev, struct event_base *base, evutil_socket_t fd, shor
 
 #ifdef EVENT__ENABLE_DTRACE
 	DTRACE_PROBE7(EVENT__DTRACE_PVDR_NAME, assign__return,
-		ev, base, fd, events, callback, arg, 0); 
+		base, ev, fd, events, callback, arg, 0); 
 #endif
 
 	return 0;
@@ -2323,7 +2323,8 @@ event_free(struct event *ev)
 	// event_debug_assert_is_setup_(ev);
 
 #ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE1(EVENT__DTRACE_PVDR_NAME, free__enter, ev);
+	struct event_base *base = ev->ev_base;
+	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, free__enter, base, ev);
 #endif
 
 	/* make sure that this event won't be coming back to haunt us. */
@@ -2332,7 +2333,7 @@ event_free(struct event *ev)
 	mm_free(ev);
 
 #ifdef EVENT__ENABLE_DTRACE
-	DTRACE_PROBE(EVENT__DTRACE_PVDR_NAME, free__return);
+	DTRACE_PROBE1(EVENT__DTRACE_PVDR_NAME, free__return, base);
 #endif
 }
 

--- a/event.c
+++ b/event.c
@@ -1942,6 +1942,10 @@ event_base_loop(struct event_base *base, int flags)
 	struct timeval *tv_p;
 	int res, done, retval = 0;
 
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, base_loop___enter, base, flags);
+#endif
+
 	/* Grab the lock.  We will release it inside evsel.dispatch, and again
 	 * as we invoke user callbacks. */
 	EVBASE_ACQUIRE_LOCK(base, th_base_lock);
@@ -2058,6 +2062,10 @@ event_base_loop(struct event_base *base, int flags)
 done:
 	clear_time_cache(base);
 	base->running_loop = 0;
+
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE2(EVENT__DTRACE_PVDR_NAME, base_loop___return, base, retval);
+#endif
 
 	EVBASE_RELEASE_LOCK(base, th_base_lock);
 

--- a/event.c
+++ b/event.c
@@ -2054,9 +2054,15 @@ event_base_loop(struct event_base *base, int flags)
 			goto done;
 		}
 
+#ifdef EVENT__ENABLE_DTRACE
+		DTRACE_PROBE1(EVENT__DTRACE_PVDR_NAME, base_loop___timeout_proc_start, base);
+#endif
 		update_time_cache(base);
-
 		timeout_process(base);
+
+#ifdef EVENT__ENABLE_DTRACE
+		DTRACE_PROBE1(EVENT__DTRACE_PVDR_NAME, base_loop___timeout_proc_end, base);
+#endif
 
 		if (N_ACTIVE_CALLBACKS(base)) {
 			int n;

--- a/event.c
+++ b/event.c
@@ -1758,9 +1758,7 @@ event_process_active_single_queue(struct event_base *base,
 			break;
 	}
 
-#ifdef EVENT__ENABLE_DTRACE
 	EVENT__PROBE(process_active_single_queue__return, 2, base, count); 
-#endif
 
 	return count;
 }

--- a/event.c
+++ b/event.c
@@ -2311,11 +2311,18 @@ event_free(struct event *ev)
 	 * valid target for event_free(). That's */
 	// event_debug_assert_is_setup_(ev);
 
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE1(EVENT__DTRACE_PVDR_NAME, free__enter, ev);
+#endif
+
 	/* make sure that this event won't be coming back to haunt us. */
 	event_del(ev);
 	event_debug_note_teardown_(ev);
 	mm_free(ev);
 
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE(EVENT__DTRACE_PVDR_NAME, free__return);
+#endif
 }
 
 void
@@ -3273,6 +3280,10 @@ timeout_process(struct event_base *base)
 		return;
 	}
 
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE1(EVENT__DTRACE_PVDR_NAME, timeout_process__enter, base);
+#endif
+
 	gettime(base, &now);
 
 	while ((ev = min_heap_top_(&base->timeheap))) {
@@ -3286,6 +3297,10 @@ timeout_process(struct event_base *base)
 			 ev, ev->ev_callback));
 		event_active_nolock_(ev, EV_TIMEOUT, 1);
 	}
+
+#ifdef EVENT__ENABLE_DTRACE
+	DTRACE_PROBE1(EVENT__DTRACE_PVDR_NAME, timeout_process__return, base);
+#endif
 }
 
 #ifndef MAX

--- a/libevent.bt
+++ b/libevent.bt
@@ -1,11 +1,6 @@
 // dtrace/bpftrace script for monitoring loop_dispatch / process_active latencies
 // run: sudo bpftrace ./libevent.bt
 
-struct event_base {
-    void * evsel;
-    void * base;
-};
-    
 
 BEGIN
 {
@@ -48,4 +43,45 @@ interval:s:5
     print(@loop_process_active_lat);
     clear(@loop_process_active_lat);
 }
+
+// delta timing totals
+
+usdt:/usr/local/lib/libevent.so:base_loop___dispatch___start
+{
+    @dispatches[arg0] = nsecs;
+}
+
+usdt:/usr/local/lib/libevent.so:base_loop___dispatch___end
+/ @dispatches[arg0] /
+{
+    $elapsed = (nsecs - @dispatches[arg0]);
+
+    @dispatch_total_time[arg0] = sum($elapsed);
+}
+    
+usdt:/usr/local/lib/libevent.so:base_loop___process_active___start
+{
+    @pactives[arg0] = nsecs;
+}
+
+usdt:/usr/local/lib/libevent.so:base_loop___process_active___end
+/ @pactives[arg0] /
+{
+    $delta = (nsecs - @pactives[arg0]);
+
+    @activation_total_time[arg0] = sum($delta);
+}
+
+usdt:/usr/local/lib/libevent.so:process_active_single_queue__enter
+{
+    @single_queues[arg0] = nsecs;
+}
+
+usdt:/usr/local/lib/libevent.so:process_active_single_queue__return
+{
+    $sdelta = (nsecs - @single_queues[arg0]);
+
+    @single_queues_total_time[arg0] = sum($sdelta);
+}
+    
 

--- a/libevent.bt
+++ b/libevent.bt
@@ -1,5 +1,12 @@
-# dtrace/bpftrace script for monitoring loop_dispatch / process_active latencies
-# run: sudo bpftrace ./libevent.bt
+// dtrace/bpftrace script for monitoring loop_dispatch / process_active latencies
+// run: sudo bpftrace ./libevent.bt
+
+struct event_base {
+    void * evsel;
+    void * base;
+};
+    
+
 BEGIN
 {
     printf("Tracing libevent loop/dispatch latencies\n");

--- a/libevent.bt
+++ b/libevent.bt
@@ -10,6 +10,7 @@ BEGIN
 usdt:/usr/local/lib/libevent.so:base_loop___dispatch___start
 {
     @loop_dispatch_start[tid] = nsecs;
+    @dispatches[arg0] = nsecs;
 }
 
 usdt:/usr/local/lib/libevent.so:base_loop___dispatch___end
@@ -42,13 +43,6 @@ interval:s:5
     printf("event loop process_active latencies\n");
     print(@loop_process_active_lat);
     clear(@loop_process_active_lat);
-}
-
-// delta timing totals
-
-usdt:/usr/local/lib/libevent.so:base_loop___dispatch___start
-{
-    @dispatches[arg0] = nsecs;
 }
 
 usdt:/usr/local/lib/libevent.so:base_loop___dispatch___end

--- a/libevent.bt
+++ b/libevent.bt
@@ -13,6 +13,7 @@ usdt:/usr/local/lib/libevent.so:base_loop___dispatch___end
     $delta = (nsecs - @dispatch_start[arg0]) / 1000;
     
     @dispatch_latency[arg0] = hist($delta);
+    @dispatches[arg0] = count();
 
     delete(@dispatch_start[arg0]);
 }
@@ -29,13 +30,14 @@ usdt:/usr/local/lib/libevent.so:base_loop___process_active___end
     $delta2 = (nsecs - @proc_active_start[arg0]) / 1000;
 
     @proc_active_latency[arg0] = hist($delta2);
+    @proc_actives[arg0] = count();
 
     delete(@proc_active_start[arg0]);
 }
 
 interval:s:1
 {
-    printf("event_base_loop inner-dispatch latency\n");
+    printf("\n\nevent_base_loop inner-dispatch latency\n");
 
     print(@dispatch_latency);
     clear(@dispatch_latency);
@@ -43,4 +45,11 @@ interval:s:1
     printf("event_base_loop inner-process_active latency\n");
     print(@proc_active_latency);
     clear(@proc_active_latency);
+
+    print(@proc_actives);
+    print(@dispatches);
+
+    clear(@proc_actives);
+    clear(@dispatches);
+
 }

--- a/libevent.bt
+++ b/libevent.bt
@@ -1,81 +1,46 @@
-// dtrace/bpftrace script for monitoring loop_dispatch / process_active latencies
-// run: sudo bpftrace ./libevent.bt
-
-
-BEGIN
-{
-    printf("Tracing libevent loop/dispatch latencies\n");
-}
+#!/usr/bin/env bpftrace
 
 usdt:/usr/local/lib/libevent.so:base_loop___dispatch___start
 {
-    @loop_dispatch_start[tid] = nsecs;
-    @dispatches[arg0] = nsecs;
+    // arg0 == struct event_base;
+
+    @dispatch_start[arg0] = nsecs;
 }
 
 usdt:/usr/local/lib/libevent.so:base_loop___dispatch___end
-/ @loop_dispatch_start[tid] /
+/ @dispatch_start[arg0] /
 {
-    @loop_dispatch_lat[tid] = hist((nsecs - @loop_dispatch_start[tid]) / 1000);
-
-    delete(@loop_dispatch_start[tid]);
-}
-
-usdt:/usr/local/lib/libevent.so:base_loop___process_active___start
-{
-    @loop_process_active_start[tid] = nsecs;
-}
-
-usdt:/usr/local/lib/libevent.so:base_loop___process_active___end 
-/ @loop_process_active_start[tid] /
-{
-    @loop_process_active_lat[tid] = hist((nsecs - @loop_process_active_start[tid]) / 1000);
-
-    delete(@loop_process_active_start[tid]);
-}
-
-interval:s:5
-{
-    printf("event loop dispatch latencies\n");
-    print(@loop_dispatch_lat);
-    clear(@loop_dispatch_lat);
-
-    printf("event loop process_active latencies\n");
-    print(@loop_process_active_lat);
-    clear(@loop_process_active_lat);
-}
-
-usdt:/usr/local/lib/libevent.so:base_loop___dispatch___end
-/ @dispatches[arg0] /
-{
-    $elapsed = (nsecs - @dispatches[arg0]);
-
-    @dispatch_total_time[arg0] = sum($elapsed);
-}
+    $delta = (nsecs - @dispatch_start[arg0]) / 1000;
     
+    @dispatch_latency[arg0] = hist($delta);
+
+    delete(@dispatch_start[arg0]);
+}
+
 usdt:/usr/local/lib/libevent.so:base_loop___process_active___start
 {
-    @pactives[arg0] = nsecs;
+    // arg0 == event_base
+    @proc_active_start[arg0] = nsecs;
 }
 
 usdt:/usr/local/lib/libevent.so:base_loop___process_active___end
-/ @pactives[arg0] /
+/ @proc_active_start[arg0] /
 {
-    $delta = (nsecs - @pactives[arg0]);
+    $delta2 = (nsecs - @proc_active_start[arg0]) / 1000;
 
-    @activation_total_time[arg0] = sum($delta);
+    @proc_active_latency[arg0] = hist($delta2);
+
+    delete(@proc_active_start[arg0]);
 }
 
-usdt:/usr/local/lib/libevent.so:process_active_single_queue__enter
+interval:s:1
 {
-    @single_queues[arg0] = nsecs;
+    printf("event_base_loop inner-dispatch latency\n");
+
+    print(@dispatch_latency);
+    clear(@dispatch_latency);
+
+    printf("event_base_loop inner-process_active latency\n");
+    print(@proc_active_latency);
+    clear(@proc_active_latency);
 }
-
-usdt:/usr/local/lib/libevent.so:process_active_single_queue__return
-{
-    $sdelta = (nsecs - @single_queues[arg0]);
-
-    @single_queues_total_time[arg0] = sum($sdelta);
-}
-    
-

--- a/libevent.bt
+++ b/libevent.bt
@@ -1,0 +1,44 @@
+# dtrace/bpftrace script for monitoring loop_dispatch / process_active latencies
+# run: sudo bpftrace ./libevent.bt
+BEGIN
+{
+    printf("Tracing libevent loop/dispatch latencies\n");
+}
+
+usdt:/usr/local/lib/libevent.so:base_loop___dispatch___start
+{
+    @loop_dispatch_start[tid] = nsecs;
+}
+
+usdt:/usr/local/lib/libevent.so:base_loop___dispatch___end
+/ @loop_dispatch_start[tid] /
+{
+    @loop_dispatch_lat[tid] = hist((nsecs - @loop_dispatch_start[tid]) / 1000);
+
+    delete(@loop_dispatch_start[tid]);
+}
+
+usdt:/usr/local/lib/libevent.so:base_loop___process_active___start
+{
+    @loop_process_active_start[tid] = nsecs;
+}
+
+usdt:/usr/local/lib/libevent.so:base_loop___process_active___end 
+/ @loop_process_active_start[tid] /
+{
+    @loop_process_active_lat[tid] = hist((nsecs - @loop_process_active_start[tid]) / 1000);
+
+    delete(@loop_process_active_start[tid]);
+}
+
+interval:s:5
+{
+    printf("event loop dispatch latencies\n");
+    print(@loop_dispatch_lat);
+    clear(@loop_dispatch_lat);
+
+    printf("event loop process_active latencies\n");
+    print(@loop_process_active_lat);
+    clear(@loop_process_active_lat);
+}
+


### PR DESCRIPTION
# THIS IS A DRAFT

Prereqs
==============================
1. Use linux (testing).
2. Install systemtab SDT dev for proper dtrace macros (`sudo apt install systemtap-sdt-dev`)
3. Add the cmake option `-DEVENT__ENABLE_DTRACE=ON`
4. (optional) Install iovisor bcc tools.

Testing
==============================
1. Install `bpftrace` https://github.com/iovisor/bpftrace
2. Start up anything that is linked to /usr/local/lib/libevent.so
3. run: `bpftrace ./libevent.bt`

You should see output histograms like:

```
sudo bpftrace ./libevent.bt 
event_base_loop inner-dispatch latency
@dispatch_latency[94474611720864]:
[1]                  157 |@@@@@                                               |
[2, 4)               259 |@@@@@@@@@                                           |
[4, 8)                16 |                                                    |
[8, 16)               37 |@                                                   |
[16, 32)            1382 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[32, 64)              28 |@                                                   |
[64, 128)              3 |                                                    |

event_base_loop inner-process_active latency
@proc_active_latency[94474611720864]:
[4, 8)                92 |@@@                                                 |
[8, 16)              197 |@@@@@@@                                             |
[16, 32)             160 |@@@@@                                               |
[32, 64)              11 |                                                    |
[64, 128)              8 |                                                    |
[128, 256)             8 |                                                    |
[256, 512)             7 |                                                    |
[512, 1K)           1398 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[1K, 2K)               2 |                                                    |
```

This displays a histogram of latencies of the event-dispatch call (e.g.,
epoll()), and the process_active dispatch (user callbacks).

Here we can see that 1382 epoll calls averaged aroudn 16ns latency to execute,
while process_active had 1398 calls between 512-1000ns.


Other Noteworthy Probes
================================
/usr/local/lib/libevent.so libevent.so:bev_suspend_read___enter
/usr/local/lib/libevent.so libevent.so:bev_suspend_read___return
/usr/local/lib/libevent.so libevent.so:bev_unsuspend_read___enter
/usr/local/lib/libevent.so libevent.so:bev_unsuspend_read___return
/usr/local/lib/libevent.so libevent.so:bev_suspend_write___enter
/usr/local/lib/libevent.so libevent.so:bev_suspend_write___return
/usr/local/lib/libevent.so libevent.so:bev_unsuspend_write___enter
/usr/local/lib/libevent.so libevent.so:bev_unsuspend_write___return
/usr/local/lib/libevent.so libevent.so:bev_run_deferred_callbacks___enter
/usr/local/lib/libevent.so libevent.so:assign__enter
/usr/local/lib/libevent.so libevent.so:assign__return
/usr/local/lib/libevent.so libevent.so:process_active_single_queue__enter
/usr/local/lib/libevent.so libevent.so:process_active_single_queue__return
/usr/local/lib/libevent.so libevent.so:process_active_single_queue___usercb_start
/usr/local/lib/libevent.so libevent.so:process_active_single_queue___usercb_end
/usr/local/lib/libevent.so libevent.so:base_loop___enter
/usr/local/lib/libevent.so libevent.so:base_loop___start
/usr/local/lib/libevent.so libevent.so:base_loop___dispatch___start
/usr/local/lib/libevent.so libevent.so:base_loop___dispatch___end
/usr/local/lib/libevent.so libevent.so:base_loop___timeout_proc_start
/usr/local/lib/libevent.so libevent.so:base_loop___timeout_proc_end
/usr/local/lib/libevent.so libevent.so:base_loop___end
/usr/local/lib/libevent.so libevent.so:timeout_process__enter
/usr/local/lib/libevent.so libevent.so:base_loop___process_active___start
/usr/local/lib/libevent.so libevent.so:process_active___enter
/usr/local/lib/libevent.so libevent.so:process_active___return
/usr/local/lib/libevent.so libevent.so:base_loop___process_active___end
/usr/local/lib/libevent.so libevent.so:timeout_process__return
/usr/local/lib/libevent.so libevent.so:base_loop___return
/usr/local/lib/libevent.so libevent.so:new__enter
/usr/local/lib/libevent.so libevent.so:new__return
/usr/local/lib/libevent.so libevent.so:free__enter
/usr/local/lib/libevent.so libevent.so:free__return


NOTES
==================================

`___` == space
`___enter` == function entry
`___return` == function return
`___start` == start of operation/call
`___end` == end of operation/call
