### PR TITLE
Add error-handling routine for arc4_seed()

### DIFF
--- a/arc4random.c
+++ b/arc4random.c
@@ -379,7 +379,9 @@ arc4_stir(void)
 		rs_initialized = 1;
 	}
 
-	arc4_seed();
+	if (0 != arc4_seed())
+		return -1;
+
 	if (!arc4_seeded_ok)
 		return -1;
 


### PR DESCRIPTION
Motivation:
- There is no error-handling routine after calling 'arc4_seed()'

Modification:
- Correct the above issue