### PR TITLE
Remove needless check for arc4_seeded_ok

### DIFF
--- a/arc4random.c
+++ b/arc4random.c
@@ -89,7 +89,6 @@ static int rs_initialized;
 static struct arc4_stream rs;
 static pid_t arc4_stir_pid;
 static int arc4_count;
-static int arc4_seeded_ok;
 
 static inline unsigned char arc4_getbyte(void);
 
@@ -163,7 +162,6 @@ arc4_seed_win32(void)
 		return -1;
 	arc4_addrandom(buf, sizeof(buf));
 	evutil_memclear_(buf, sizeof(buf));
-	arc4_seeded_ok = 1;
 	return 0;
 }
 #endif
@@ -201,7 +199,6 @@ arc4_seed_sysctl_linux(void)
 
 	arc4_addrandom(buf, sizeof(buf));
 	evutil_memclear_(buf, sizeof(buf));
-	arc4_seeded_ok = 1;
 	return 0;
 }
 #endif
@@ -241,7 +238,6 @@ arc4_seed_sysctl_bsd(void)
 
 	arc4_addrandom(buf, sizeof(buf));
 	evutil_memclear_(buf, sizeof(buf));
-	arc4_seeded_ok = 1;
 	return 0;
 }
 #endif
@@ -287,7 +283,6 @@ arc4_seed_proc_sys_kernel_random_uuid(void)
 	}
 	evutil_memclear_(entropy, sizeof(entropy));
 	evutil_memclear_(buf, sizeof(buf));
-	arc4_seeded_ok = 1;
 	return 0;
 }
 #endif
@@ -311,7 +306,6 @@ static int arc4_seed_urandom_helper_(const char *fname)
 		return -1;
 	arc4_addrandom(buf, sizeof(buf));
 	evutil_memclear_(buf, sizeof(buf));
-	arc4_seeded_ok = 1;
 	return 0;
 }
 
@@ -380,9 +374,6 @@ arc4_stir(void)
 	}
 
 	if (0 != arc4_seed())
-		return -1;
-
-	if (!arc4_seeded_ok)
 		return -1;
 
 	/*

--- a/evutil_rand.c
+++ b/evutil_rand.c
@@ -171,9 +171,7 @@ evutil_secure_rng_init(void)
 	int val;
 
 	ARC4_LOCK_();
-	if (!arc4_seeded_ok)
-		arc4_stir();
-	val = arc4_seeded_ok ? 0 : -1;
+	val = (!arc4_stir()) ? 0 : -1;
 	ARC4_UNLOCK_();
 	return val;
 }


### PR DESCRIPTION
Motivation:
- It is not necessary to have ```arc4_seeded_ok``` check immediately after calling ```arc4_seed()```.

Modification:
- Correct the above issue