### PR TITLE
[RFC] epoll: polling from userspace

### DIFF
--- a/bufferevent_sock.c
+++ b/bufferevent_sock.c
@@ -213,6 +213,11 @@ bufferevent_readcb(evutil_socket_t fd, short event, void *arg)
 	/* Invoke the user callback - must always be called last */
 	bufferevent_trigger_nolock_(bufev, EV_READ, 0);
 
+	if (event & EV_CLOSED) {
+		what |= BEV_EVENT_EOF;
+		goto error;
+	}
+
 	goto done;
 
  reschedule:
@@ -364,7 +369,7 @@ bufferevent_socket_new(struct event_base *base, evutil_socket_t fd,
 	evbuffer_set_flags(bufev->output, EVBUFFER_FLAG_DRAINS_TO_FD);
 
 	event_assign(&bufev->ev_read, bufev->ev_base, fd,
-	    EV_READ|EV_PERSIST|EV_FINALIZE, bufferevent_readcb, bufev);
+	    EV_READ|EV_PERSIST|EV_FINALIZE|EV_CLOSED, bufferevent_readcb, bufev);
 	event_assign(&bufev->ev_write, bufev->ev_base, fd,
 	    EV_WRITE|EV_PERSIST|EV_FINALIZE, bufferevent_writecb, bufev);
 


### PR DESCRIPTION
Hi all,

Recently I was improving epoll performance in linux kernel and eventually
came up with some RFC patches [[1](https://lwn.net/Articles/777263/)] which allow collecting events of file
descriptors directly from userspace without entering the kernel (i.e. no
costs of calling epoll_wait(2) at all).

The following is a patch for the libevent which uses new epoll interface
and polls events from userspace.  The only purpose of this change is to
run some benchmarking without consideration of correct implementation
of edge triggered mode in libevent, e.g. the following are quick results
of bench_httpclient:

o current libevent master without any modifications:

```
  20000 requests in 0.636265 sec. (31433.44 throughput)
  Each took about 6.39 msec latency
  1600000bytes read. 0 errors.
```

o EPOLLET (the following patch is applied, but USE_USERPOLL is not defined):

```
  20000 requests in 0.551306 sec. (36277.49 throughput)
  Each took about 5.54 msec latency
  1600000bytes read. 0 errors.
```

o USE_USERPOLL (the following patch is applied and USE_USERPOLL is defined):

```
  20000 requests in 0.475585 sec. (42053.47 throughput)
  Each took about 4.78 msec latency
  1600000bytes read. 0 errors.
```

So comparing EPOLLET modification with harvesting events from userspace
there is a 15% gain and 33% gain comparing to the libevent without any
modifications (which is not quite fair comparison since polling from
userspace requires EPOLLET flag set).

My question is: do you guys care to boost libevent with support of such
a feature?  Any feedback regarding the new epoll interface, limitations,
etc is welcome.

And I would really appreciate if someone points me out good and real world
benchmark suite (in addition to the sources from test/ folder) which I can
adopt in order to test polling from userspace carefully.

[1]  https://lwn.net/Articles/777263/
