### PR TITLE
Enforce limit of NSIG signals.

### DIFF
--- a/evmap.c
+++ b/evmap.c
@@ -43,6 +43,7 @@
 #include <unistd.h>
 #endif
 #include <errno.h>
+#include <limits.h>
 #include <signal.h>
 #include <string.h>
 #include <time.h>
@@ -446,6 +447,9 @@ evmap_signal_add_(struct event_base *base, int sig, struct event *ev)
 	struct event_signal_map *map = &base->sigmap;
 	struct evmap_signal *ctx = NULL;
 
+	if (sig < 0 || sig >= NSIG)
+		return (-1);
+
 	if (sig >= map->nentries) {
 		if (evmap_make_space(
 			map, sig, sizeof(struct evmap_signal *)) == -1)
@@ -472,7 +476,7 @@ evmap_signal_del_(struct event_base *base, int sig, struct event *ev)
 	struct event_signal_map *map = &base->sigmap;
 	struct evmap_signal *ctx;
 
-	if (sig >= map->nentries)
+	if (sig < 0 || sig >= map->nentries)
 		return (-1);
 
 	GET_SIGNAL_SLOT(ctx, map, sig, evmap_signal);

--- a/evmap.c
+++ b/evmap.c
@@ -208,8 +208,14 @@ evmap_make_space(struct event_signal_map *map, int slot, int msize)
 		int nentries = map->nentries ? map->nentries : 32;
 		void **tmp;
 
+		if (slot > INT_MAX / 2)
+			return (-1);
+
 		while (nentries <= slot)
 			nentries <<= 1;
+
+		if (nentries > INT_MAX / msize)
+			return (-1);
 
 		tmp = (void **)mm_realloc(map->entries, nentries * msize);
 		if (tmp == NULL)


### PR DESCRIPTION
It doesn't make sense to allow a signal number higher than NSIG.
At worst, libevent could enter an endless loop if sig is INT_MAX.

The NSIG check already exists in signal.c for internally used
functions.

As this is a programming error of libevent consumers, this is a
purely defensive mechanism.

Example to trigger this issue:

--poc.c--

static void callback(int a, short b, void *c) { }

int main(void)
{
  struct event_base *b = event_init();
  struct event *ev = evsignal_new(b, INT_MAX, callback, (void *)b);
  event_add(ev, NULL);
  return 0;
}
--poc.c--

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>