### PR TITLE
Prevent integer overflow in kq_build_changes_list.

### DIFF
--- a/kqueue.c
+++ b/kqueue.c
@@ -62,6 +62,7 @@
 #include "log-internal.h"
 #include "evmap-internal.h"
 #include "event2/thread.h"
+#include "event2/util.h"
 #include "evthread-internal.h"
 #include "changelist-internal.h"
 
@@ -209,6 +210,12 @@ kq_build_changes_list(const struct event_changelist *changelist,
 		if (n_changes >= kqop->changes_size - 1) {
 			int newsize = kqop->changes_size * 2;
 			struct kevent *newchanges;
+
+			if (newsize < 0 || (size_t)newsize >
+			    EV_SIZE_MAX / sizeof(struct kevent)) {
+				event_warnx("%s: int overflow", __func__);
+				return (-1);
+			}
 
 			newchanges = mm_realloc(kqop->changes,
 			    newsize * sizeof(struct kevent));


### PR DESCRIPTION
On amd64 systems with kqueue (e.g. *BSD systems) an integer overflow
could be triggered with an excessively huge amount of events.

Lightly tested on OpenBSD (and fixed there for libevent 1.x as well).

Haven't added a unit test for this, because it only affects amd64, a
subset of supported systems and takes a lot of memory (and time).

Let me know if you prefer the cast this way and that I try to allow as
much memory as possible. Otherwise we can simply check against
"INT_MAX / sizeof(struct kevent)" instead.