### PR TITLE
Avoid undefined behaviour.

### DIFF
--- a/kqueue.c
+++ b/kqueue.c
@@ -37,6 +37,7 @@
 #endif
 #include <sys/queue.h>
 #include <sys/event.h>
+#include <limits.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -208,15 +209,17 @@ kq_build_changes_list(const struct event_changelist *changelist,
 		struct event_change *in_ch = &changelist->changes[i];
 		struct kevent *out_ch;
 		if (n_changes >= kqop->changes_size - 1) {
-			int newsize = kqop->changes_size * 2;
+			int newsize;
 			struct kevent *newchanges;
 
-			if (newsize < 0 || (size_t)newsize >
-			    EV_SIZE_MAX / sizeof(struct kevent)) {
+			if (kqop->changes_size > INT_MAX / 2 ||
+			    (size_t)kqop->changes_size * 2 > EV_SIZE_MAX /
+			    sizeof(struct kevent)) {
 				event_warnx("%s: int overflow", __func__);
 				return (-1);
 			}
 
+			newsize = kqop->changes_size * 2;
 			newchanges = mm_realloc(kqop->changes,
 			    newsize * sizeof(struct kevent));
 			if (newchanges == NULL) {


### PR DESCRIPTION
As ploxiln pointed out in pull request 811 the check "newsize < 0"
is undefined behaviour (signed int overflow).

Follow the advice and check kqop->changes_size instead.

See: https://github.com/libevent/libevent/pull/811

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>