### PR TITLE
cmake: MSVC is always defined with Clang on Unix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ endif()
 if (("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") OR (${CLANG}))
     set(GNUC 1)
 endif()
-if (("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC") OR (${CLANG}))
+if (("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC") OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC"))
     set(MSVC 1)
 endif()
 


### PR DESCRIPTION
According to CMakeLists.txt if Clang is detected it's always both GCC and MSVC compatible. However, Clang is GCC compatible while Clang-CL is MSVC compatible. What this leads to is no static library by default on Unix systems.

```
$ cc -v
FreeBSD clang version 8.0.0 (tags/RELEASE_800/final 356365) (based on LLVM 8.0.0)
Target: x86_64-unknown-freebsd13.0
Thread model: posix
InstalledDir: /usr/bin
```
```
$ cmake .
$ make
$ find . -name \*.a
```
https://github.com/libevent/libevent/blob/1c573ab3a9037c560981ea325170ca6044c2dff6/CMakeLists.txt#L180-L192
