### PR TITLE
Correction error checking in http_client.c

### DIFF
--- a/sample/https-client.c
+++ b/sample/https-client.c
@@ -79,6 +79,7 @@ http_request_done(struct evhttp_request *req, void *ctx)
 	}
 	
 	if (evhttp_request_get_response_code(req) == 0) {
+		int errcode = EVUTIL_SOCKET_ERROR();
 		fprintf(stderr, "socket error = %s (%d)\n",
 				evutil_socket_error_to_string(errcode),
 				errcode);

--- a/sample/https-client.c
+++ b/sample/https-client.c
@@ -77,7 +77,14 @@ http_request_done(struct evhttp_request *req, void *ctx)
 				errcode);
 		return;
 	}
-
+	
+	if (evhttp_request_get_response_code(req) == 0) {
+		fprintf(stderr, "socket error = %s (%d)\n",
+				evutil_socket_error_to_string(errcode),
+				errcode);
+		return;
+	}
+	
 	fprintf(stderr, "Response line: %d %s\n",
 	    evhttp_request_get_response_code(req),
 	    evhttp_request_get_response_code_line(req));


### PR DESCRIPTION
When connecting to a non-existent HTTPS service, the `req` is not null but the `evhttp_request_get_response_code(req)` is zero. so should place the socket error checking behind.

e.g. the https server listening on port 443, but we connect to port 433
