### PR TITLE
readme: cmake command on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Install CMake: <https://www.cmake.org>
 ```
 $ md build && cd build
 $ cmake -G "Visual Studio 10" ..   # Or whatever generator you want to use cmake --help for a list.
-$ start libevent.sln
+$ cmake --build . --config Release # Or "start libevent.sln" and build with menu in Visual Studio.
 ```
 
 See [Documentation/Building#Building on Windows](/Documentation/Building.md#building-on-windows) for more information


### PR DESCRIPTION
It is recommended to use "cmake --build" in the cmake system. So I recommend using it first.
