### PR TITLE
m4/libevent_openssl.m4: fix detection of openssl

### DIFF
--- a/m4/libevent_openssl.m4
+++ b/m4/libevent_openssl.m4
@@ -40,7 +40,7 @@ case "$enable_openssl" in
 	;;
     esac
     CPPFLAGS_SAVE=$CPPFLAGS
-    CPPFLAGS+=$OPENSSL_INCS
+    CPPFLAGS="$CPPFLAGS $OPENSSL_INCS"
     AC_CHECK_HEADERS([openssl/ssl.h], [], [have_openssl=no])
     CPPFLAGS=$CPPFLAGS_SAVE
     AC_SUBST(OPENSSL_INCS)


### PR DESCRIPTION
Since commit 506df426dbeb0187bbd3654bd286b4100628fb16, OPENSSL_INCS is
added to CPPFLAGS without any white space, as a result openssl detection
fails on:
configure:10395: checking openssl/ssl.h usability
configure:10395: /home/fabrice/buildroot-test/buildroot/output/host/bin/riscv32-linux-gcc -c -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os   -Wall -fno-strict-aliasing -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64-I/home/fabrice/buildroot-test/buildroot/output/host/bin/../riscv32-buildroot-linux-gnu/sysroot/usr/include  conftest.c >&5
<command-line>:0:0: warning: "_FILE_OFFSET_BITS" redefined
<command-line>:0:0: note: this is the location of the previous definition
<command-line>:0:23: error: division by zero in #if

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>