### PR TITLE
cmake: add doxygen and uninstall targets, install 'event_rpcgen.py'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,7 @@ cscope*
 /m4/ltversion.m4
 /m4/lt~obsolete.m4
 
-/doxygen
+doxygen
 /aclocal.m4
 compile
 config.cache
@@ -131,6 +131,7 @@ LibeventConfigVersion.cmake
 LibeventTargets.cmake
 bin/
 cmake_install.cmake
+Uninstall.cmake
 lib/
 tmp/
 verify_tests.sh
@@ -141,6 +142,7 @@ event_extra.dir
 *.vcxproj
 *.sln
 *.filters
+install_manifest.txt
 
 # ninja
 build.ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1482,7 +1482,8 @@ install(PROGRAMS
 
 # Create documents with doxygen.
 add_custom_target(doxygen
-                  COMMAND doxygen ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile)
+                  COMMAND doxygen Doxyfile
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Create the uninstall target.
 # https://gitlab.kitware.com/cmake/community/wikis/FAQ#can-i-do-make-uninstall-with-cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1474,6 +1474,26 @@ install(EXPORT LibeventTargets
         DESTINATION "${DEF_INSTALL_CMAKE_DIR}"
         COMPONENT dev)
 
+# Install the scripts.
+install(PROGRAMS
+       ${CMAKE_CURRENT_SOURCE_DIR}/event_rpcgen.py
+       DESTINATION "bin"
+       COMPONENT runtime)
+
+# Create documents with doxygen.
+add_custom_target(doxygen
+                  COMMAND doxygen ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile)
+
+# Create the uninstall target.
+# https://gitlab.kitware.com/cmake/community/wikis/FAQ#can-i-do-make-uninstall-with-cmake
+configure_file(${PROJECT_SOURCE_DIR}/cmake/Uninstall.cmake.in
+               ${PROJECT_BINARY_DIR}/Uninstall.cmake
+               @ONLY)
+
+add_custom_target(uninstall
+                  COMMAND ${CMAKE_COMMAND} -P ${PROJECT_BINARY_DIR}/Uninstall.cmake)
+
+
 message(STATUS "")
 message(STATUS "        ---( Libevent " ${EVENT_VERSION} " )---")
 message(STATUS "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1481,9 +1481,15 @@ install(PROGRAMS
        COMPONENT runtime)
 
 # Create documents with doxygen.
-add_custom_target(doxygen
-                  COMMAND doxygen Doxyfile
-                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+find_program(DOXYGEN doxygen)
+if (DOXYGEN)
+    add_custom_target(doxygen
+                      COMMAND ${DOXYGEN} Doxyfile
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+else()
+    message(WARNING "The doxygen target will not support since doxygen command was not found!")
+endif()
+
 
 # Create the uninstall target.
 # https://gitlab.kitware.com/cmake/community/wikis/FAQ#can-i-do-make-uninstall-with-cmake

--- a/cmake/Uninstall.cmake.in
+++ b/cmake/Uninstall.cmake.in
@@ -1,0 +1,23 @@
+# https://gitlab.kitware.com/cmake/community/wikis/FAQ#can-i-do-make-uninstall-with-cmake
+
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif(NOT "${rm_retval}" STREQUAL 0)
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)


### PR DESCRIPTION
When building with autoconf, there are "doxygen" and "uninstall" targets available, and the script "event_rpcgen.py" will be installed.  But they are missing in cmake.

After adding in cmake , I can run as follows:
```bash
$ cmake ..
$ make doxygen        # generate documents.
$ make install        # can also install "event_rpcgen.py" to binary dir.
$ make uninstall      # remove all installed files and bins.
```