### PR TITLE
add reset 'running_loop' in 'event_reinit()'

### DIFF
--- a/event.c
+++ b/event.c
@@ -1081,6 +1081,10 @@ event_reinit(struct event_base *base)
 	if (was_notifiable && res == 0)
 		res = evthread_make_base_notifiable_nolock_(base);
 
+    /* Reset running_loop if event base is running loop */
+    if (base->running_loop && res == 0)
+        base->running_loop = 0;
+
 done:
 	EVBASE_RELEASE_LOCK(base, th_base_lock);
 	return (res);


### PR DESCRIPTION
In 'event_loop()' or 'event_base_loop()' only allow 'event_base' is not running loop. So , I think must be check 'running_loop' or reset 'running_loop' in 'event_reinit()'. I think reset 'running_loop'  in 'event_reinit()' is better.

Because in one of my project, a master process will receive some signal or fd IO to control the increase or decrease of the work process. Suppose we ’fork()’ a worker process when an event triggered in the master process. At this time event_base is running loop. The worker process call 'event_reinit()' to initialize event_base ,but it doesn't reset 'running_loop '. And then call ’event_loop()/event_base_loop()’ will be rejected.
