### PR TITLE
missing header "winerror.h" on MinGW

### DIFF
--- a/arc4random.c
+++ b/arc4random.c
@@ -54,6 +54,7 @@
 #ifdef _WIN32
 #include <wincrypt.h>
 #include <process.h>
+#include <winerror.h>
 #else
 #include <fcntl.h>
 #include <unistd.h>

--- a/buffer_iocp.c
+++ b/buffer_iocp.c
@@ -44,6 +44,7 @@
 #include "mm-internal.h"
 
 #include <winsock2.h>
+#include <winerror.h>
 #include <windows.h>
 #include <stdio.h>
 

--- a/bufferevent_async.c
+++ b/bufferevent_async.c
@@ -46,6 +46,7 @@
 
 #ifdef _WIN32
 #include <winsock2.h>
+#include <winerror.h>
 #include <ws2tcpip.h>
 #endif
 

--- a/evdns.c
+++ b/evdns.c
@@ -77,6 +77,7 @@
 #include <stdarg.h>
 #ifdef _WIN32
 #include <winsock2.h>
+#include <winerror.h>
 #include <ws2tcpip.h>
 #ifndef _WIN32_IE
 #define _WIN32_IE 0x400

--- a/evutil.c
+++ b/evutil.c
@@ -29,6 +29,7 @@
 
 #ifdef _WIN32
 #include <winsock2.h>
+#include <winerror.h>
 #include <ws2tcpip.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>

--- a/listener.c
+++ b/listener.c
@@ -35,6 +35,7 @@
 #define _WIN32_WINNT 0x0403
 #endif
 #include <winsock2.h>
+#include <winerror.h>
 #include <ws2tcpip.h>
 #include <mswsock.h>
 #endif


### PR DESCRIPTION
My environment is :
win7 + MinGW(MINGW32_NT-6.1) + MSYS   

I compile with cmake  and get following error:
```sh
d:/libevent-master/evutil.c: In function 'evutil_check_ifaddrs':
d:/libevent-master/evutil.c:718:13: error: 'ERROR_BUFFER_OVERFLOW' undeclared (f
irst use in this function)
  if (res == ERROR_BUFFER_OVERFLOW) {
             ^~~~~~~~~~~~~~~~~~~~~
d:/libevent-master/evutil.c:718:13: note: each undeclared identifier is reported
 only once for each function it appears in
d:/libevent-master/evutil.c:726:13: error: 'NO_ERROR' undeclared (first use in t
his function)
  if (res != NO_ERROR)
             ^~~~~~~~
make[2]: *** [CMakeFiles/event_static.dir/evutil.c.obj] Error 1
make[1]: *** [CMakeFiles/event_static.dir/all] Error 2
make: *** [all] Error 2
```
This is most likely caused by the  missing of header file.
When I include `winerror.h` in `util.h`, it run success.