### PR TITLE
Enable kqueue for APPLE targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -627,7 +627,7 @@ CHECK_TYPE_SIZE("time_t" EVENT__SIZEOF_TIME_T)
 
 # Verify kqueue works with pipes.
 if (EVENT__HAVE_KQUEUE)
-    if (CMAKE_CROSSCOMPILING AND NOT EVENT__FORCE_KQUEUE_CHECK)
+    if ((CMAKE_CROSSCOMPILING OR APPLE) AND NOT EVENT__FORCE_KQUEUE_CHECK)
         message(WARNING "Cannot check if kqueue works with pipes when crosscompiling, use EVENT__FORCE_KQUEUE_CHECK to be sure (this requires manually running a test program on the cross compilation target)")
         set(EVENT__HAVE_WORKING_KQUEUE 1)
     else()


### PR DESCRIPTION
The CMAKE_CROSSCOMPILING variable is not set for Apple targets seemingly
because of cmake implementation details (more info
https://cmake.org/cmake/help/latest/variable/CMAKE_CROSSCOMPILING.html).
Since Apple targets have working kqueue implementations this check makes
sure we enable it always when those are the targets, without users
having to explicitly set EVENT__HAVE_WORKING_KQUEUE