### PR TITLE
Enable _GNU_SOURCE for Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,10 @@ if (NOT DEFINED _GNU_SOURCE)
     unset(_GNU_SOURCE CACHE)
     CHECK_SYMBOL_EXISTS(_GNU_SOURCE "features.h" _GNU_SOURCE)
   endif()
+
+  if (ANDROID)
+    set(_GNU_SOURCE TRUE)
+  endif()
 endif()
 
 if (_GNU_SOURCE)


### PR DESCRIPTION
When targeting the Android NDK _GNU_SOURCE is not enabled by default:

```
 /*
  * With bionic, you always get all C and POSIX API.
  *
  * If you want BSD and/or GNU extensions, _BSD_SOURCE and/or _GNU_SOURCE are
  * expected to be defined by callers before *any* standard header file is
  * included.
  *
  * In our header files we test against __USE_BSD and __USE_GNU.
  */
 #if defined(_GNU_SOURCE)
 #  define __USE_BSD 1
 #  define __USE_GNU 1
 #endif
```

Because of this `pipe2` is not available:

```
 #if defined(__USE_GNU)
 int pipe2(int __fds[2], int __flags) __INTRODUCED_IN(9);
 #endif
```

The function used to check if it does exist:

```
CHECK_FUNCTION_EXISTS_EX(pipe2 EVENT__HAVE_PIPE2)
```

Just check that the _linking_ succeeds, which it does, it's just not
visible in the import, leading to a warning (or error):

```
evutil.c:2637:6: error: implicit declaration of function 'pipe2' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        if (pipe2(fd, O_NONBLOCK|O_CLOEXEC) == 0)
            ^
```

When targeting the NDK it should be safe to always opt into this. Clang
would pass the right flag for us automatically _if_ the source was C++
instead of C.