### PR TITLE
change autoconf version to 2.62 and automake version to 1.11.2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,8 +5,8 @@
 # See LICENSE for copying information.
 
 # 'foreign' means that we're not enforcing GNU package rules strictly.
-# '1.9' means that we need automake 1.9 or later (and we do).
-AUTOMAKE_OPTIONS = foreign 1.9 subdir-objects
+# '1.11.2' means that we need automake 1.11.2 or later (and we do).
+AUTOMAKE_OPTIONS = foreign 1.11.2 subdir-objects
 
 ACLOCAL_AMFLAGS = -I m4
 

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ dnl
 dnl Original version Dug Song <dugsong@monkey.org>
 
 AC_INIT(libevent,2.2.0-alpha-dev)
-AC_PREREQ(2.59)
+AC_PREREQ(2.62)
 AC_CONFIG_SRCDIR(event.c)
 
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
On my computer, the version of `autoconf` is 2.59 and `automake` is 1.9 
I build with `autogen.sh & configure & make` and failed.

I find In `Makefile.am` line 227~230:
```
include/event2/event-config.h: config.h make-event-config.sed
	$(AM_V_GEN)test -d include/event2 || $(MKDIR_P) include/event2
	$(AM_V_at)$(SED) -f $(srcdir)/make-event-config.sed < config.h > $@T
	$(AM_V_at)mv -f $@T $@
```
there are three undefined variables: MKDIR_P, AM_V_GEN and AM_V_at.
Then I tried `autoconf-2.60 & automake-1.10`, `autoconf-2.61 & automake-1.11`, `autoconf-2.62 & automake-1.11.2` and only `autoconf-2.62 & automake-1.11.2` is ok.

Therefore, I recommend changing the autoconf version from 2.59 to 2.62 and automake version from 1.9 to 1.11.2, thanks.