### PR TITLE
Change the minimum version of automake to 1.13 and autoconf to 2.67

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,8 +5,8 @@
 # See LICENSE for copying information.
 
 # 'foreign' means that we're not enforcing GNU package rules strictly.
-# '1.11.2' means that we need automake 1.11.2 or later (and we do).
-AUTOMAKE_OPTIONS = foreign 1.11.2 subdir-objects
+# '1.13' means that we need automake 1.13 or later (and we do).
+AUTOMAKE_OPTIONS = foreign 1.13 subdir-objects
 
 ACLOCAL_AMFLAGS = -I m4
 

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ dnl
 dnl Original version Dug Song <dugsong@monkey.org>
 
 AC_INIT(libevent,2.2.0-alpha-dev)
-AC_PREREQ(2.62)
+AC_PREREQ(2.67)
 AC_CONFIG_SRCDIR(event.c)
 
 AC_CONFIG_MACRO_DIR([m4])
@@ -126,7 +126,8 @@ AC_ARG_ENABLE([clock-gettime],
   [], [enable_clock_gettime=yes])
 
 
-AC_PROG_LIBTOOL
+LT_PREREQ([2.4.2])
+LT_INIT
 
 dnl   Uncomment "AC_DISABLE_SHARED" to make shared libraries not get
 dnl   built by default.  You can also turn shared libs on and off from


### PR DESCRIPTION
When I run make check via automake with a version of 1.12.6 or lower, I got this error:

    /bin/sh: line 9: ./test_runner_epoll: No such file or directory
    FAIL: test_runner_epoll
    /bin/sh: line 9: ./test_runner_select: No such file or directory
    FAIL: test_runner_select
    /bin/sh: line 9: ./test_runner_kqueue: No such file or directory
    FAIL: test_runner_kqueue
    /bin/sh: line 9: ./test_runner_evport: No such file or directory
    FAIL: test_runner_evport
    /bin/sh: line 9: ./test_runner_devpoll: No such file or directory
    FAIL: test_runner_devpoll
    /bin/sh: line 9: ./test_runner_poll: No such file or directory
    FAIL: test_runner_poll
    /bin/sh: line 9: ./test_runner_win32: No such file or directory
    FAIL: test_runner_win32
    /bin/sh: line 9: ./test_runner_timerfd: No such file or directory
    FAIL: test_runner_timerfd
    /bin/sh: line 9: ./test_runner_changelist: No such file or directory
    FAIL: test_runner_changelist
    /bin/sh: line 9: ./test_runner_timerfd_changelist: No such file or directory
    FAIL: test_runner_timerfd_changelist

Open the Makefile generated by command ./autogen.sh && ./configure
I can see the errors are caused by this line:

    if $(TESTS_ENVIRONMENT) $${dir}$$tst $(AM_TESTS_FD_REDIRECT); then

$${dir}$$tst will expand to ./test_runner_epoll, but test_runner_epoll is only a target in test/include.am,
not a file, so it print:

    /bin/sh: line 9: ./test_runner_epoll: No such file or directory.

It seems like a bug in automake 1.12.6.
The errors will disappear if I simply upgrade automake to 1.13, and upgrade autoconf to 2.65
(2.65 is the lowest version dependent by automake-1.13).

When I build with automake-1.13 and autoconf-2.66, I got another error:

    configure.ac:667: error: AC_CHECK_SIZEOF: requires literal arguments

The code in configure.ac line 667 is :

    AC_CHECK_SIZEOF(void *)

It is a bug in autoconf-2.66 :
http://gnu-autoconf.7623.n7.nabble.com/AC-CHECK-SIZEOF-int-is-error-in-autoconf-2-66-td13537.html

Finally, everything works fine when using automake-1.13 and autoconf-2.67.
Refs: https://github.com/libevent/libevent/pull/858