### PR TITLE
sample: fix 'INFINITY' undeclared error

### DIFF
--- a/sample/watch-timing.c
+++ b/sample/watch-timing.c
@@ -11,6 +11,10 @@
 #include <event2/util.h>
 #include <event2/watch.h>
 
+#if !defined(INFINITY)
+#define INFINITY (1.0/0.0)
+#endif
+
 /**
   An approximate histogram in constant space, based on Ben-Haim & Yom-Tov, "A
   Streaming Parallel Decision Tree Algorithm" [1] and a previous implementation


### PR DESCRIPTION
The `INFINITY` macro is usually defined in the `math.h` file. But some older versions of the compiler do not define it. So you need to define it yourself. See [this](http://c-faq.com/fp/nan.html).

Refs: #877