### PR TITLE
eliminate some C4267 warnings in Windows

### DIFF
--- a/test/tinytest_macros.h
+++ b/test/tinytest_macros.h
@@ -113,8 +113,8 @@
 #define tt_assert_test_fmt_type(a,b,str_test,type,test,printf_type,printf_fmt, \
     setup_block,cleanup_block,die_on_fail)				\
 	TT_STMT_BEGIN							\
-	type val1_ = (a);						\
-	type val2_ = (b);						\
+	type val1_ = (type)(a);						\
+	type val2_ = (type)(b);						\
 	int tt_status_ = (test);					\
 	if (!tt_status_ || tinytest_get_verbosity_()>1)	{		\
 		printf_type print_;					\


### PR DESCRIPTION
There are a large number of warnings in the appveyor build log, of which 128 are `C4267`:
https://ci.appveyor.com/project/libevent/libevent/builds/27023437/job/qm3944n9gqjntp9b

After adding two type castings in the macro `tt_assert_test_fmt_type` in `tinytest_macros.h`, 117 warnings will disappear.
 I think  this type castings are safe and will not introduce any errors.