### PR TITLE
regress_buffer: improve testcases for evbuffer_freeze()

### DIFF
--- a/include/event2/buffer.h
+++ b/include/event2/buffer.h
@@ -748,7 +748,8 @@ int evbuffer_write_atmost(struct evbuffer *buffer, evutil_socket_t fd,
 
   @param buffer the evbuffer to store the result
   @param fd the file descriptor to read from
-  @param howmuch the number of bytes to be read
+  @param howmuch the number of bytes to be read. If the given number is negative
+  or out of maximum bytes per one read, as many bytes as we can will be read.
   @return the number of bytes read, or -1 if an error occurred
   @see evbuffer_write()
  */


### PR DESCRIPTION
Add testcases for these functions when using evbuffer_freeze():
```
evbuffer_add_buffer()
evbuffer_add_file()
evbuffer_read()
evbuffer_remove_buffer()
evbuffer_drain()
evbuffer_write()
evbuffer_prepend_buffer()
evbuffer_write_atmost()
```