### PR TITLE
Avoid transforming base C_FLAGS set deliberately

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,6 @@ if (${MSVC})
 
     if (EVENT__MSVC_STATIC_RUNTIME)
         foreach (flag_var
-                 CMAKE_C_FLAGS
                  CMAKE_C_FLAGS_DEBUG
                  CMAKE_C_FLAGS_RELEASE
                  CMAKE_C_FLAGS_MINSIZEREL


### PR DESCRIPTION
The CMAKE_C_FLAGS_DEBUG, CMAKE_C_FLAGS_RELEASE, CMAKE_C_FLAGS_MINSIZEREL
and CMAKE_C_FLAGS_RELWITHDEBINFO options are correctly and deliberately
toggled to use the libcmt (/MT) flag options in place of the usual
msvcrt (/MD) options, but this isn't necessarily desired by the user.
The default choice can be overriden with the EVENT__MSVC_STATIC_RUNTIME
cmake option.

However, the /MD flag that is the choice of CMake only enters into
play for the four types of builds above. If the user introduces another
CMAKE_BUILD_TYPE, the base CMAKE_C_FLAGS must not be manipulated, as
that value (and the CMAKE_C_FLAGS_{custom} value) have been explicitly
chosen by the user/developer deploying this library, and the mismatch
between these flags in different dependencies results in link errors.

The CMake build schema itself doesn't place an /MD flag in CMAKE_BUILD_TYPE
so any /M compile option in that variable needs to be retained.

Signed-off-by: William Rowe <wrowe@pivotal.io>
Signed-off-by: Yechiel Kalmenson <ykalmenson@pivotal.io>