### PR TITLE
Fix compat with NetBSD >= 10

### DIFF
--- a/kqueue.c
+++ b/kqueue.c
@@ -51,7 +51,10 @@
 /* Some platforms apparently define the udata field of struct kevent as
  * intptr_t, whereas others define it as void*.  There doesn't seem to be an
  * easy way to tell them apart via autoconf, so we need to use OS macros. */
-#if defined(EVENT__HAVE_INTTYPES_H) && !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__darwin__) && !defined(__APPLE__) && !defined(__CloudABI__)
+#if defined(__NetBSD__)
+#define PTR_TO_UDATA(x) ((typeof(((struct kevent *)0)->udata))(x))
+#define INT_TO_UDATA(x) ((typeof(((struct kevent *)0)->udata))(intptr_t)(x))
+#elif defined(EVENT__HAVE_INTTYPES_H) && !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__darwin__) && !defined(__APPLE__) && !defined(__CloudABI__)
 #define PTR_TO_UDATA(x)	((intptr_t)(x))
 #define INT_TO_UDATA(x) ((intptr_t)(x))
 #else


### PR DESCRIPTION
kevent::udata was switched from intptr_t to void*.

Handle both cases with the GCC extension typeof().