### PR TITLE
appveyor: fix build script for compiling using mingw-w64

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,9 +19,8 @@ skip_commits:
 environment:
   global:
     APPVEYOR_SAVE_CACHE_ON_ERROR: true
-    MINGW_ROOT: C:/mingw-w64/x86_64-7.2.0-posix-seh-rt_v5-rev1
     OPENSSL_ROOT: C:/OpenSSL-Win64
-    MPATH: C:/mingw-w64/x86_64-7.2.0-posix-seh-rt_v5-rev1/bin;C:/msys64/bin;C:/cygwin64/bin
+    MPATH: C:/mingw-w64/x86_64-7.2.0-posix-seh-rt_v5-rev1/mingw64/bin;C:/msys64/usr/bin
     EVENT_TESTS_PARALLEL: 20
     EVENT_BUILD_PARALLEL: 10
   matrix:
@@ -33,19 +32,19 @@ environment:
     # EVENT_ALLOW_FAILURE
     - EVENT_BUILD_METHOD: "autotools"
       EVENT_CONFIGURE_OPTIONS: ""
-      EVENT_ALLOW_FAILURE: 1
+      EVENT_ALLOW_FAILURE: 0
     - EVENT_BUILD_METHOD: "autotools"
       EVENT_CONFIGURE_OPTIONS: "--disable-openssl"
-      EVENT_ALLOW_FAILURE: 1
+      EVENT_ALLOW_FAILURE: 0
     - EVENT_BUILD_METHOD: "autotools"
       EVENT_CONFIGURE_OPTIONS: "--disable-thread-support"
-      EVENT_ALLOW_FAILURE: 1
+      EVENT_ALLOW_FAILURE: 0
     - EVENT_BUILD_METHOD: "autotools"
       EVENT_CONFIGURE_OPTIONS: "--disable-debug-mode"
-      EVENT_ALLOW_FAILURE: 1
+      EVENT_ALLOW_FAILURE: 0
     - EVENT_BUILD_METHOD: "autotools"
       EVENT_CONFIGURE_OPTIONS: "--disable-malloc-replacement"
-      EVENT_ALLOW_FAILURE: 1
+      EVENT_ALLOW_FAILURE: 0
     - EVENT_BUILD_METHOD: "cmake"
       EVENT_CMAKE_OPTIONS: "-DEVENT__DISABLE_OPENSSL=ON"
       EVENT_ALLOW_FAILURE: 1
@@ -80,18 +79,22 @@ build_script:
         $env:LDFLAGS="-L$($env:OPENSSL_ROOT)/lib -L$($env:OPENSSL_ROOT)"
         $env:CFLAGS="-I$($env:OPENSSL_ROOT)/include"
 
-        bash ./autogen.sh 2>&1 3>&1
-        if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
+        $script='
+        ./autogen.sh 2>&1 3>&1
+        [[ $? -ne 0 ]] && exit 1
 
-        md build-autotools 2> $null
+        mkdir build-autotools 2>/dev/null
         cd build-autotools
-        if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
+        [[ $? -ne 0 ]] && exit 1
 
-        bash ../configure $env:EVENT_CONFIGURE_OPTIONS 2>&1
-        if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
-        make -j $env:EVENT_BUILD_PARALLEL 2>&1
-        if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
-        make verify -j $env:EVENT_TESTS_PARALLEL 2>&1
+        ../configure $EVENT_CONFIGURE_OPTIONS 2>&1
+        [[ $? -ne 0 ]] && exit 1
+        make -j $EVENT_BUILD_PARALLEL 2>&1
+        [[ $? -ne 0 ]] && exit 1
+        make verify -j $EVENT_TESTS_PARALLEL 2>&1 '
+
+        bash -c $script
+
       } else {
         md build-cmake 2> $null
         cd build-cmake

--- a/sample/include.am
+++ b/sample/include.am
@@ -31,6 +31,9 @@ sample_https_client_SOURCES = \
 	sample/hostcheck.c \
 	sample/openssl_hostname_validation.c
 sample_https_client_LDADD = libevent.la libevent_openssl.la $(OPENSSL_LIBS) $(OPENSSL_LIBADD)
+if BUILD_WIN32
+sample_https_client_LDADD += -lcrypt32
+endif
 sample_https_client_CPPFLAGS = $(AM_CPPFLAGS) $(OPENSSL_INCS)
 noinst_HEADERS += \
 	sample/hostcheck.h \


### PR DESCRIPTION
I made several changes in `appveyor.yml`:
-  these paths are invalid:
`C:/mingw-w64/x86_64-7.2.0-posix-seh-rt_v5-rev1/bin;C:/msys64/bin`
the correct paths are:
`C:/mingw-w64/x86_64-7.2.0-posix-seh-rt_v5-rev1/mingw64/bin;C:/msys64/usr/bin`

- `C:/cygwin64/bin` is redundant, because `msys64` contains the `bash` command. `MINGW_ROOT` is not used.  I will remove them.

- replace `bash shell-command` with `bash -c shell-command-string`, the latter will run smoothly in Powershell.