### PR TITLE
appveyor: fix openssl version mismatch warning

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -106,6 +106,7 @@ build_script:
         bash -c $script
 
       } else {
+        $env:PATH="$env:OPENSSL_ROOT/bin;$env:PATH"
         if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq 'Visual Studio 2017') {
           $env:BUILD_DIR="build-cmake"
         }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,8 @@ environment:
     APPVEYOR_SAVE_CACHE_ON_ERROR: true
     OPENSSL_ROOT: C:/OpenSSL-Win64
     MPATH: C:/mingw-w64/x86_64-7.2.0-posix-seh-rt_v5-rev1/mingw64/bin;C:/msys64/usr/bin
-    EVENT_TESTS_PARALLEL: 20
+    # Do not run tests in parallel to reduce false-positive
+    EVENT_TESTS_PARALLEL: 1
     EVENT_BUILD_PARALLEL: 10
   matrix:
     - EVENT_BUILD_METHOD: "cmake"


### PR DESCRIPTION
Many warnings appear when building and running with `Visual Studio 2019` in Appveyor:
> WARN C:\projects\libevent\test\regress_ssl.c:210: Version mismatch for openssl: compiled with 1000214f but running with 1000212f

Simply add the openssl binary to the "PATH" environment variable to fix it.

I wrote a simple demo to reproduce it: https://github.com/ygj6/verify
I see there are dozens of openssl libraries in the system of appveyor: https://ci.appveyor.com/project/ygj6/verify/builds/28290688
If you do not specify which openssl to use, the system cannot find the correct library.