### PR TITLE
cmake: register package for install tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1447,8 +1447,6 @@ set(EVENT_INSTALL_CMAKE_DIR
     "${CMAKE_INSTALL_PREFIX}/${DEF_INSTALL_CMAKE_DIR}"
     CACHE PATH "Installation directory for CMake files")
 
-export(PACKAGE libevent)
-
 # Generate the config file for the build-tree.
 set(EVENT__INCLUDE_DIRS
     "${PROJECT_SOURCE_DIR}/include"
@@ -1505,6 +1503,9 @@ install(FILES
 install(EXPORT LibeventTargets
         DESTINATION "${DEF_INSTALL_CMAKE_DIR}"
         COMPONENT dev)
+
+# Register package for the install-tree.
+register_package("${EVENT_INSTALL_CMAKE_DIR}")
 
 # Install the scripts.
 install(PROGRAMS


### PR DESCRIPTION
`export(PACKAGE libevent)` will register the package for build tree. In another project, when I search for the libevent library using `find_package()`, I will find the `cmake-build/LibeventConfig.cmake` file that configured from `cmake/LibeventConfigBuildTree.cmake.in`. Then I will receive an error message stating that there is no `event` library.


The function `register_package()` could register package for install tree, then  I can find `LibeventConfig.cmake` file that configured from `cmake/LibeventConfig.cmake.in`, which provides the correct libraries.