### PR TITLE
fix potential null pointer threat of evbase in libevent's process

### DIFF
--- a/event.c
+++ b/event.c
@@ -2091,6 +2091,9 @@ event_base_once(struct event_base *base, evutil_socket_t fd, short events,
 	int res = 0;
 	int activate = 0;
 
+	if (!base)
+		return (-1);
+
 	/* We cannot support signals that just fire once, or persistent
 	 * events. */
 	if (events & (EV_SIGNAL|EV_PERSIST))


### PR DESCRIPTION
If base is null, EVBASE_ACQUIRE_LOCK and EVBASE_RELEASE_LOCK would get
a coredump.

Signed-off-by: chenguolong <cgl.chenguolong@huawei.com>