### PR TITLE
evdns: fix a crash when evdns_base with waiting requests is freed

### DIFF
--- a/evdns.c
+++ b/evdns.c
@@ -4106,17 +4106,17 @@ evdns_base_free_and_unlock(struct evdns_base *base, int fail_requests)
 
 	/* TODO(nickm) we might need to refcount here. */
 
+	while (base->req_waiting_head) {
+		if (fail_requests)
+			reply_schedule_callback(base->req_waiting_head, 0, DNS_ERR_SHUTDOWN, NULL);
+		request_finished(base->req_waiting_head, &base->req_waiting_head, 1);
+	}
 	for (i = 0; i < base->n_req_heads; ++i) {
 		while (base->req_heads[i]) {
 			if (fail_requests)
 				reply_schedule_callback(base->req_heads[i], 0, DNS_ERR_SHUTDOWN, NULL);
 			request_finished(base->req_heads[i], &REQ_HEAD(base, base->req_heads[i]->trans_id), 1);
 		}
-	}
-	while (base->req_waiting_head) {
-		if (fail_requests)
-			reply_schedule_callback(base->req_waiting_head, 0, DNS_ERR_SHUTDOWN, NULL);
-		request_finished(base->req_waiting_head, &base->req_waiting_head, 1);
 	}
 	base->global_requests_inflight = base->global_requests_waiting = 0;
 

--- a/test/regress_dns.c
+++ b/test/regress_dns.c
@@ -2127,6 +2127,7 @@ dns_client_fail_requests_test(void *arg)
 {
 	struct basic_test_data *data = arg;
 	struct event_base *base = data->base;
+	int limit_inflight = data->setup_data && !strcmp(data->setup_data, "limit-inflight");
 	struct evdns_base *dns = NULL;
 	struct evdns_server_port *dns_port = NULL;
 	ev_uint16_t portnum = 0;
@@ -2143,6 +2144,9 @@ dns_client_fail_requests_test(void *arg)
 
 	dns = evdns_base_new(base, EVDNS_BASE_DISABLE_WHEN_INACTIVE);
 	tt_assert(!evdns_base_nameserver_ip_add(dns, buf));
+
+	if (limit_inflight)
+		tt_assert(!evdns_base_set_option(dns, "max-inflight:", "11"));
 
 	for (i = 0; i < 20; ++i)
 		evdns_base_resolve_ipv4(dns, "foof.example.com", 0, generic_dns_callback, &r[i]);
@@ -2437,6 +2441,8 @@ struct testcase_t dns_testcases[] = {
 
 	{ "client_fail_requests", dns_client_fail_requests_test,
 	  TT_FORK|TT_NEED_BASE|TT_NO_LOGS, &basic_setup, NULL },
+	{ "client_fail_waiting_requests", dns_client_fail_requests_test,
+	  TT_FORK|TT_NEED_BASE|TT_NO_LOGS, &basic_setup, (char*)"limit-inflight" },
 	{ "client_fail_requests_getaddrinfo",
 	  dns_client_fail_requests_getaddrinfo_test,
 	  TT_FORK|TT_NEED_BASE|TT_NO_LOGS, &basic_setup, NULL },


### PR DESCRIPTION
Fix undefined behaviour and application crash that might take
place in some rare cases after calling evdns_base_free when
there are requests in the waiting queue.

Current cleanup procedure in evdns_base_free_and_unlock
function includes 2 steps:
1. Finish all inflight requests.
2. Finish all waiting requests.

During the first step we iterate over each list in req_heads
structure and finish all requests in these lists. With current
logic finishing an inflight request (function request_finished)
removes it from the inflight requests container and forces
a wating connection to be sent (by calling
evdns_requests_pump_waiting_queue). When these new requests are
sent it is possible that they will be inserted to the list in
req_heads that we've already cleaned.
So in some cases container of the inflight requests is not empty
after this procedure and some requests are not finished and
deleted. When timeouts for these requests expire
evdns_request_timeout_callback is called but corresponding
evdns_base has been already deleted which causes undefined
behaviour and possible applicaton crash.

It is interesting to note that in old versions of libevent such
situation was not possible. This bug was introduced by the commit
14f84bbdc77d90b1d936076661443cdbf516c593. Before this commit
nameservers were deleted before finishing the requests. Therefore
it was not possible that requests from the waiting queue be sent
while we finish the inflight requests.