### PR TITLE
increase segment refcnt only if evbuffer_add_file_segment() succeeds

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -3226,7 +3226,6 @@ evbuffer_add_file_segment(struct evbuffer *buf,
 			}
 		}
 	}
-	++seg->refcnt;
 	EVLOCK_UNLOCK(seg->lock, 0);
 
 	if (buf->freeze_end)
@@ -3290,6 +3289,9 @@ evbuffer_add_file_segment(struct evbuffer *buf,
 		chain->off = length;
 	}
 
+	EVLOCK_LOCK(seg->lock, 0);
+	++seg->refcnt;
+	EVLOCK_UNLOCK(seg->lock, 0);
 	extra->segment = seg;
 	buf->n_add_for_cb += length;
 	evbuffer_chain_insert(buf, chain);
@@ -3316,7 +3318,7 @@ evbuffer_add_file(struct evbuffer *buf, int fd, ev_off_t offset, ev_off_t length
 	if (!seg)
 		return -1;
 	r = evbuffer_add_file_segment(buf, seg, 0, length);
-	if (r == -1)
+	if (r == 0)
 		evbuffer_file_segment_free(seg);
 	return r;
 }


### PR DESCRIPTION
In `evbuffer_add_file_segment()`, assuming `seg` is frozen, the function will goto err, but `refcnt` will still increase to 2. It is more reasonable to increase segment refcnt only when the function is successful.

Otherwise, in `evbuffer_add_file()`,  `evbuffer_file_segment` can't be freed
```
evbuffer_add_file(struct evbuffer *buf, int fd, ev_off_t offset, ev_off_t length)
{
	struct evbuffer_file_segment *seg;
	unsigned flags = EVBUF_FS_CLOSE_ON_FREE;
	int r;
	seg = evbuffer_file_segment_new(fd, offset, length, flags);   // seg.refcnt = 1
	if (!seg)
		return -1;
	r = evbuffer_add_file_segment(buf, seg, 0, length);   // If add_file_segment fails, seg.refcnt = 1,  otherwise seg.refcnt = 2
	if (r == -1)  
		evbuffer_file_segment_free(seg);     // seg.refcnt = 0
	return r;        // If succeeds, seg.refcnt = 2, invoking evbuffer_free() only once don't free seg. And if fails, seg.refcnt = 0, invoking evbuffer_free() will cause double-free
}
```
