### PR TITLE
Clean up event_rpcgen.py

### DIFF
--- a/event_rpcgen.py
+++ b/event_rpcgen.py
@@ -1309,6 +1309,11 @@ def NormalizeLine(line):
 
     return line
 
+
+NAME_RE = re.compile(r"(?P<name>[^\[\]]+)(\[(?P<fixed_length>.*)\])?")
+TAG_NUMBER_RE = re.compile(r"(0x)?\d+", re.I)
+
+
 def ProcessOneEntry(factory, newstruct, entry):
     optional = 0
     array = 0
@@ -1319,11 +1324,7 @@ def ProcessOneEntry(factory, newstruct, entry):
     separator = ''
     fixed_length = ''
 
-    tokens = entry.split(' ')
-    while tokens:
-        token = tokens[0]
-        tokens = tokens[1:]
-
+    for token in entry.split(" "):
         if not entry_type:
             if not optional and token == 'optional':
                 optional = 1

--- a/event_rpcgen.py
+++ b/event_rpcgen.py
@@ -14,8 +14,8 @@
 #    progress outputs that space stderr at the moment)
 # 3) emit other languages
 
-import sys
 import re
+import sys
 
 _NAME = "event_rpcgen.py"
 _VERSION = "0.1"

--- a/event_rpcgen.py
+++ b/event_rpcgen.py
@@ -1711,21 +1711,22 @@ class CommandLine:
             entry.PrintCode(impl_fp)
         impl_fp.close()
 
-if __name__ == '__main__':
-    try:
-        CommandLine(sys.argv).run()
-        sys.exit(0)
 
+def main(argv=None):
+    try:
+        CommandLine(argv).run()
+        return 0
     except RpcGenError as e:
         sys.stderr.write(e)
-        sys.exit(1)
-
     except EnvironmentError as e:
         if e.filename and e.strerror:
             sys.stderr.write("%s: %s" % (e.filename, e.strerror))
-            sys.exit(1)
         elif e.strerror:
             sys.stderr.write(e.strerror)
-            sys.exit(1)
         else:
             raise
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(argv=sys.argv))

--- a/event_rpcgen.py
+++ b/event_rpcgen.py
@@ -41,12 +41,16 @@ def declare(s):
 def TranslateList(mylist, mydict):
     return [x % mydict for x in mylist]
 
-# Exception class for parse errors
+
 class RpcGenError(Exception):
-        def __init__(self, why):
-                self.why = why
-        def __str__(self):
-                return str(self.why)
+    """An Exception class for parse errors."""
+
+    def __init__(self, why):
+        self.why = why
+
+    def __str__(self):
+        return str(self.why)
+
 
 # Holds everything that makes a struct
 class Struct:

--- a/event_rpcgen.py
+++ b/event_rpcgen.py
@@ -1689,32 +1689,29 @@ class CommandLine:
 
         declare('Reading \"%s\"' % filename)
 
-        fp = open(filename, 'r')
-        entities = Parse(factory, fp)
-        fp.close()
+        with open(filename, "r") as fp:
+            entities = Parse(factory, fp)
 
         declare('... creating "%s"' % header_file)
-        header_fp = open(header_file, 'w')
-        header_fp.write(factory.HeaderPreamble(filename))
+        with open(header_file, "w") as header_fp:
+            header_fp.write(factory.HeaderPreamble(filename))
 
-        # Create forward declarations: allows other structs to reference
-        # each other
-        for entry in entities:
-            entry.PrintForwardDeclaration(header_fp)
-        header_fp.write('\n')
+            # Create forward declarations: allows other structs to reference
+            # each other
+            for entry in entities:
+                entry.PrintForwardDeclaration(header_fp)
+            header_fp.write('\n')
 
-        for entry in entities:
-            entry.PrintTags(header_fp)
-            entry.PrintDeclaration(header_fp)
-        header_fp.write(factory.HeaderPostamble(filename))
-        header_fp.close()
+            for entry in entities:
+                entry.PrintTags(header_fp)
+                entry.PrintDeclaration(header_fp)
+            header_fp.write(factory.HeaderPostamble(filename))
 
         declare('... creating "%s"' % impl_file)
-        impl_fp = open(impl_file, 'w')
-        impl_fp.write(factory.BodyPreamble(filename, header_file))
-        for entry in entities:
-            entry.PrintCode(impl_fp)
-        impl_fp.close()
+        with open(impl_file, "w") as impl_fp:
+            impl_fp.write(factory.BodyPreamble(filename, header_file))
+            for entry in entities:
+                entry.PrintCode(impl_fp)
 
 
 def main(argv=None):


### PR DESCRIPTION
This change makes multiple high-level improvements:

* Sorts imports.
* Fix indentation issues with `RpcGenError`.
* Iterates over tokens with a for loop instead of slicing in a while loop.
* Handles all file pointers with context suites for cleanliness.
* Uses `bool`s instead of `int`s for clarity.
* Renames all global variables to a form that is compliant with PEP8.
* Precompile regular expressions for performance.
* Converts raw parsing of `sys.argv` with `argparse` use. This usage messages as the `Usage` error was not properly initializing the superclass with the `.why` parameter, despite the fact that it was inheriting from the superclass.