### PR TITLE
Fix typo in windows GetAdaptersAddresses library name

### DIFF
--- a/evutil.c
+++ b/evutil.c
@@ -879,7 +879,7 @@ evutil_check_ifaddrs(void)
 	   "GetAdaptersInfo", but that's deprecated; let's just try
 	   GetAdaptersAddresses and fall back to connect+getsockname.
 	*/
-	HMODULE lib = evutil_load_windows_system_library_(TEXT("ihplapi.dll"));
+	HMODULE lib = evutil_load_windows_system_library_(TEXT("iphlpapi.dll"));
 	GetAdaptersAddresses_fn_t fn;
 	ULONG size, res;
 	IP_ADAPTER_ADDRESSES *addresses = NULL, *address;


### PR DESCRIPTION
There is typo in GetAdaptersAddresses windows library. It should be iphlpapi.dll