### PR TITLE
Fix clang-format-diff usage

### DIFF
--- a/checkpatch.sh
+++ b/checkpatch.sh
@@ -164,8 +164,8 @@ function clang_style()
     local c="${options[cfg]}"
     echo "{ $(sed -e 's/#.*//' -e '/---/d' -e '/\.\.\./d' "$c" | tr $'\n' ,) }"
 }
-function clang_format() { clang-format --style="$(clang_style)" "$@"; }
-function clang_format_diff() { clang-format-diff --style="$(clang_style)" "$@"; }
+function clang_format() { clang-format -style="$(clang_style)" "$@"; }
+function clang_format_diff() { clang-format-diff -style="$(clang_style)" "$@"; }
 # for non-bare repo will work
 function clang_format_git()
 { git format-patch --stdout "$@" -1 | clang_format_diff; }


### PR DESCRIPTION
```
"--style" is invalid:

$ ./checkpatch.sh -r HEAD
usage: clang-format-diff [-h] [-i] [-p NUM] [-regex PATTERN] [-iregex PATTERN]
                         [-sort-includes] [-v] [-style STYLE] [-binary BINARY]
clang-format-diff: error: unrecognized arguments: --style={ Language:... }
```

References:

- https://clang.llvm.org/docs/ClangFormat.html#script-for-patch-reformatting
- https://github.com/llvm/llvm-project/blob/llvmorg-10.0.0/clang/tools/clang-format/clang-format-diff.py
