### PR TITLE
evdns: Add support for setting maximum UDP DNS message size.

### DIFF
--- a/include/event2/dns.h
+++ b/include/event2/dns.h
@@ -203,6 +203,7 @@ extern "C" {
  * - randomize-case:
  * - initial-probe-timeout:
  * - tcp-idle-timeout:
+ * - edns-udp-size:
  * - use-vc
  * - ignore-tc
  */
@@ -470,7 +471,8 @@ void evdns_cancel_request(struct evdns_base *base, struct evdns_request *req);
 
     ndots, timeout, max-timeouts, max-inflight, attempts, randomize-case,
     bind-to, initial-probe-timeout, getaddrinfo-allow-skew,
-    so-rcvbuf, so-sndbuf, tcp-idle-timeout, use-vc, ignore-tc.
+    so-rcvbuf, so-sndbuf, tcp-idle-timeout, use-vc, ignore-tc,
+    edns-udp-size.
 
   In versions before Libevent 2.0.3-alpha, the option name needed to end with
   a colon.


### PR DESCRIPTION
Added new option `edns-udp-size` for evdns_base which allows
to control maximum allowed size of UDP DNS messages. This
maximum size is passed to the DNS server via edns mechanism.

Closes: #684