### PR TITLE
cmake: avoid problems from use of CMAKE_USE_PTHREADS_INIT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -972,7 +972,7 @@ if (NOT EVENT__DISABLE_OPENSSL)
         SOURCES ${SRC_OPENSSL})
 endif()
 
-if (CMAKE_USE_PTHREADS_INIT)
+if (EVENT__HAVE_PTHREADS)
     set(SRC_PTHREADS evthread_pthread.c)
     add_event_library(event_pthreads
         INNER_LIBRARIES event_core
@@ -1148,7 +1148,7 @@ if (NOT EVENT__DISABLE_TESTS)
                 if (NOT EVENT__DISABLE_THREAD_SUPPORT)
                     list(APPEND SRC_REGRESS test/regress_thread.c)
                 endif()
-            elseif (CMAKE_USE_PTHREADS_INIT)
+            elseif (EVENT__HAVE_PTHREADS)
                 list(APPEND SRC_REGRESS test/regress_thread.c)
             endif()
 


### PR DESCRIPTION
In some CMake integrations, portions of the toolchain may end up
defining CMAKE_USE_PTHREADS_INIT even when EVENT__DISABLE_THREAD_SUPPORT
is set for libevent.  Modify the build to not rely on this side effect
of find_package(Threads, ...) [which could be done elsewhere] but instead
to use EVENT__HAVE_PTHREADS which is defined only on the desired codepath.

Without this change, affected builds fail as a result of event_pthreads source
files being built but with build defines which cause the build to fail.

Signed-off-by: Paul Osborne <paul.osborne@smartthings.com>