### PR TITLE
wepoll: use lower-cased windows headers

### DIFF
--- a/wepoll.c
+++ b/wepoll.c
@@ -135,9 +135,9 @@ WEPOLL_EXPORT int epoll_wait(HANDLE ephnd,
 #pragma warning(push, 1)
 #endif
 
-#include <WS2tcpip.h>
-#include <WinSock2.h>
-#include <Windows.h>
+#include <ws2tcpip.h>
+#include <winsock2.h>
+#include <windows.h>
 
 #ifndef __GNUC__
 #pragma warning(pop)


### PR DESCRIPTION
This matches their use throughout the rest of the project, and fixes the
build when you are cross-compiling on Linux using mingw-w64. i.e:
```bash
  CC       epoll.lo
  CC       wepoll.lo
  CC       signal.lo
wepoll.c:138:10: fatal error: WS2tcpip.h: No such file or directory
 #include <WS2tcpip.h>
          ^~~~~~~~~~~~
compilation terminated.
make[2]: *** [Makefile:1918: wepoll.lo] Error 1
```