### PR TITLE
Make all classes Entry, Struct, etc) new-style classes

### DIFF
--- a/event_rpcgen.py
+++ b/event_rpcgen.py
@@ -62,7 +62,7 @@ class RpcGenError(Exception):
 
 
 # Holds everything that makes a struct
-class Struct:
+class Struct(object):
     def __init__(self, name):
         self._name = name
         self._entries = []
@@ -422,7 +422,7 @@ evtag_marshal_%(name)s(struct evbuffer *evbuf, ev_uint32_t tag,
         )
 
 
-class Entry:
+class Entry(object):
     def __init__(self, ent_type, name, tag):
         self._type = ent_type
         self._name = name
@@ -1697,7 +1697,7 @@ def Parse(factory, filep):
     return entities
 
 
-class CCodeGenerator:
+class CCodeGenerator(object):
     def __init__(self):
         pass
 
@@ -1826,7 +1826,7 @@ class CCodeGenerator:
         return EntryArray(entry)
 
 
-class CommandLine:
+class CommandLine(object):
     def __init__(self, argv=None):
         """Initialize a command-line to launch event_rpcgen, as if
            from a command-line with CommandLine(sys.argv).  If you're


### PR DESCRIPTION
This allows the object methods to be properly inherited and called via
`super(..)`, addressing breakage with python 2.x, introduced in
cfcc093606e747a5d250787012bac0b149c60d6d.

Fixes #1042.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>