### PR TITLE
build: do not disable deprecation warnings on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,9 +325,8 @@ if (${GNUC})
 endif()
 
 if (APPLE)
-    # Get rid of deprecated warnings for OpenSSL on OSX 10.7 and greater.
+    # Clang on macOS emits warnings for each directory specified which isn't used
     add_compiler_flags(
-        -Wno-error=deprecated-declarations
         -Qunused-arguments
     )
 endif()

--- a/configure.ac
+++ b/configure.ac
@@ -900,9 +900,6 @@ if test x$enable_gcc_warnings != xno && test "$GCC" = "yes"; then
             dnl Clang on macOS emits warnings for each directory specified which
             dnl isn't "used", generating a lot of build noise.
             CFLAGS="$CFLAGS -Qunused-arguments"
-            dnl macOS Lion started deprecating the system OpenSSL. Let's just
-            dnl disable all deprecation warnings on macOS; but do so only for GCC.
-            CFLAGS="$CFLAGS -Wno-deprecated-declarations"
         ;;
     esac
   fi


### PR DESCRIPTION
this was for using openssl-0.9.8 included in macOS 10.7 - 10.12,
but it is long since time you really should not use that openssl

------

I was also thinking about removing the checks for gcc < 4.2 (which was released on 2007, and used on macOS until 2012 because it was the last release under GPLv2), but I saw that the check for gcc-2.95 was added in libevent 2.0.19 in 2012 ... I like good backwards compatibility and maintaining old embedded systems, but it's pretty crazy that anyone used gcc < 2.95 in the last 15 years even for old embedded systems that never got a toolchain update. gcc-2.95 was a legend from the past when I started using Linux heavily around 2004. But meh.