### PR TITLE
build: detect and append warning flags only if they are available

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,10 +4,6 @@
 #
 # See LICENSE for copying information.
 
-# 'foreign' means that we're not enforcing GNU package rules strictly.
-# '1.13' means that we need automake 1.13 or later (and we do).
-AUTOMAKE_OPTIONS = foreign 1.13 subdir-objects
-
 ACLOCAL_AMFLAGS = -I m4
 
 # This is the "Release" of the Libevent ABI.  It takes precedence over

--- a/configure.ac
+++ b/configure.ac
@@ -45,23 +45,6 @@ AC_PROG_SED
 
 AC_PROG_GCC_TRADITIONAL
 
-dnl We need to test for at least gcc 2.95 here, because older versions don't
-dnl have -fno-strict-aliasing
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [
-#if !defined(__GNUC__) || (__GNUC__ < 2) || (__GNUC__ == 2 && __GNUC_MINOR__ < 95)
-#error
-#endif])], have_gcc295=yes, have_gcc295=no)
-
-if test "$GCC" = "yes" ; then
-        dnl Enable many gcc warnings by default...
-        CFLAGS="$CFLAGS -Wall"
-	dnl And disable the strict-aliasing optimization, since it breaks
-	dnl our sockaddr-handling code in strange ways.
-	if test x$have_gcc295 = xyes; then
-		CFLAGS="$CFLAGS -fno-strict-aliasing"
-	fi
-fi
-
 AC_ARG_ENABLE(gcc-warnings,
      AS_HELP_STRING(--disable-gcc-warnings, disable verbose warnings with GCC))
 
@@ -835,72 +818,66 @@ if test x$enable_verbose_debug = xyes; then
 	CFLAGS="$CFLAGS -DUSE_DEBUG"
 fi
 
-dnl check if we have and should use openssl
+dnl check if we have and should use OpenSSL
 AM_CONDITIONAL(OPENSSL, [test "$enable_openssl" != "no" && test "$have_openssl" = "yes"])
 
-dnl Add some more warnings which we use in development but not in the
-dnl released versions.  (Some relevant gcc versions can't handle these.)
+dnl enable some warnings by default
+AX_CHECK_COMPILE_FLAG([-Wall], [CFLAGS="$CFLAGS -Wall"],[],[-Werror])
+
+dnl Disable the strict-aliasing optimization, since it breaks
+dnl our sockaddr-handling code in strange ways.
+dnl See 52eb4951302554dd696d6a0120ad5d3f6cffb7bb.
+AX_CHECK_COMPILE_FLAG([-fno-strict-aliasing], [CFLAGS="$CFLAGS -fno-strict-aliasing"],[],[-Werror])
+
+dnl Add warnings which we use in development but not for releases.
 if test x$enable_gcc_warnings != xno && test "$GCC" = "yes"; then
 
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [
-#if !defined(__GNUC__) || (__GNUC__ < 4)
-#error
-#endif])], have_gcc4=yes, have_gcc4=no)
-
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [
-#if !defined(__GNUC__) || (__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 2)
-#error
-#endif])], have_gcc42=yes, have_gcc42=no)
-
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [
-#if !defined(__GNUC__) || (__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 5)
-#error
-#endif])], have_gcc45=yes, have_gcc45=no)
-
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [
-#if !defined(__clang__)
-#error
-#endif])], have_clang=yes, have_clang=no)
-
   dnl -W is the same as -Wextra
-  CFLAGS="$CFLAGS -W -Wfloat-equal -Wundef -Wpointer-arith -Wstrict-prototypes -Wmissing-prototypes -Wwrite-strings -Wredundant-decls -Wmissing-declarations -Wnested-externs -Wbad-function-cast"
+  AX_CHECK_COMPILE_FLAG([-W], [CFLAGS="$CFLAGS -W"],[],[-Werror])
+
+  dnl The AX_CHECK_COMPILE_FLAG macro ignores warnings, so -Werror is used
+  dnl to convert warnings into errors and prevent the addition of unknown flags.
+  AX_CHECK_COMPILE_FLAG([-Waddress],[CFLAGS="$CFLAGS -Waddress"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Wbad-function-cast],[CFLAGS="$CFLAGS -Wbad-function-cast"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Wdeclaration-after-statement],[CFLAGS="$CFLAGS -Wdeclaration-after-statement"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Wfloat-equal],[CFLAGS="$CFLAGS -Wfloat-equal"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Winit-self],[CFLAGS="$CFLAGS -Winit-self"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Wlogical-op],[CFLAGS="$CFLAGS -Wlogical-op"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Wmissing-declarations],[CFLAGS="$CFLAGS -Wmissing-declarations"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Wmissing-field-initializers],[CFLAGS="$CFLAGS -Wmissing-field-initializers"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Wmissing-prototypes],[CFLAGS="$CFLAGS -Wmissing-prototypes"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Wnested-externs],[CFLAGS="$CFLAGS -Wnested-externs"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Wnormalized=id],[CFLAGS="$CFLAGS -Wnormalized=id"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Woverride-init],[CFLAGS="$CFLAGS -Woverride-init"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Wpointer-arith],[CFLAGS="$CFLAGS -Wpointer-arith"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Wredundant-decls],[CFLAGS="$CFLAGS -Wredundant-decls"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Wstrict-aliasing],[CFLAGS="$CFLAGS -Wstrict-aliasing"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Wstrict-prototypes],[CFLAGS="$CFLAGS -Wstrict-prototypes"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Wundef],[CFLAGS="$CFLAGS -Wundef"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Wwrite-strings],[CFLAGS="$CFLAGS -Wwrite-strings"],[],[-Werror])
+
+  dnl Convert warnings into errors
   if test x$enable_gcc_warnings = xyes; then
-    CFLAGS="$CFLAGS -Werror"
+    AX_CHECK_COMPILE_FLAG([-Werror], [CFLAGS="$CFLAGS -Werror"])
   fi
 
-  CFLAGS="$CFLAGS -Wno-unused-parameter -Wstrict-aliasing"
+  dnl Disable warnings for unused paramaters
+  AX_CHECK_COMPILE_FLAG([-Wno-unused-parameter], [CFLAGS="$CFLAGS -Wno-unused-parameter"],[],[-Werror])
 
-  if test x$have_gcc4 = xyes ; then
-    dnl These warnings break gcc 3.3.5 and work on gcc 4.0.2
-    CFLAGS="$CFLAGS -Winit-self -Wmissing-field-initializers -Wdeclaration-after-statement"
-    dnl CFLAGS="$CFLAGS -Wold-style-definition"
-  fi
-
-  if test x$have_gcc42 = xyes ; then
-    dnl These warnings break gcc 4.0.2 and work on gcc 4.2
-    CFLAGS="$CFLAGS -Waddress"
-  fi
-
-  if test x$have_gcc42 = xyes && test x$have_clang = xno; then
-    dnl These warnings break gcc 4.0.2 and clang, but work on gcc 4.2
-    CFLAGS="$CFLAGS -Wnormalized=id -Woverride-init"
-  fi
-
-  if test x$have_gcc45 = xyes ; then
-    dnl These warnings work on gcc 4.5
-    CFLAGS="$CFLAGS -Wlogical-op"
-  fi
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [
+  #if !defined(__clang__)
+  #error
+  #endif])], have_clang=yes, have_clang=no)
 
   if test x$have_clang = xyes; then
     dnl Disable unused-function warnings. These trigger for minheap-internal.h.
-    CFLAGS="$CFLAGS -Wno-unused-function"
+    AX_CHECK_COMPILE_FLAG([-Wno-unused-function], [CFLAGS="$CFLAGS -Wno-unused-function"],[],[-Werror])
 
     case "$host_os" in
-        darwin*)
-            dnl Clang on macOS emits warnings for each directory specified which
-            dnl isn't "used", generating a lot of build noise.
-            CFLAGS="$CFLAGS -Qunused-arguments"
-        ;;
+      darwin*)
+        dnl Clang on macOS emits warnings for each directory specified which
+        dnl isn't "used", generating a lot of build noise.
+        AX_CHECK_COMPILE_FLAG([-Qunused-arguments], [CFLAGS="$CFLAGS -Qunused-arguments"],[],[-Werror])
     esac
   fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -842,7 +842,6 @@ if test x$enable_gcc_warnings != xno && test "$GCC" = "yes"; then
   AX_CHECK_COMPILE_FLAG([-Woverride-init],[CFLAGS="$CFLAGS -Woverride-init"],[],[-Werror])
   AX_CHECK_COMPILE_FLAG([-Wpointer-arith],[CFLAGS="$CFLAGS -Wpointer-arith"],[],[-Werror])
   AX_CHECK_COMPILE_FLAG([-Wredundant-decls],[CFLAGS="$CFLAGS -Wredundant-decls"],[],[-Werror])
-  AX_CHECK_COMPILE_FLAG([-Wstrict-aliasing],[CFLAGS="$CFLAGS -Wstrict-aliasing"],[],[-Werror])
   AX_CHECK_COMPILE_FLAG([-Wstrict-prototypes],[CFLAGS="$CFLAGS -Wstrict-prototypes"],[],[-Werror])
   AX_CHECK_COMPILE_FLAG([-Wundef],[CFLAGS="$CFLAGS -Wundef"],[],[-Werror])
   AX_CHECK_COMPILE_FLAG([-Wwrite-strings],[CFLAGS="$CFLAGS -Wwrite-strings"],[],[-Werror])

--- a/configure.ac
+++ b/configure.ac
@@ -11,9 +11,14 @@ AC_CONFIG_SRCDIR(event.c)
 
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])
-AM_INIT_AUTOMAKE
-dnl AM_SILENT_RULES req. automake 1.11.  [no] defaults V=1
+
+dnl Automake setup
+dnl 'foreign' means that GNU package rules are not strictly enforced.
+AM_INIT_AUTOMAKE([1.13 foreign subdir-objects])
+
+dnl make compilation quiet unless V=1 is used
 AM_SILENT_RULES([yes])
+
 AC_CONFIG_HEADERS(config.h  evconfig-private.h:evconfig-private.h.in)
 AC_DEFINE(NUMERIC_VERSION, 0x02020001, [Numeric representation of the version])
 

--- a/configure.ac
+++ b/configure.ac
@@ -23,26 +23,16 @@ AC_PREFIX_DEFAULT([/usr/local])
 dnl Try and get a full POSIX environment on obscure systems
 AC_USE_SYSTEM_EXTENSIONS
 
-AC_CANONICAL_BUILD
-AC_CANONICAL_HOST
 dnl the 'build' machine is where we run configure and compile
 dnl the 'host' machine is where the resulting stuff runs.
-
-dnlcase "$host_os" in
-dnl
-dnl osf5*)
-dnl    CFLAGS="$CFLAGS -D_OSF_SOURCE"
-dnl    ;;
-dnlesac
+AC_CANONICAL_BUILD
+AC_CANONICAL_HOST
 
 dnl Checks for programs.
 AM_PROG_CC_C_O
 AC_PROG_INSTALL
 AC_PROG_LN_S
-dnl AC_PROG_MKDIR_P - $(MKDIR_P) should be defined by AM_INIT_AUTOMAKE
-
 AC_PROG_SED
-
 AC_PROG_GCC_TRADITIONAL
 
 AC_ARG_ENABLE(gcc-warnings,
@@ -91,10 +81,6 @@ AC_ARG_ENABLE([clock-gettime],
 LT_PREREQ([2.4.2])
 LT_INIT
 
-dnl   Uncomment "AC_DISABLE_SHARED" to make shared libraries not get
-dnl   built by default.  You can also turn shared libs on and off from
-dnl   the command line with --enable-shared and --disable-shared.
-dnl AC_DISABLE_SHARED
 AC_SUBST(LIBTOOL_DEPS)
 
 AM_CONDITIONAL([BUILD_SAMPLES], [test "$enable_samples" = "yes"])
@@ -880,10 +866,6 @@ if test x$enable_gcc_warnings != xno && test "$GCC" = "yes"; then
         AX_CHECK_COMPILE_FLAG([-Qunused-arguments], [CFLAGS="$CFLAGS -Qunused-arguments"],[],[-Werror])
     esac
   fi
-
-dnl This will break the world on some 64-bit architectures
-dnl CFLAGS="$CFLAGS -Winline"
-
 fi
 
 LIBEVENT_GC_SECTIONS=

--- a/m4/ax_check_compile_flag.m4
+++ b/m4/ax_check_compile_flag.m4
@@ -1,0 +1,53 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS


### PR DESCRIPTION
This is a followup to #1046. Opening a draft for feedback.

Rather than appending flags directly, or testing for various old versions of GCC, check if the flag will work with the compiler, and append it to CFLAGS if so. `-Werror` is used, so that flags which aren't understood, i.e Clang and `-Wlogical-op`, don't end up appended (AX_CHECK_COMPILE_FLAG ignores warnings).

This also removes code which is commented out, and moves the automake options into configure.

Note: Why is `-Wstrict-aliasing` explicitly turned on (it's also part of `-Wall`), when strict aliasing is disabled using `-fno-strict-aliasing`? Looking at the git history is seems that it was added before strict aliasing was disabled. 