### PR TITLE
build: attempt to find OpenSSL via homebrew on macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -132,12 +132,6 @@ jobs:
       - name: Build And Test
         shell: bash
         run: |
-          if [ "${{ matrix.EVENT_MATRIX }}" == "OPENSSL_1_1" ]; then
-            export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig:$PKG_CONFIG_PATH"
-          else
-            export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH"
-          fi
-
           if [ "${{ matrix.EVENT_MATRIX }}" == "DISABLE_OPENSSL" ]; then
             EVENT_CONFIGURE_OPTIONS="--disable-openssl"
 

--- a/m4/libevent_openssl.m4
+++ b/m4/libevent_openssl.m4
@@ -3,6 +3,22 @@ dnl OpenSSL support
 AC_DEFUN([LIBEVENT_OPENSSL], [
 AC_REQUIRE([NTP_PKG_CONFIG])dnl
 
+case "$host_os" in
+    darwin*)
+    dnl when compiling for Darwin, attempt to find OpenSSL using brew.
+    dnl We append the location given by brew to PKG_CONFIG_PATH path
+    dnl and then export it, so that it can be used in detection below.
+    AC_CHECK_PROG([BREW],brew, brew)
+    if test x$BREW = xbrew; then
+        openssl_prefix=$($BREW --prefix openssl 2>/dev/null)
+        if test xopenssl_prefix != x; then
+            PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$openssl_prefix/lib/pkgconfig"
+            export PKG_CONFIG_PATH
+        fi
+    fi
+    ;;
+esac
+
 case "$enable_openssl" in
  yes)
     have_openssl=no
@@ -27,7 +43,7 @@ case "$enable_openssl" in
 	LIBS=""
 	OPENSSL_LIBS=""
 	for lib in crypto eay32; do
-		# clear cache
+		dnl clear cache
 		unset ac_cv_search_SSL_new
 		AC_SEARCH_LIBS([SSL_new], [ssl ssl32],
 		    [have_openssl=yes
@@ -47,15 +63,15 @@ case "$enable_openssl" in
     AC_SUBST(OPENSSL_LIBS)
     case "$have_openssl" in
      yes)  AC_DEFINE(HAVE_OPENSSL, 1, [Define if the system has openssl]) ;;
-     *) AC_MSG_ERROR([openssl is a must but can not be found. You should add the \
-directory containing `openssl.pc' to the `PKG_CONFIG_PATH' environment variable, \
-or set `CFLAGS' and `LDFLAGS' directly for openssl, or use `--disable-openssl' \
-to disable support for openssl encryption])
+     *) AC_MSG_ERROR([OpenSSL could not be found. You should add the directory \
+     containing 'openssl.pc' to the 'PKG_CONFIG_PATH' environment variable, set \
+     'CFLAGS' and 'LDFLAGS' directly, or use '--disable-openssl' to disable \
+     support for OpenSSL encryption])
 	;;
     esac
     ;;
 esac
 
-# check if we have and should use openssl
+dnl check if we have and should use OpenSSL
 AM_CONDITIONAL(OPENSSL, [test "$enable_openssl" != "no" && test "$have_openssl" = "yes"])
 ])


### PR DESCRIPTION
When compiling on macOS, where users will likely have OpenSSL installed via [brew](https://github.com/Homebrew/brew) (or maybe another package manager), use `brew  --prefix` to figure out where OpenSSL is, and then augment the pkg-config path so that it is found.

From what I can tell, OpenSSL is currently found in the CI's, because the GitHub actions image for macOS, symlinks the brew installed OpenSSL into `/usr/local/` (which is not done by default in a homebrew installation). See: https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md#utilities.

This also clarifies the language in the error message. "openssl is a must" isn't correct, as it's perfectly fine to compile libevent without OpenSSL.

Opening this as a draft, as it may be too platform specific for what you'd like in your macros. Up until this point, I've just been building with `--disable-openssl` when compiling libevent on macOS.