### PR TITLE
fix CI failures

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,15 +43,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2.0.0
       - name: Cache Build
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v2
         with:
           path: build
-          key: ${{ matrix.os }}-cmake-${{ matrix.EVENT_MATRIX }}-v2
+          key: ${{ matrix.os }}-cmake-${{ matrix.EVENT_MATRIX }}-v3
       - name: Cache Dist Build
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v2
         with:
           path: dist
-          key: ${{ matrix.os }}-cmake-dist-${{ matrix.EVENT_MATRIX }}-v2
+          key: ${{ matrix.os }}-cmake-dist-${{ matrix.EVENT_MATRIX }}-v3
 
       - name: Install Depends
         run: |
@@ -148,15 +148,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2.0.0
       - name: Cache Build
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v2
         with:
           path: build
           key: ${{ matrix.os }}-autotools-${{ matrix.EVENT_MATRIX }}-v2
       - name: Cache Dist Build
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v2
         with:
           path: dist
-          key: ${{ matrix.os }}-autotools-dist-${{ matrix.EVENT_MATRIX }}-v2
+          key: ${{ matrix.os }}-autotools-dist-${{ matrix.EVENT_MATRIX }}-v3
 
       - name: Install Depends
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,10 +40,10 @@ jobs:
       - uses: actions/checkout@v2.0.0
 
       - name: Cache Build
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v2
         with:
           path: build
-          key: macos-10.15-cmake-${{ matrix.EVENT_MATRIX }}-v2
+          key: macos-10.15-cmake-${{ matrix.EVENT_MATRIX }}-v3
 
       - name: Install Depends
         run: brew install mbedtls
@@ -121,10 +121,10 @@ jobs:
       - uses: actions/checkout@v2.0.0
 
       - name: Cache Build
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v2
         with:
           path: build
-          key: ${{ matrix.os }}-autotools-${{ matrix.EVENT_MATRIX }}-v2
+          key: ${{ matrix.os }}-autotools-${{ matrix.EVENT_MATRIX }}-v3
 
       - name: Install Depends
         run: brew install autoconf automake libtool pkg-config mbedtls

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -34,29 +34,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.0.0
-
-      - name: Cache MinGW
-        id: cache-mingw
-        uses: actions/cache@v1.1.2
-        with:
-          path: D:\a\_temp\msys
-          key: windows-mingw
-
       - name: Cache Build
-        uses: actions/cache@v1.1.2
+        uses: actions/cache@v2
         with:
           path: build
-          key: mingw-autotools-${{ matrix.EVENT_MATRIX }}-v3
-
-      - uses: numworks/setup-msys2@v1
-        if: steps.cache-mingw.outputs.cache-hit != 'true'
+          key: mingw-autotools-${{ matrix.EVENT_MATRIX }}-v4
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
-
-      - name: Install Dependes
-        if: steps.cache-mingw.outputs.cache-hit != 'true'
-        run: |
-          msys2do pacman -S --noconfirm mingw-w64-x86_64-gcc autoconf automake libtool mingw-w64-x86_64-openssl mingw-w64-x86_64-mbedtls
+          update: true
+          install: mingw-w64-x86_64-gcc autoconf automake libtool mingw-w64-x86_64-openssl mingw-w64-x86_64-mbedtls
 
       - name: Build And Test
         shell: powershell
@@ -103,29 +91,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.0.0
-
-      - name: Cache MinGW
-        id: cache-mingw-cmake
-        uses: actions/cache@v1.1.2
-        with:
-          path: D:\a\_temp\msys
-          key: windows-mingw-cmake
-
       - name: Cache Build
-        uses: actions/cache@v1.1.2
+        uses: actions/cache@v2
         with:
           path: build
-          key: mingw-cmake-${{ matrix.EVENT_MATRIX }}-v3
+          key: mingw-cmake-${{ matrix.EVENT_MATRIX }}-v4
 
-      - uses: numworks/setup-msys2@v1
-        if: steps.cache-mingw-cmake.outputs.cache-hit != 'true'
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
-
-      - name: Install Dependes
-        if: steps.cache-mingw-cmake.outputs.cache-hit != 'true'
-        run: |
-          msys2do pacman -S --noconfirm mingw-w64-x86_64-gcc mingw-w64-x86_64-openssl mingw-w64-x86_64-mbedtls
+          update: true
+          install: mingw-w64-x86_64-gcc mingw-w64-x86_64-openssl mingw-w64-x86_64-mbedtls  
 
       - name: Build And Test
         shell: powershell

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,26 +31,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2.0.0
 
-      - name: Cache Depends
-        id: cache-depends
-        uses: actions/cache@v1.0.3
-        with:
-          path: C:\vcpkg\installed
-          key: ${{ matrix.os }}-vcpkg-v2
-
       - name: Cache Build
-        uses: actions/cache@v1.0.3
+        uses: actions/cache@v2
         with:
           path: build
-          key: ${{ matrix.os }}-${{ matrix.EVENT_MATRIX }}-v3
+          key: ${{ matrix.os }}-${{ matrix.EVENT_MATRIX }}-v4
 
-      - name: Install Depends
-        if: steps.cache-depends.outputs.cache-hit != 'true'
-        shell: powershell
-        run: |
-          vcpkg install openssl:x64-windows
-          vcpkg install zlib:x64-windows
-          vcpkg install mbedtls:x64-windows
+      - name: Prepare vcpkg
+        uses: lukka/run-vcpkg@v2
+        id: runvcpkg
+        with:
+          vcpkgArguments: zlib:x64-windows openssl:x64-windows mbedtls:x64-windows
+          vcpkgDirectory: ${{ runner.workspace }}/vcpkg/
+          vcpkgGitCommitId: 8e76503a769e153dad8f4e7b2c95a152bb35edaa
+          vcpkgTriplet: x64-windows
 
       - name: Build And Test
         shell: powershell
@@ -61,7 +55,7 @@ jobs:
           mkdir build -ea 0
           cd build
 
-          $CMAKE_CMD="cmake -G 'Visual Studio 15 2017 Win64' -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake .."
+          $CMAKE_CMD="cmake -G 'Visual Studio 15 2017 Win64' -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake .."
           function cmake_configure($retry)
           {
             $errcode=0
@@ -136,26 +130,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2.0.0
 
-      - name: Cache Depends
-        id: cache-depends
-        uses: actions/cache@v1.1.0
-        with:
-          path: C:\vcpkg\installed
-          key: ${{ matrix.os }}-vcpkg-v2
-
       - name: Cache Build
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v2
         with:
           path: build
-          key: ${{ matrix.os }}-${{ matrix.EVENT_MATRIX }}-v3
+          key: ${{ matrix.os }}-${{ matrix.EVENT_MATRIX }}-v4
 
-      - name: Install Depends
-        if: steps.cache-depends.outputs.cache-hit != 'true'
-        shell: powershell
-        run: |
-          vcpkg install openssl:x64-windows
-          vcpkg install zlib:x64-windows
-          vcpkg install mbedtls:x64-windows
+      - name: Prepare vcpkg
+        uses: lukka/run-vcpkg@v2
+        id: runvcpkg
+        with:
+          vcpkgArguments: zlib:x64-windows openssl:x64-windows mbedtls:x64-windows
+          vcpkgDirectory: ${{ runner.workspace }}/vcpkg/
+          vcpkgGitCommitId: 8e76503a769e153dad8f4e7b2c95a152bb35edaa
+          vcpkgTriplet: x64-windows
 
       - name: Build And Test
         shell: powershell
@@ -195,10 +183,10 @@ jobs:
           cd build
 
           if ("${{ matrix.os }}" -eq "windows-2016") {
-            $CMAKE_CMD="cmake -G 'Visual Studio 15 2017 Win64' -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake .."
+            $CMAKE_CMD="cmake -G 'Visual Studio 15 2017 Win64' -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake .."
           }
           else { # windows-2019
-            $CMAKE_CMD="cmake -G 'Visual Studio 16 2019' -A x64 -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake .. $EVENT_CMAKE_OPTIONS"
+            $CMAKE_CMD="cmake -G 'Visual Studio 16 2019' -A x64 -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake .. $EVENT_CMAKE_OPTIONS"
           }
           function cmake_configure($retry)
           {


### PR DESCRIPTION
fix CI failures #1071

1. Install vcpkg through the source code to temporarily solve the windows CI problem.

2. Update cache version and replace setup-msys2.