### PR TITLE
Fix: long -> enum evhttp_cmd_type type

### DIFF
--- a/test/regress_http.c
+++ b/test/regress_http.c
@@ -5176,8 +5176,8 @@ http_error_callback_test_done(struct evhttp_request *req, void *arg)
 	test_info = state_info->test;
 
 	tt_assert(req);
-	tt_int_op(evhttp_request_get_command(req), ==,
-	    test_info->type);
+	tt_assert_op_type(evhttp_request_get_command(req), ==,
+	    test_info->type, enum evhttp_cmd_type, "%d");
 	tt_int_op(evhttp_request_get_response_code(req), ==,
 	    test_info->response_code);
 


### PR DESCRIPTION
Fixes:
```
In file included from test/regress.h:35,
                 from test/regress_http.c:66:
test/regress_http.c: In function ‘http_error_callback_test_done’:
test/tinytest_macros.h:116:15: warning: cast from function call of type ‘enum evhttp_cmd_type’ to non-matching type ‘long int’ [-Wbad-function-cast]
  type val1_ = (type)(a);      \
               ^
test/tinytest_macros.h:144:2: note: in expansion of macro ‘tt_assert_test_fmt_type’
  tt_assert_test_fmt_type(a,b,str_test,type,test,type,fmt, \
  ^~~~~~~~~~~~~~~~~~~~~~~
test/tinytest_macros.h:158:2: note: in expansion of macro ‘tt_assert_test_type’
  tt_assert_test_type(a,b,#a" "#op" "#b,long,(val1_ op val2_), \
  ^~~~~~~~~~~~~~~~~~~
test/regress_http.c:5179:2: note: in expansion of macro ‘tt_int_op’
  tt_int_op(evhttp_request_get_command(req), ==,
  ^~~~~~~~~
```