### PR TITLE
http: const out address param to evcon_get_peer

### DIFF
--- a/http.c
+++ b/http.c
@@ -2754,7 +2754,7 @@ evhttp_connection_set_closecb(struct evhttp_connection *evcon,
 
 void
 evhttp_connection_get_peer(struct evhttp_connection *evcon,
-    char **address, ev_uint16_t *port)
+    const char **address, ev_uint16_t *port)
 {
 	*address = evcon->address;
 	*port = evcon->port;

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -959,7 +959,7 @@ void evhttp_connection_set_closecb(struct evhttp_connection *evcon,
 /** Get the remote address and port associated with this connection. */
 EVENT2_EXPORT_SYMBOL
 void evhttp_connection_get_peer(struct evhttp_connection *evcon,
-    char **address, ev_uint16_t *port);
+    const char **address, ev_uint16_t *port);
 
 /** Get the remote address associated with this connection.
  * extracted from getpeername() OR from nameserver.


### PR DESCRIPTION
The address returned by `evhttp_connection_get_peer` is a copy of the reference used internally by libevent.
It probably shouldn't be modified and it most definitely shouldn't be free'd to avoid double-free issues.

This commit adds the `const` modifier to the `address` parameter to indicate that it shouldn't be written to or free'd.