### PR TITLE
Remove dead code from bufferevent_socket_connect

### DIFF
--- a/bufferevent_sock.c
+++ b/bufferevent_sock.c
@@ -396,7 +396,7 @@ bufferevent_socket_connect(struct bufferevent *bev,
 		fd = evutil_socket_(sa->sa_family,
 		    SOCK_STREAM|EVUTIL_SOCK_NONBLOCK, 0);
 		if (fd < 0)
-			goto freesock;
+			goto done;
 		ownfd = 1;
 	}
 	if (sa) {
@@ -431,16 +431,11 @@ bufferevent_socket_connect(struct bufferevent *bev,
 			result = 0;
 			goto done;
 		}
-	} else if (r == 1) {
+	} else {
 		/* The connect succeeded already. How very BSD of it. */
 		result = 0;
 		bufev_p->connecting = 1;
 		bufferevent_trigger_nolock_(bev, EV_WRITE, BEV_OPT_DEFER_CALLBACKS);
-	} else {
-		/* The connect failed already.  How very BSD of it. */
-		result = 0;
-		bufferevent_run_eventcb_(bev, BEV_EVENT_ERROR, BEV_OPT_DEFER_CALLBACKS);
-		bufferevent_disable(bev, EV_WRITE|EV_READ);
 	}
 
 	goto done;


### PR DESCRIPTION
Currently, if `connect()` call fails immediately e.g. with EHOSTUNREACH, libevent never calls `eventcb` b/c relevant code is unreachable (always skipped by `goto`).
Which isn't a bug, but still there's a bit of dead code.