### PR TITLE
Fixed win32_dispatch() error return if select() returns <= 0.

### DIFF
--- a/win32select.c
+++ b/win32select.c
@@ -328,7 +328,7 @@ win32_dispatch(struct event_base *base, struct timeval *tv)
 	if (res <= 0) {
 		event_debug(("%s: %s", __func__,
 		    evutil_socket_error_to_string(EVUTIL_SOCKET_ERROR())));
-		return res;
+		return (-1);
 	}
 
 	if (win32op->readset_out->fd_count) {


### PR DESCRIPTION
The function win32_dispatch() should 0 on success, -1 on error, as documented in event_internal.h:
/** Function to implement the core of an event loop.  It must see which
   added events are ready, and cause event_active to be called for each
   active event (usually via event_io_active or such).  It should
   return 0 on success and -1 on error.
*/
int (*dispatch)(struct event_base *, struct timeval *);
 
Return value res is the return from call to winsock2 select(), which is:
The select function returns the total number of socket handles that are ready and
contained in the fd_set structures, zero if the time limit expired, or SOCKET_ERROR
if an error occurred.
 
Because a timeout (res == 0) is not a successful completion of select(), an error return value
of (-1) should be returned.  We encountered a timeout from select() when connections were
being blocked/delayed by firewall/vpn product.