### PR TITLE
Remove compile time dependence of iphlpapi library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1022,18 +1022,6 @@ add_event_library(event SOURCES ${SRC_CORE} ${SRC_EXTRA})
 
 set(WIN32_GETOPT)
 if (WIN32)
-    set(_TMPLIBS)
-    if (${EVENT_LIBRARY_STATIC})
-        list(APPEND _TMPLIBS event_core_static event_static)
-    endif()
-    if (${EVENT_LIBRARY_SHARED})
-        list(APPEND _TMPLIBS event_core_shared event_shared)
-    endif()
-    foreach(lib ${_TMPLIBS})
-        target_link_libraries(${lib} iphlpapi)
-    endforeach()
-    unset(_TMPLIBS)
-
     list(APPEND WIN32_GETOPT
          WIN32-Code/getopt.c
          WIN32-Code/getopt_long.c)

--- a/Makefile.am
+++ b/Makefile.am
@@ -182,7 +182,6 @@ include test/include.am
 
 if BUILD_WIN32
 
-SYS_CORE_LIBS = -liphlpapi
 SYS_LIBS = -lws2_32 -lshell32 -ladvapi32 -lbcrypt
 SYS_SRC = win32select.c buffer_iocp.c event_iocp.c \
 	bufferevent_async.c
@@ -194,7 +193,6 @@ endif
 
 else
 
-SYS_CORE_LIBS =
 SYS_LIBS =
 SYS_SRC =
 SYS_INCLUDES =
@@ -276,11 +274,11 @@ AM_LDFLAGS = $(LIBEVENT_LDFLAGS)
 GENERIC_LDFLAGS = -version-info $(VERSION_INFO) $(RELEASE) $(NO_UNDEFINED) $(AM_LDFLAGS)
 
 libevent_la_SOURCES = $(CORE_SRC) $(EXTRAS_SRC)
-libevent_la_LIBADD = @LTLIBOBJS@ $(SYS_LIBS) $(SYS_CORE_LIBS)
+libevent_la_LIBADD = @LTLIBOBJS@ $(SYS_LIBS)
 libevent_la_LDFLAGS = $(GENERIC_LDFLAGS)
 
 libevent_core_la_SOURCES = $(CORE_SRC)
-libevent_core_la_LIBADD = @LTLIBOBJS@ $(SYS_LIBS) $(SYS_CORE_LIBS)
+libevent_core_la_LIBADD = @LTLIBOBJS@ $(SYS_LIBS)
 libevent_core_la_LDFLAGS = $(GENERIC_LDFLAGS)
 
 if PTHREADS

--- a/evutil.c
+++ b/evutil.c
@@ -2199,7 +2199,7 @@ if_nametoindex_fn(const char *ifname)
 		goto done;
 	result = fn(ifname);
 done:
-	if(lib)
+	if (lib)
 		FreeLibrary(lib);
 	return result;
 }


### PR DESCRIPTION
Load the function `if_nametoindex` at runtime as on windows it's only available for windows vista and greater. This will remove the need to link the library iphlpapi at compile time and will restore support for older windows versions. If the function isn't loaded, it returns 0.

Fixes: #1110 
Fixes: #1096 (it is also related to this as vcpkg isn't linking the library automatically if libevent is used)