### PR TITLE
cmake: do not link libevent with libevent_core

### DIFF
--- a/cmake/AddEventLibrary.cmake
+++ b/cmake/AddEventLibrary.cmake
@@ -102,6 +102,7 @@ macro(add_event_library LIB_NAME)
         set(LIB_OUTER_INCLUDES NONE)
     endif()
     set(ADD_EVENT_LIBRARY_INTERFACE)
+    set(INNER_LIBRARIES)
 
     if (${EVENT_LIBRARY_STATIC})
         add_library("${LIB_NAME}_static" STATIC ${LIB_SOURCES})


### PR DESCRIPTION
When add_event_library macro was called without the INNER_LIBRARIES parameter, it reused the
value set by a previous call, since the INNER_LIBRARIES variable was not reset.