### PR TITLE
evdns: add max-probe-timeout/probe-backoff-factor settings

### DIFF
--- a/include/event2/dns.h
+++ b/include/event2/dns.h
@@ -202,6 +202,8 @@ extern "C" {
  * - attempts:
  * - randomize-case:
  * - initial-probe-timeout:
+ * - max-probe-timeout:
+ * - probe-backoff-factor:
  * - tcp-idle-timeout:
  * - edns-udp-size:
  * - use-vc
@@ -470,9 +472,16 @@ void evdns_cancel_request(struct evdns_base *base, struct evdns_request *req);
   The currently available configuration options are:
 
     ndots, timeout, max-timeouts, max-inflight, attempts, randomize-case,
-    bind-to, initial-probe-timeout, getaddrinfo-allow-skew,
-    so-rcvbuf, so-sndbuf, tcp-idle-timeout, use-vc, ignore-tc,
-    edns-udp-size.
+    bind-to, initial-probe-timeout, max-probe-timeout, probe-backoff-factor,
+    getaddrinfo-allow-skew, so-rcvbuf, so-sndbuf, tcp-idle-timeout, use-vc,
+    ignore-tc, edns-udp-size.
+
+  - probe-backoff-factor
+    Backoff factor of probe timeout
+
+  - max-probe-timeout
+    Maximum timeout between two probe packets will change initial-probe-timeout
+    when this value is smaller
 
   In versions before Libevent 2.0.3-alpha, the option name needed to end with
   a colon.


### PR DESCRIPTION
I recently found that when the network status changed when calling `bufferevent_socket_connect_hostname` (e.g. switching between several WIFIs), all DNS servers would fail, and the timeout of probe would be very long if there were many DNS requests. I want libevent to support manual setting of `MAX_PROBE_TIMEOUT` and `TIMEOUT_BACKOFF_FACTOR`

move hardcoded `MAX_PROBE_TIMEOUT` and `TIMEOUT_BACKOFF_FACTOR` into struct, and allow configured.

Fixes: #1129 