### PR TITLE
Check return value of evbuffer_remove() in bufferevent_read()

### DIFF
--- a/bufferevent.c
+++ b/bufferevent.c
@@ -469,7 +469,12 @@ bufferevent_write_buffer(struct bufferevent *bufev, struct evbuffer *buf)
 size_t
 bufferevent_read(struct bufferevent *bufev, void *data, size_t size)
 {
-	return (evbuffer_remove(bufev->input, data, size));
+	int r = evbuffer_remove(bufev->input, data, size);
+
+	if (r == -1)
+		return 0;
+
+	return r;
 }
 
 int

--- a/include/event2/bufferevent.h
+++ b/include/event2/bufferevent.h
@@ -430,7 +430,8 @@ int bufferevent_write_buffer(struct bufferevent *bufev, struct evbuffer *buf);
   @param bufev the bufferevent to be read from
   @param data pointer to a buffer that will store the data
   @param size the size of the data buffer, in bytes
-  @return the amount of data read, in bytes.
+  @return the amount of data read, in bytes. If 0 is returned, it is possible
+  that there is no data in the buffer or that the read failed.
  */
 EVENT2_EXPORT_SYMBOL
 size_t bufferevent_read(struct bufferevent *bufev, void *data, size_t size);


### PR DESCRIPTION
The conflict cast convertion between the return value of
bufferevent_read() and evbuffer_remove(), int(-1)->size_t(An undefined
maximum)

Add test case of bufferevent_read() should return 0 in case of
evbuffer_remove() returns -1

Fixes: #1132
