### PR TITLE
build: use AC_CHECK_LIB over AC_HAVE_LIBRARY

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -316,7 +316,7 @@ AM_CONDITIONAL(BUILD_MIDIPIX, test x$midipix = xtrue)
 AM_CONDITIONAL(BUILD_WITH_NO_UNDEFINED, test x$bwin32 = xtrue || test x$cygwin = xtrue || test x$midipix = xtrue)
 
 if test x$bwin32 = xtrue; then
-  AC_HAVE_LIBRARY([ws2_32])
+  AC_CHECK_LIB([ws2_32], [main])
 fi
 
 dnl Checks for typedefs, structures, and compiler characteristics.


### PR DESCRIPTION
AC_HAVE_LIBRARY is deprecated, see [Obsolete-Macros.html](https://www.gnu.org/software/autoconf/manual/autoconf-2.70/html_node/Obsolete-Macros.html):
>  Macro: AC_HAVE_LIBRARY (library, [action-if-found], [action-if-not-found], [other-libraries])
> This macro is equivalent to calling AC_CHECK_LIB with a function argument of main. In addition, library can be written as any of ‘foo’, -lfoo, or ‘libfoo.a’. In all of those cases, the compiler is passed -lfoo. However, library cannot be a shell variable; it must be a literal name. See AC_CHECK_LIB. 

and has been prior to Autoconf 2.67, which is the minimum required by the project. It's usage also causes warnings with newer versions of autoconf:
```bash
configure.ac:319: warning: The macro `AC_HAVE_LIBRARY' is obsolete.
configure.ac:319: You should run autoupdate.
```

`AC_HAVE_LIBRARY` was introduced in #969, although it's not clear why it was decided to revert to using an obsolete macro.