### PR TITLE
ci: Switch to lukka/run-vcpkg@v7

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,13 +38,13 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.EVENT_MATRIX }}-v4
 
       - name: Prepare vcpkg
-        uses: lukka/run-vcpkg@v2
+        uses: lukka/run-vcpkg@v7
         id: runvcpkg
         with:
           vcpkgArguments: zlib:x64-windows openssl:x64-windows mbedtls:x64-windows
           vcpkgDirectory: ${{ runner.workspace }}/vcpkg/
-          vcpkgGitCommitId: 8e76503a769e153dad8f4e7b2c95a152bb35edaa
           vcpkgTriplet: x64-windows
+          vcpkgGitCommitId: 7bc5b8cdfaf35329c1520b2af8d368e2b1cb78e6
 
       - name: Build And Test
         shell: powershell
@@ -138,13 +138,13 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.EVENT_MATRIX }}-v4
 
       - name: Prepare vcpkg
-        uses: lukka/run-vcpkg@v2
+        uses: lukka/run-vcpkg@v7
         id: runvcpkg
         with:
           vcpkgArguments: zlib:x64-windows openssl:x64-windows mbedtls:x64-windows
           vcpkgDirectory: ${{ runner.workspace }}/vcpkg/
-          vcpkgGitCommitId: 8e76503a769e153dad8f4e7b2c95a152bb35edaa
           vcpkgTriplet: x64-windows
+          vcpkgGitCommitId: 7bc5b8cdfaf35329c1520b2af8d368e2b1cb78e6
 
       - name: Build And Test
         shell: powershell


### PR DESCRIPTION
Let's see if it uses set-env or not [1]:

    Run lukka/run-vcpkg@v2
    Restore vcpkg and its artifacts from cache
    Set output env vars
      Error: Unable to process command '::set-env name=RUNVCPKG_VCPKG_ROOT::D:\a\libevent\vcpkg' successfully.
      Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

  [1]: https://github.com/libevent/libevent/runs/2172680596?check_suite_focus=true#step:4:24

And this one [2]:

    error: could not open file /var/cache/pacman/pkg/libzstd-1.5.0-1-x86_64.pkg.tar.zst: Child process exited with status 127
    error: could not open file /var/cache/pacman/pkg/zstd-1.5.0-1-x86_64.pkg.tar.zst: Child process exited with status 127
    error: could not open file /var/cache/pacman/pkg/pacman-5.2.2-23-x86_64.pkg.tar.zst: Child process exited with status 127
    error: failed to commit transaction (cannot open package file)

  [2]: https://github.com/libevent/libevent/pull/1168/checks?check_run_id=2706159518#step:4:367