### PR TITLE
ci: fix mingw workflow

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -219,7 +219,7 @@ AC_CHECK_HEADERS([ \
   sys/wait.h \
   sys/random.h \
   errno.h \
-  afunix.h \
+  afunix.h
 ])
 
 case "${host_os}" in
@@ -359,7 +359,7 @@ AC_CHECK_FUNCS([ \
   umask \
   unsetenv \
   usleep \
-  getrandom \
+  getrandom
 ])
 
 AS_IF([test x$bwin32 = xtrue],


### PR DESCRIPTION
https://github.com/libevent/libevent/runs/2171607687

```
../configure: line 14724: syntax error near unexpected token `as_ac_Header=`printf "%s\n" "ac_cv_header_$ac_header" | $as_tr_sh`'
../configure: line 14724: `  as_ac_Header=`printf "%s\n" "ac_cv_header_$ac_header" | $as_tr_sh`'
Error: Process completed with exit code 1.
```