### PR TITLE
build: remove no-longer used checks for vasprintf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,7 +473,6 @@ list(APPEND SYMBOLS_TO_CHECK
     strlcpy
     strsep
     strtok_r
-    vasprintf
     timerclear
     timercmp
     timerisset
@@ -551,7 +550,6 @@ if (NOT EVENT__DISABLE_THREAD_SUPPORT)
     endif()
 endif()
 
-# Add stdio.h for vasprintf
 list(APPEND CMAKE_EXTRA_INCLUDE_FILES ${EVENT_INCLUDES} stdio.h)
 CHECK_SYMBOLS_EXIST("${SYMBOLS_TO_CHECK}" "${CMAKE_EXTRA_INCLUDE_FILES}" "EVENT")
 unset(SYMBOLS_TO_CHECK)

--- a/buffer.c
+++ b/buffer.c
@@ -34,12 +34,6 @@
 #include <io.h>
 #endif
 
-#ifdef EVENT__HAVE_VASPRINTF
-/* If we have vasprintf, we need to define _GNU_SOURCE before we include
- * stdio.h.  This comes from evconfig-private.h.
- */
-#endif
-
 #include <sys/types.h>
 
 #ifdef EVENT__HAVE_SYS_TIME_H

--- a/configure.ac
+++ b/configure.ac
@@ -359,7 +359,6 @@ AC_CHECK_FUNCS([ \
   umask \
   unsetenv \
   usleep \
-  vasprintf \
   getrandom \
 ])
 

--- a/event-config.h.cmake
+++ b/event-config.h.cmake
@@ -446,9 +446,6 @@
 /* Define to 1 if you have the `unsetenv' function. */
 #cmakedefine EVENT__HAVE_UNSETENV 1
 
-/* Define to 1 if you have the `vasprintf' function. */
-#cmakedefine EVENT__HAVE_VASPRINTF 1
-
 /* Define if kqueue works correctly with pipes */
 #cmakedefine EVENT__HAVE_WORKING_KQUEUE 1
 


### PR DESCRIPTION
From what I can tell the last usage was removed in
8d1317d71c46e27c5073d3429a64af69de0351a6.