### PR TITLE
build: remove splice implementation fragments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,7 +470,6 @@ list(APPEND SYMBOLS_TO_CHECK
     gettimeofday
     signal
     strtoll
-    splice
     strlcpy
     strsep
     strtok_r

--- a/buffer.c
+++ b/buffer.c
@@ -2513,7 +2513,6 @@ evbuffer_write_sendfile(struct evbuffer *buffer, evutil_socket_t dest_fd,
 
 	return (len);
 #elif defined(SENDFILE_IS_LINUX)
-	/* TODO(niels): implement splice */
 	res = sendfile(dest_fd, source_fd, &offset, chain->off);
 	if (res == -1 && EVUTIL_ERR_RW_RETRIABLE(errno)) {
 		/* if this is EAGAIN or EINTR return 0; otherwise, -1 */

--- a/configure.ac
+++ b/configure.ac
@@ -350,7 +350,6 @@ AC_CHECK_FUNCS([ \
   sigaction \
   signal \
   strsignal \
-  splice \
   strlcpy \
   strsep \
   strtok_r \

--- a/event-config.h.cmake
+++ b/event-config.h.cmake
@@ -271,9 +271,6 @@
 /* Define to 1 if you have the `strsignal' function. */
 #cmakedefine EVENT__HAVE_STRSIGNAL 1
 
-/* Define to 1 if you have the `splice' function. */
-#cmakedefine EVENT__HAVE_SPLICE 1
-
 /* Define to 1 if you have the <stdarg.h> header file. */
 #cmakedefine EVENT__HAVE_STDARG_H 1
 

--- a/include/event2/buffer.h
+++ b/include/event2/buffer.h
@@ -552,10 +552,9 @@ int evbuffer_add_file(struct evbuffer *outbuf, int fd, ev_off_t offset,
 /**
   An evbuffer_file_segment holds a reference to a range of a file --
   possibly the whole file! -- for use in writing from an evbuffer to a
-  socket.  It could be implemented with mmap, sendfile, splice, or (if all
-  else fails) by just pulling all the data into RAM.  A single
-  evbuffer_file_segment can be added more than once, and to more than one
-  evbuffer.
+  socket.  It could be implemented with mmap or sendfile, or (if all else
+  fails) by just pulling all the data into RAM. A single evbuffer_file_segment
+  can be added more than once, and to more than one evbuffer.
  */
 struct evbuffer_file_segment;
 
@@ -572,7 +571,7 @@ struct evbuffer_file_segment;
 #define EVBUF_FS_DISABLE_MMAP     0x02
 /**
    Flag for creating evbuffer_file_segment: Disable direct fd-to-fd
-   implementations (including sendfile and splice).
+   implementations (sendfile).
 
    You might want to use this option if data needs to be taken from the
    evbuffer by any means other than writing it to the network: the sendfile
@@ -600,7 +599,7 @@ typedef void (*evbuffer_file_segment_cleanup_cb)(
    file and sending it out via an evbuffer.
 
    This function avoids unnecessary data copies between userland and
-   kernel.  Where available, it uses sendfile or splice.
+   kernel.  Where available, it uses sendfile.
 
    The file descriptor must not be closed so long as any evbuffer is using
    this segment.

--- a/test/regress_buffer.c
+++ b/test/regress_buffer.c
@@ -1161,8 +1161,7 @@ test_evbuffer_add_file(void *ptr)
 		view_from_offset = 1;
 	}
 	if (strstr(impl, "sendfile")) {
-		/* If sendfile is set, we try to use a sendfile/splice style
-		 * backend. */
+		/* If sendfile is set, we try to use a sendfile style backend. */
 		flags = EVBUF_FS_DISABLE_MMAP;
 		want_cansendfile = 1;
 		want_ismapping = 0;


### PR DESCRIPTION
Looks like a `splice` implementation was planned, but has clearly never
eventuated (the TODO comment is from ~12 years ago, in
8b5bd77415fb6634fadf08357676926fecf5f032). For now, it's probably better
to remove the unused code/correct the docs.