### PR TITLE
sample: use unsigned short instead of int for port

### DIFF
--- a/include/event2/event.h
+++ b/include/event2/event.h
@@ -1078,7 +1078,7 @@ void *event_self_cbarg(void);
   The EV_TIMEOUT flag has no effect here.
 
   It is okay to have multiple events all listening on the same fds; but
-  they must either all be edge-triggered, or all not be edge triggered.
+  they must either all be edge-triggered, or not be edge-triggered at all.
 
   When the event becomes active, the event loop will run the provided
   callback function, with three arguments.  The first will be the provided

--- a/sample/hello-world.c
+++ b/sample/hello-world.c
@@ -27,7 +27,7 @@
 
 static const char MESSAGE[] = "Hello, World!\n";
 
-static const int PORT = 9995;
+static const unsigned short PORT = 9995;
 
 static void listener_cb(struct evconnlistener *, evutil_socket_t,
     struct sockaddr *, int socklen, void *);


### PR DESCRIPTION
The C standard gurantees that an unsigned short is at least up to 65535
huge. Enough to store every TCP port. Also the parameter PORT is
overgiven to the `htons()` function which assumes that the parameter is
of type `uint16_t` which unsigned short is on most platforms.