### PR TITLE
dns: add ability to get CNAME with evdns_base_resolve_ipv4()/evdns_base_resolve_ipv6() 

### DIFF
--- a/include/event2/dns.h
+++ b/include/event2/dns.h
@@ -182,6 +182,7 @@ extern "C" {
 #define DNS_IPv4_A 1
 #define DNS_PTR 2
 #define DNS_IPv6_AAAA 3
+#define DNS_CNAME 4
 
 /** Disable searching for the query. */
 #define DNS_QUERY_NO_SEARCH 0x01
@@ -189,6 +190,8 @@ extern "C" {
 #define DNS_QUERY_USEVC 0x02
 /** Ignore trancation flag in responses (don't fallback to TCP connections). */
 #define DNS_QUERY_IGNTC 0x04
+/** Make a separate callback for CNAME in answer */
+#define DNS_CNAME_CALLBACK 0x80
 
 /* Allow searching */
 #define DNS_OPTION_SEARCH 1

--- a/test/regress_testutils.c
+++ b/test/regress_testutils.c
@@ -257,6 +257,11 @@ regress_dns_server_cb(struct evdns_server_request *req, void *data)
 		}
 		evdns_server_request_add_aaaa_reply(req,
 		    question, 1, &in6.s6_addr, 100);
+	} else if (!strcmp(tab->anstype, "CNAME")) {
+		struct in_addr in;
+		evutil_inet_pton(AF_INET, "11.22.33.44", &in);
+		evdns_server_request_add_a_reply(req, question, 1, &in, 100);
+		evdns_server_request_add_cname_reply(req, question, tab->ans, 100);
 	} else {
 		TT_DIE(("Weird table entry with type '%s'", tab->anstype));
 	}


### PR DESCRIPTION
dns: add ability to get CNAME with evdns_base_resolve_ipv4()/evdns_base_resolve_ipv6() by setting
DNS_CNAME_CALLBACK flag. After that we get one more callback with type == DNS_CNAME and CNAME in addrs argument.