### PR TITLE
test/regress.h: Increase default timeval tolerance 50 ms -> 100 ms

### DIFF
--- a/test/regress.h
+++ b/test/regress.h
@@ -127,7 +127,7 @@ int test_ai_eq_(const struct evutil_addrinfo *ai, const char *sockaddr_port,
 	tt_int_op(labs(timeval_msec_diff((tv1), (tv2)) - diff), <=, tolerance)
 
 #define test_timeval_diff_eq(tv1, tv2, diff)				\
-	test_timeval_diff_leq((tv1), (tv2), (diff), 50)
+	test_timeval_diff_leq((tv1), (tv2), (diff), 100)
 
 long timeval_msec_diff(const struct timeval *start, const struct timeval *end);
 


### PR DESCRIPTION
The default timeout tolerance is 50 ms,
which causes intermittent failure in many the
related tests in arm64 QEMU.

See: https://bugzilla.yoctoproject.org/show_bug.cgi?id=14163
(The root cause seems to be a heavy load)

Signed-off-by: Yi Fan Yu <yifan.yu@windriver.com>