### PR TITLE
RTEMS has no SA_RESTART

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -254,7 +254,9 @@ evsig_set_handler_(struct event_base *base,
 #ifdef EVENT__HAVE_SIGACTION
 	memset(&sa, 0, sizeof(sa));
 	sa.sa_handler = handler;
+#ifdef SA_RESTART
 	sa.sa_flags |= SA_RESTART;
+#endif
 	sigfillset(&sa.sa_mask);
 
 	if (sigaction(evsignal, &sa, sig->sh_old[evsignal]) == -1) {


### PR DESCRIPTION
Fix compile failure against [RTEMS](https://www.rtems.org/) 5.1 w/ libbsd network stack.