### PR TITLE
make evthread_use_pthreads() a MT-Safe function

### DIFF
--- a/evthread_pthread.c
+++ b/evthread_pthread.c
@@ -214,7 +214,7 @@ evthread_use_pthreads_with_flags(int flags)
 	evthread_set_condition_callbacks(&cond_cbs);
 	evthread_set_id_callback(evthread_posix_get_id);
 	once_init = 1;
-	
+
 	return 0;
 error:
 	pthread_mutex_unlock(&once_init_lock);


### PR DESCRIPTION
make it safe to enable event thread support [`evthread_use_pthreads()`] by mutiple threads. If a huge project have some separate callings to evthread, `once_init_lock` is  a staic lock to make sure `attr_recursive` is always the attribute for a recurise lock, avoid deadlock.

Fixes: #1175