### PR TITLE
build: fail with a useful error message if pkg-config isn't available

### DIFF
--- a/m4/libevent_openssl.m4
+++ b/m4/libevent_openssl.m4
@@ -1,6 +1,9 @@
 dnl ######################################################################
 dnl OpenSSL support
 AC_DEFUN([LIBEVENT_OPENSSL], [
+
+m4_ifndef([PKG_PROG_PKG_CONFIG], [AC_MSG_ERROR([PKG_PROG_PKG_CONFIG not found. Please install pkg-config and re-run autogen.sh])])
+
 PKG_PROG_PKG_CONFIG([0.15.0])
 
 case "$host_os" in


### PR DESCRIPTION
Bought up in #1171.