### PR TITLE
ev_io_timeout consistency

### DIFF
--- a/event.c
+++ b/event.c
@@ -2605,7 +2605,7 @@ event_remove_timer_nolock_(struct event *ev)
 	/* If it's not pending on a timeout, we don't need to do anything. */
 	if (ev->ev_flags & EVLIST_TIMEOUT) {
 		event_queue_remove_timeout(base, ev);
-		evutil_timerclear(&ev->ev_.ev_io.ev_timeout);
+		evutil_timerclear(&ev->ev_io_timeout);
 	}
 
 	return (0);


### PR DESCRIPTION
replace `ev->ev_.ev_io.ev_timeout` with `ev->ev_io_timeout`