### PR TITLE
test: skip dns_initialize_nameservers if missing /etc/resolv.conf

### DIFF
--- a/test/regress_dns.c
+++ b/test/regress_dns.c
@@ -1146,6 +1146,15 @@ dns_initialize_nameservers_test(void *arg)
 	struct sockaddr_storage ss;
 	int size;
 
+#ifndef _WIN32
+	/* /etc/resolv.conf does not exist in some test container
+	 * setups but EVDNS_BASE_INITIALIZE_NAMESERVERS requires it */
+	struct stat st;
+	if (stat("/etc/resolv.conf", &st) < 0 || st.st_size == 0) {
+		tt_skip();
+	}
+#endif
+
 	dns = evdns_base_new(base, 0);
 	tt_assert(dns);
 	tt_int_op(evdns_base_get_nameserver_addr(dns, 0, NULL, 0), ==, -1);


### PR DESCRIPTION
some build systems run tests in minimal containers with no resolv.conf,
and the primary thing this test does is load the default /etc/resolv.conf

issue raised in #1155

I didn't actually test in a container with no `resolv.conf` ... just assuming this is simple enough ...