### PR TITLE
test: retriable tests are marked failed only when all attempts have failed

### DIFF
--- a/test/tinytest.c
+++ b/test/tinytest.c
@@ -550,7 +550,7 @@ tinytest_main(int c, const char **v, struct testgroup_t *groups)
 		struct testgroup_t *group = &groups[i];
 		for (j = 0; group->cases[j].name; ++j) {
 			struct testcase_t *testcase = &group->cases[j];
-			int attempts = (testcase->flags & TT_RETRIABLE) ? opt_retries: 1;
+			int attempts = (testcase->flags & TT_RETRIABLE) ? opt_retries : 1;
 			int test_ret_err;
 
 			if (!(testcase->flags & TT_ENABLED_))

--- a/test/tinytest.h
+++ b/test/tinytest.h
@@ -92,7 +92,7 @@ char *tinytest_format_hex_(const void *, unsigned long);
 	tinytest_set_flag_(groups, named, 1, TT_SKIP)
 
 /** Run a single testcase in a single group. */
-int testcase_run_one(const struct testgroup_t *,const struct testcase_t *);
+int testcase_run_one(const struct testgroup_t *,const struct testcase_t *, const int test_attempts);
 
 void tinytest_set_aliases(const struct testlist_alias_t *aliases);
 


### PR DESCRIPTION
Signed-off-by: Thomas Perrot <thomas.perrot@bootlin.com>