### PR TITLE
Use GNUInstallDirs for mapping installation directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,20 +170,21 @@ if (NOT DEFINED CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 endif()
 
+include(GNUInstallDirs)
+
 # The RPATH to be used when installing, but only if it's not a system directory
 #
 # Refs: https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
 macro(Configure_RPATH)
-    # NOTE: that CMAKE_INSTALL_PREFIX not always normalized correctly, i.e.:
+    # NOTE: that CMAKE_INSTALL_LIBDIR not always normalized correctly, i.e.:
     # - "///" -> "/"
     # - "/////usr///" -> "//usr"
     # So it should be normalized again.
-
-    get_filename_component(CMAKE_INSTALL_PREFIX_NORMALIZED "${CMAKE_INSTALL_PREFIX}" REALPATH)
-    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX_NORMALIZED}/lib" isSystemDir)
+    get_filename_component(CMAKE_INSTALL_LIBDIR_NORMALIZED "${CMAKE_INSTALL_PREFIX}" REALPATH)
+    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_LIBDIR_NORMALIZED}/lib" isSystemDir)
 
     if("${isSystemDir}" STREQUAL "-1")
-        set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX_NORMALIZED}/lib")
+        set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR_NORMALIZED}")
     endif()
 endmacro()
 Configure_RPATH()
@@ -1594,8 +1595,6 @@ endif()
 #
 # Installation preparation.
 #
-
-include(GNUInstallDirs)
 
 set(EVENT_INSTALL_CMAKE_DIR
     "${CMAKE_INSTALL_LIBDIR}/cmake/libevent")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1602,18 +1602,9 @@ set(EVENT_INSTALL_CMAKE_DIR
 
 export(PACKAGE libevent)
 
-function(gen_package_config forinstall)
-    if(${forinstall})
-        set(CONFIG_FOR_INSTALL_TREE 1)
-        set(dir "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}")
-    else()
-        set(CONFIG_FOR_INSTALL_TREE 0)
-        set(dir "${PROJECT_BINARY_DIR}")
-    endif()
-    configure_file(${PROJECT_SOURCE_DIR}/cmake/LibeventConfig.cmake.in
-                "${dir}/LibeventConfig.cmake"
-                @ONLY)
-endfunction()
+configure_file(${PROJECT_SOURCE_DIR}/cmake/LibeventConfig.cmake.in
+    "${PROJECT_BINARY_DIR}/LibeventConfig.cmake"
+    @ONLY)
 
 # Generate the config file for the build-tree.
 set(EVENT__INCLUDE_DIRS
@@ -1623,11 +1614,6 @@ set(EVENT__INCLUDE_DIRS
 set(LIBEVENT_INCLUDE_DIRS
     ${EVENT__INCLUDE_DIRS}
     CACHE PATH "Libevent include directories")
-
-gen_package_config(0)
-
-# Generate the config file for the installation tree.
-gen_package_config(1)
 
 # Generate version info for both build-tree and install-tree.
 configure_file(${PROJECT_SOURCE_DIR}/cmake/LibeventConfigVersion.cmake.in
@@ -1646,7 +1632,7 @@ install(FILES ${HDR_PUBLIC}
 
 # Install the configs.
 install(FILES
-        ${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/LibeventConfig.cmake
+        ${PROJECT_BINARY_DIR}/LibeventConfig.cmake
         ${PROJECT_BINARY_DIR}/LibeventConfigVersion.cmake
         DESTINATION "${EVENT_INSTALL_CMAKE_DIR}"
         COMPONENT dev)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1595,8 +1595,10 @@ endif()
 # Installation preparation.
 #
 
+include(GNUInstallDirs)
+
 set(EVENT_INSTALL_CMAKE_DIR
-    "${CMAKE_INSTALL_PREFIX}/lib/cmake/libevent")
+    "${CMAKE_INSTALL_LIBDIR}/cmake/libevent")
 
 export(PACKAGE libevent)
 

--- a/cmake/AddEventLibrary.cmake
+++ b/cmake/AddEventLibrary.cmake
@@ -13,8 +13,8 @@ endmacro()
 macro(generate_pkgconfig LIB_NAME)
     set(prefix      ${CMAKE_INSTALL_PREFIX})
     set(exec_prefix ${CMAKE_INSTALL_PREFIX})
-    set(libdir      ${CMAKE_INSTALL_PREFIX}/lib)
-    set(includedir  ${CMAKE_INSTALL_PREFIX}/include)
+    set(libdir      ${CMAKE_INSTALL_LIBDIR})
+    set(includedir  ${CMAKE_INSTALL_INCLUDEDIR})
 
     set(VERSION ${EVENT_ABI_LIBVERSION})
 
@@ -31,7 +31,7 @@ macro(generate_pkgconfig LIB_NAME)
     configure_file("lib${LIB_NAME}.pc.in" "lib${LIB_NAME}.pc" @ONLY)
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/lib${LIB_NAME}.pc"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
     )
 endmacro()
 
@@ -151,7 +151,7 @@ macro(add_event_library LIB_NAME)
             set_target_properties(
                 "${LIB_NAME}_shared" PROPERTIES
                 OUTPUT_NAME "${LIB_NAME}-${EVENT_PACKAGE_RELEASE}.${CURRENT_MINUS_AGE}"
-                INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib"
+                INSTALL_NAME_DIR "${CMAKE_INSTALL_LIBDIR}"
                 LINK_FLAGS "-compatibility_version ${COMPATIBILITY_VERSION} -current_version ${COMPATIBILITY_VERSION}.${EVENT_ABI_LIBVERSION_REVISION}")
         else()
             math(EXPR CURRENT_MINUS_AGE "${EVENT_ABI_LIBVERSION_CURRENT}-${EVENT_ABI_LIBVERSION_AGE}")

--- a/cmake/LibeventConfig.cmake.in
+++ b/cmake/LibeventConfig.cmake.in
@@ -58,7 +58,6 @@ endif()
 
 # Get the path of the current file.
 get_filename_component(LIBEVENT_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-get_filename_component(_INSTALL_PREFIX "${LIBEVENT_CMAKE_DIR}/../../.." ABSOLUTE)
 
 macro(message_if_needed _flag _msg)
     if (NOT ${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
@@ -116,7 +115,7 @@ if(CONFIG_FOR_INSTALL_TREE)
     unset(_event_h CACHE)
     find_path(_event_h
               NAMES event2/event.h
-              PATHS "${_INSTALL_PREFIX}/include"
+              PATHS "@CMAKE_INSTALL_INCLUDEDIR@"
               NO_DEFAULT_PATH)
     if(_event_h)
         set(LIBEVENT_INCLUDE_DIRS "${_event_h}")
@@ -135,7 +134,7 @@ if(CONFIG_FOR_INSTALL_TREE)
                     NO_DEFAULT_PATH)
         find_library(_event_lib_rel
                     NAMES "event_${_comp}"
-                    PATHS "${_INSTALL_PREFIX}/lib"
+                    PATHS "@CMAKE_INSTALL_LIBDIR@"
                     NO_DEFAULT_PATH)
         if(_event_lib_rel OR _event_lib_dbg)
             list(APPEND LIBEVENT_LIBRARIES "libevent::${_comp}")
@@ -167,7 +166,7 @@ set(LIBEVENT_INCLUDE_DIR ${LIBEVENT_INCLUDE_DIRS})
 if(LIBEVENT_LIBRARIES)
     set(LIBEVENT_LIBRARY ${LIBEVENT_LIBRARIES})
     if(CONFIG_FOR_INSTALL_TREE)
-        message_if_needed(STATUS "Found libevent ${LIBEVENT_VERSION} in ${_INSTALL_PREFIX}")
+        message_if_needed(STATUS "Found libevent ${LIBEVENT_VERSION} in @CMAKE_INSTALL_LIBDIR@")
     else()
         message_if_needed(STATUS "Found libevent ${LIBEVENT_VERSION} in ${LIBEVENT_CMAKE_DIR}")
     endif()
@@ -190,4 +189,3 @@ unset(_LIB_TYPE)
 unset(_AVAILABLE_LIBS)
 unset(_EVENT_COMPONENTS)
 unset(_POSSIBLE_PKG_NAMES)
-unset(_INSTALL_PREFIX)

--- a/cmake/UseDoxygen.cmake
+++ b/cmake/UseDoxygen.cmake
@@ -90,7 +90,7 @@ macro(UseDoxygen)
       if ("${DOXYGEN_GENERATE_HTML}" STREQUAL "YES")
         install(DIRECTORY
           ${PROJECT_BINARY_DIR}/${DOXYGEN_OUTPUT_DIRECTORY}/html
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/share/doc/${PROJECT_NAME}
+          DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}
           COMPONENT doc
         )
       endif()
@@ -106,7 +106,7 @@ macro(UseDoxygen)
         # Install manual into <prefix>/share/man/man3
         install(DIRECTORY
           ${MAN_PAGES_DIR}
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man
+          DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/man
           COMPONENT doc
         )
       endif()

--- a/test-export/test-export.py
+++ b/test-export/test-export.py
@@ -109,18 +109,6 @@ def test_group():
         testcase("mbedtls", "pthreads", 1)
 
 
-def config_restore():
-    if os.path.isfile("tempconfig") and not os.path.isfile("LibeventConfig.cmake"):
-        os.rename("tempconfig", "LibeventConfig.cmake")
-
-
-def config_backup():
-    if os.path.isfile("tempconfig"):
-        os.remove("tempconfig")
-    if os.path.isfile("LibeventConfig.cmake"):
-        os.rename("LibeventConfig.cmake", "tempconfig")
-
-
 shutil.rmtree(os.path.join(script_dir, "build"), ignore_errors=True)
 
 
@@ -158,7 +146,6 @@ print("[test-export] use %s library" % link_type)
 # Test for build tree.
 print("[test-export] test for build tree")
 dllpath = os.path.join(working_dir, "bin", "Debug")
-config_restore()
 os.environ["CMAKE_PREFIX_PATH"] = working_dir
 export_dll(dllpath)
 run_test_group()
@@ -175,7 +162,6 @@ else:
     prefix = "/usr/local"
 exec_cmd('cmake -DCMAKE_SKIP_INSTALL_RPATH=OFF -DCMAKE_INSTALL_PREFIX="%s" ..' % prefix, True)
 exec_cmd('cmake --build . -v --target install', True)
-config_backup()
 os.environ["CMAKE_PREFIX_PATH"] = os.path.join(prefix, "lib/cmake/libevent")
 export_dll(dllpath)
 run_test_group()
@@ -191,13 +177,11 @@ tempdir = tempfile.TemporaryDirectory()
 cmd = 'cmake -DCMAKE_SKIP_INSTALL_RPATH=OFF -DCMAKE_INSTALL_PREFIX="%s" ..' % tempdir.name
 exec_cmd(cmd, True)
 exec_cmd("cmake --build . -v --target install", True)
-config_backup()
 os.environ["CMAKE_PREFIX_PATH"] = os.path.join(tempdir.name, "lib/cmake/libevent")
 dllpath = os.path.join(tempdir.name, "lib")
 export_dll(dllpath)
 run_test_group()
 unexport_dll(dllpath)
 del os.environ["CMAKE_PREFIX_PATH"]
-config_restore()
 
 print("[test-export] all testcases have run successfully")


### PR DESCRIPTION
Was iterating on this package for Nixpkgs, and found it difficult to consume the `.cmake` configurations as `get_filename_component(_INSTALL_PREFIX "${LIBEVENT_CMAKE_DIR}/../../.." ABSOLUTE)` was not always true.

This should be a no-op for most libevent package maintainers.