### PR TITLE
CheckWorkingKqueue.cmake: fix missing headers

### DIFF
--- a/cmake/CheckWorkingKqueue.cmake
+++ b/cmake/CheckWorkingKqueue.cmake
@@ -2,6 +2,8 @@ include(CheckCSourceRuns)
 
 check_c_source_runs(
 "
+#include <stdlib.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/event.h>


### PR DESCRIPTION
Avoid implicitly declaring functions `memset()` and `exit()` as it is considered an error by some compilers (e.g. Xcode clang 12 and later)