### PR TITLE
build: remove inconsistently used x-prefix comparisons

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -12,7 +12,7 @@ fi
 
 LIBTOOLIZE=libtoolize
 SYSNAME=`uname`
-if [ "x$SYSNAME" = "xDarwin" ] ; then
+if [ "$SYSNAME" = "Darwin" ] ; then
   LIBTOOLIZE=glibtoolize
 fi
 aclocal -I m4 && \

--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@ AC_ARG_ENABLE([gcc-warnings],
 
 AC_ARG_ENABLE([gcc-hardening],
      AS_HELP_STRING([--enable-gcc-hardening, enable compiler security checks]),
-[if test x$enableval = xyes; then
+[if test "$enableval" = "yes"; then
     CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=2 -fstack-protector-all"
     CFLAGS="$CFLAGS -fwrapv -fPIE -Wstack-protector"
     CFLAGS="$CFLAGS --param ssp-buffer-size=1"
@@ -94,7 +94,7 @@ dnl Checks for libraries.
 AC_SEARCH_LIBS([inet_ntoa], [nsl])
 AC_SEARCH_LIBS([socket], [socket])
 AC_SEARCH_LIBS([inet_aton], [resolv])
-if test "x$enable_clock_gettime" = "xyes"; then
+if test "$enable_clock_gettime" = "yes"; then
   AC_SEARCH_LIBS([clock_gettime], [rt])
   AC_CHECK_FUNCS([clock_gettime])
 fi
@@ -147,7 +147,7 @@ die horribly
 
 AC_CHECK_HEADERS([zlib.h])
 
-if test "x$ac_cv_header_zlib_h" = "xyes"; then
+if test "$ac_cv_header_zlib_h" = "yes"; then
 dnl Determine if we have zlib for regression tests
 dnl Don't put this one in LIBS
 save_LIBS="$LIBS"
@@ -164,7 +164,7 @@ fi
 AM_CONDITIONAL(ZLIB_REGRESS, [test "$have_zlib" = "yes"])
 
 dnl See if we have openssl.  This doesn't go in LIBS either.
-if test "$bwin32" = true; then
+if test "$bwin32" = "true"; then
   EV_LIB_WS32=-lws2_32
   EV_LIB_GDI=-lgdi32
 else
@@ -193,7 +193,7 @@ case "${host_os}" in
         ])
 esac
 
-if test "x$ac_cv_header_sys_queue_h" = "xyes"; then
+if test "$ac_cv_header_sys_queue_h" = "yes"; then
 	AC_MSG_CHECKING(for TAILQ_FOREACH in sys/queue.h)
 	AC_EGREP_CPP(yes,
 [
@@ -209,7 +209,7 @@ if test "x$ac_cv_header_sys_queue_h" = "xyes"; then
 fi
 
 dnl if we have sys/time.h, check for timer* macros
-if test "x$ac_cv_header_sys_time_h" = "xyes"; then
+if test "$ac_cv_header_sys_time_h" = "yes"; then
 
 AC_MSG_CHECKING(for timeradd in sys/time.h)
 AC_EGREP_CPP(yes, [
@@ -252,19 +252,19 @@ AC_EGREP_CPP(yes, [
 )
 fi
 
-if test "x$ac_cv_header_sys_sysctl_h" = "xyes"; then
+if test "$ac_cv_header_sys_sysctl_h" = "yes"; then
 	AC_CHECK_DECLS([CTL_KERN, KERN_ARND], [], [],
 	   [[#include <sys/types.h>
 	     #include <sys/sysctl.h>]]
 	)
 fi
 
-AM_CONDITIONAL(BUILD_WIN32, test x$bwin32 = xtrue)
-AM_CONDITIONAL(BUILD_CYGWIN, test x$cygwin = xtrue)
-AM_CONDITIONAL(BUILD_MIDIPIX, test x$midipix = xtrue)
+AM_CONDITIONAL(BUILD_WIN32, test "$bwin32" = "true")
+AM_CONDITIONAL(BUILD_CYGWIN, test "$cygwin" = "true")
+AM_CONDITIONAL(BUILD_MIDIPIX, test "$midipix" = "true")
 AM_CONDITIONAL(BUILD_WITH_NO_UNDEFINED, test x$bwin32 = xtrue || test x$cygwin = xtrue || test x$midipix = xtrue)
 
-if test x$bwin32 = xtrue; then
+if test "$bwin32" = "true"; then
   AC_CHECK_LIB([ws2_32], [main])
 fi
 
@@ -274,11 +274,11 @@ AC_C_INLINE
 dnl Checks for library functions.
 AC_CHECK_FUNCS([accept4 arc4random arc4random_buf arc4random_addrandom eventfd epoll_create1 fcntl getegid geteuid getifaddrs gettimeofday issetugid mach_absolute_time mmap nanosleep pipe pipe2 putenv sendfile setenv setrlimit sigaction signal strsignal strlcpy strsep strtok_r strtoll sysctl timerfd_create umask unsetenv usleep getrandom ])
 
-AS_IF([test x$bwin32 = xtrue],
+AS_IF([test "$bwin32" = "true"],
   AC_CHECK_FUNCS(_gmtime64_s, , [AC_CHECK_FUNCS(_gmtime64)])
 )
 
-AM_CONDITIONAL(STRLCPY_IMPL, [test x"$ac_cv_func_strlcpy" = xno])
+AM_CONDITIONAL(STRLCPY_IMPL, [test "$ac_cv_func_strlcpy" = "no"])
 
 m4_define([funcstochk],
   [getnameinfo
@@ -288,7 +288,7 @@ m4_define([funcstochk],
   inet_pton]
 )
 
-AS_IF([test x$bwin32 = xtrue],
+AS_IF([test "$bwin32" = "true"],
   [AX_CHECK_DECLS_EX([funcstochk getaddrinfo],
     [#ifdef _WIN32
     #include <winsock2.h>
@@ -396,32 +396,32 @@ yes
 
 needsignal=no
 haveselect=no
-if test x$bwin32 != xtrue; then
+if test "$bwin32" != "true"; then
     AC_CHECK_FUNCS(select, [haveselect=yes], )
-    if test "x$haveselect" = "xyes" ; then
+    if test "$haveselect" = "yes" ; then
  	needsignal=yes
     fi
 fi
-AM_CONDITIONAL(SELECT_BACKEND, [test "x$haveselect" = "xyes"])
+AM_CONDITIONAL(SELECT_BACKEND, [test "$haveselect" = "yes"])
 
 havepoll=no
 AC_CHECK_FUNCS(poll, [havepoll=yes], )
-if test "x$havepoll" = "xyes" ; then
+if test "$havepoll" = "yes" ; then
 	needsignal=yes
 fi
-AM_CONDITIONAL(POLL_BACKEND, [test "x$havepoll" = "xyes"])
+AM_CONDITIONAL(POLL_BACKEND, [test "$havepoll" = "yes"])
 
 havedevpoll=no
-if test "x$ac_cv_header_sys_devpoll_h" = "xyes"; then
+if test "$ac_cv_header_sys_devpoll_h" = "yes"; then
 	AC_DEFINE(HAVE_DEVPOLL, 1,
 		    [Define if /dev/poll is available])
 fi
-AM_CONDITIONAL(DEVPOLL_BACKEND, [test "x$ac_cv_header_sys_devpoll_h" = "xyes"])
+AM_CONDITIONAL(DEVPOLL_BACKEND, [test "$ac_cv_header_sys_devpoll_h" = "yes"])
 
 havekqueue=no
-if test "x$ac_cv_header_sys_event_h" = "xyes"; then
+if test "$ac_cv_header_sys_event_h" = "yes"; then
 	AC_CHECK_FUNCS(kqueue, [havekqueue=yes], )
-	if test "x$havekqueue" = "xyes" ; then
+	if test "$havekqueue" = "yes" ; then
 		AC_MSG_CHECKING(for working kqueue)
 		AC_RUN_IFELSE(
       [AC_LANG_PROGRAM([
@@ -483,18 +483,18 @@ if test "x$ac_cv_header_sys_event_h" = "xyes"; then
     )
 	fi
 fi
-AM_CONDITIONAL(KQUEUE_BACKEND, [test "x$havekqueue" = "xyes"])
+AM_CONDITIONAL(KQUEUE_BACKEND, [test "$havekqueue" = "yes"])
 
 haveepollsyscall=no
 haveepoll=no
 AC_CHECK_FUNCS(epoll_ctl, [haveepoll=yes], )
-if test "x$haveepoll" = "xyes" ; then
+if test "$haveepoll" = "yes" ; then
 	AC_DEFINE(HAVE_EPOLL, 1,
 		[Define if your system supports the epoll system calls])
 	needsignal=yes
 fi
-if test "x$ac_cv_header_sys_epoll_h" = "xyes"; then
-	if test "x$haveepoll" = "xno" ; then
+if test "$ac_cv_header_sys_epoll_h" = "yes"; then
+	if test "$haveepoll" = "no" ; then
 		AC_MSG_CHECKING(for epoll system call)
 		AC_RUN_IFELSE(
       [AC_LANG_PROGRAM([[
@@ -527,28 +527,28 @@ epoll_create(int size)
     )
 	fi
 fi
-AM_CONDITIONAL(EPOLL_BACKEND, [test "x$haveepoll" = "xyes"])
+AM_CONDITIONAL(EPOLL_BACKEND, [test "$haveepoll" = "yes"])
 
 haveeventports=no
 AC_CHECK_FUNCS(port_create, [haveeventports=yes], )
-if test "x$haveeventports" = "xyes" ; then
+if test "$haveeventports" = "yes" ; then
 	AC_DEFINE(HAVE_EVENT_PORTS, 1,
 		[Define if your system supports event ports])
 	needsignal=yes
 fi
-AM_CONDITIONAL(EVPORT_BACKEND, [test "x$haveeventports" = "xyes"])
+AM_CONDITIONAL(EVPORT_BACKEND, [test "$haveeventports" = "yes"])
 
 havewepoll=no
-if test "x$bwin32" = "xtrue"; then
+if test "$bwin32" = "true"; then
 	needsignal=yes
-  if test "x$cygwin" = "xfalse"; then
+  if test "$cygwin" = "false"; then
     havewepoll=yes
     AC_DEFINE(HAVE_WEPOLL, 1,
       [Define if your system supports the wepoll module])
   fi
 fi
-AM_CONDITIONAL(WEPOLL_BACKEND, [test "x$havewepoll" = "xyes"])
-AM_CONDITIONAL(SIGNAL_SUPPORT, [test "x$needsignal" = "xyes"])
+AM_CONDITIONAL(WEPOLL_BACKEND, [test "$havewepoll" = "yes"])
+AM_CONDITIONAL(SIGNAL_SUPPORT, [test "$needsignal" = "yes"])
 
 AC_TYPE_PID_T
 AC_TYPE_SIZE_T
@@ -686,7 +686,7 @@ AC_COMPILE_IFELSE(
 
 dnl check if we can compile with pthreads
 have_pthreads=no
-if test x$bwin32 != xtrue && test "$enable_thread_support" != "no"; then
+if test "$bwin32" != "true" && test "$enable_thread_support" != "no"; then
   ACX_PTHREAD([
 	AC_DEFINE(HAVE_PTHREADS, 1,
 		[Define if we have pthreads on this system])
@@ -703,25 +703,25 @@ AM_CONDITIONAL(THREADS, [test "$enable_thread_support" != "no"])
 AM_CONDITIONAL(PTHREADS, [test "$have_pthreads" != "no" && test "$enable_thread_support" != "no"])
 
 dnl check if we should compile locking into the library
-if test x$enable_thread_support = xno; then
+if test "$enable_thread_support" = "no"; then
    AC_DEFINE(DISABLE_THREAD_SUPPORT, 1,
 	[Define if libevent should not be compiled with thread support])
 fi
 
 dnl check if we should hard-code the mm functions.
-if test x$enable_malloc_replacement = xno; then
+if test "$enable_malloc_replacement" = "no"; then
   AC_DEFINE(DISABLE_MM_REPLACEMENT, 1,
         [Define if libevent should not allow replacing the mm functions])
 fi
 
 dnl check if we should hard-code debugging out
-if test x$enable_debug_mode = xno; then
+if test "$enable_debug_mode" = "no"; then
   AC_DEFINE(DISABLE_DEBUG_MODE, 1,
         [Define if libevent should build without support for a debug mode])
 fi
 
 dnl check if we should enable verbose debugging
-if test x$enable_verbose_debug = xyes; then
+if test "$enable_verbose_debug" = "yes"; then
 	CFLAGS="$CFLAGS -DUSE_DEBUG"
 fi
 
@@ -740,7 +740,7 @@ dnl See 52eb4951302554dd696d6a0120ad5d3f6cffb7bb.
 AX_CHECK_COMPILE_FLAG([-fno-strict-aliasing], [CFLAGS="$CFLAGS -fno-strict-aliasing"],[],[-Werror])
 
 dnl Add warnings which we use in development but not for releases.
-if test x$enable_gcc_warnings != xno && test "$GCC" = "yes"; then
+if test "$enable_gcc_warnings" != "no" && test "$GCC" = "yes"; then
 
   dnl -W is the same as -Wextra
   AX_CHECK_COMPILE_FLAG([-W], [CFLAGS="$CFLAGS -W"],[],[-Werror])
@@ -766,7 +766,7 @@ if test x$enable_gcc_warnings != xno && test "$GCC" = "yes"; then
   AX_CHECK_COMPILE_FLAG([-Wwrite-strings],[CFLAGS="$CFLAGS -Wwrite-strings"],[],[-Werror])
 
   dnl Convert warnings into errors
-  if test x$enable_gcc_warnings = xyes; then
+  if test x"$enable_gcc_warnings" = "yes"; then
     AX_CHECK_COMPILE_FLAG([-Werror], [CFLAGS="$CFLAGS -Werror"])
   fi
 
@@ -779,7 +779,7 @@ if test x$enable_gcc_warnings != xno && test "$GCC" = "yes"; then
   #error
   #endif])], have_clang=yes, have_clang=no)
 
-  if test x$have_clang = xyes; then
+  if test "$have_clang" = "yes"; then
     dnl Disable unused-function warnings. These trigger for minheap-internal.h.
     AX_CHECK_COMPILE_FLAG([-Wno-unused-function], [CFLAGS="$CFLAGS -Wno-unused-function"],[],[-Werror])
 
@@ -843,7 +843,7 @@ if test "$GCC" = yes && test "$enable_function_sections" = yes ; then
                     dnl We have to do this invocation manually so that we can
                     dnl get the output of conftest.err to make sure it doesn't
                     dnl mention gc-sections.
-		    if test "X$cross_compiling" = "Xyes" || grep gc-sections conftest.err ; then
+		    if test "$cross_compiling" = "yes" || grep gc-sections conftest.err ; then
 			libevent_cv_gc_sections_runs=no
 		    else
 			libevent_cv_gc_sections_runs=no

--- a/m4/ax_check_funcs_ex.m4
+++ b/m4/ax_check_funcs_ex.m4
@@ -4,7 +4,7 @@
 # $1: the name of function
 # $2: the headers in where the function declared
 AC_DEFUN([AX_CHECK_DECL_EX], [dnl
-	AS_IF([test "x$2" = "x"], [AC_MSG_ERROR([header not privided])])
+	AS_IF([test "$2" = ""], [AC_MSG_ERROR([header not privided])])
 	AS_VAR_PUSHDEF([have_func_var], [HAVE_[]m4_toupper($1)])
 	AC_CHECK_DECL([$1],dnl
 		[AC_DEFINE([have_func_var], [1], [Define to 1 if you have the `$1' function.])],,dnl
@@ -14,7 +14,7 @@ AC_DEFUN([AX_CHECK_DECL_EX], [dnl
 ])
 
 AC_DEFUN([AX_CHECK_DECLS_EX], [dnl
-	AS_IF([test "x$2" = "x"], [AC_MSG_ERROR([header not privided])])
+	AS_IF([test "$2" = ""], [AC_MSG_ERROR([header not privided])])
 	m4_foreach([decl],dnl
 		m4_split(m4_normalize($1)),dnl
 		[AX_CHECK_DECL_EX([decl], [$2])]dnl

--- a/m4/ax_check_funcs_ex.m4
+++ b/m4/ax_check_funcs_ex.m4
@@ -4,7 +4,7 @@
 # $1: the name of function
 # $2: the headers in where the function declared
 AC_DEFUN([AX_CHECK_DECL_EX], [dnl
-	AS_IF([test "$2" = ""], [AC_MSG_ERROR([header not privided])])
+	AS_IF([test "$2" = ""], [AC_MSG_ERROR([header not provided])])
 	AS_VAR_PUSHDEF([have_func_var], [HAVE_[]m4_toupper($1)])
 	AC_CHECK_DECL([$1],dnl
 		[AC_DEFINE([have_func_var], [1], [Define to 1 if you have the `$1' function.])],,dnl
@@ -14,7 +14,7 @@ AC_DEFUN([AX_CHECK_DECL_EX], [dnl
 ])
 
 AC_DEFUN([AX_CHECK_DECLS_EX], [dnl
-	AS_IF([test "$2" = ""], [AC_MSG_ERROR([header not privided])])
+	AS_IF([test "$2" = ""], [AC_MSG_ERROR([header not provided])])
 	m4_foreach([decl],dnl
 		m4_split(m4_normalize($1)),dnl
 		[AX_CHECK_DECL_EX([decl], [$2])]dnl

--- a/test/test-ratelim.sh
+++ b/test/test-ratelim.sh
@@ -2,7 +2,7 @@
 
 FAILED=no
 
-if test "x$TEST_OUTPUT_FILE" = "x"
+if test "$TEST_OUTPUT_FILE" = ""
 then
 	TEST_OUTPUT_FILE=/dev/null
 fi


### PR DESCRIPTION
Given that these are already used inconsistently with `test` checks (i.e [here](https://github.com/libevent/libevent/blob/master/configure.ac#L164), [here](https://github.com/libevent/libevent/blob/master/configure.ac#L90) etc), it makes sense to consolidate to not using the x-prefix comparisons at all, as anyone using a shell that actually has this issue, would likely have reported it. In any case, it would be nice to think we no longer have to work around a problem that existed in shells many, many (some decades) years ago.

More info:
https://github.com/koalaman/shellcheck/wiki/SC2268
https://www.vidarholen.net/contents/blog/?p=1035