### PR TITLE
feat: add `evdns_base_get_nameserver_fd` method

### DIFF
--- a/evdns.c
+++ b/evdns.c
@@ -3435,6 +3435,27 @@ done:
 	return result;
 }
 
+int
+evdns_base_get_nameserver_fd(struct evdns_base *base, int idx)
+{
+	int result = -1;
+	int i;
+	struct nameserver *server;
+	EVDNS_LOCK(base);
+	server = base->server_head;
+	for (i = 0; i < idx && server; ++i, server = server->next) {
+		if (server->next == base->server_head)
+			goto done;
+	}
+	if (! server)
+		goto done;
+	result = server->socket;
+done:
+	EVDNS_UNLOCK(base);
+	return result;
+}
+
+
 /* remove from the queue */
 static void
 evdns_request_remove(struct request *req, struct request **head)

--- a/include/event2/dns.h
+++ b/include/event2/dns.h
@@ -800,6 +800,18 @@ EVENT2_EXPORT_SYMBOL
 int evdns_base_get_nameserver_addr(struct evdns_base *base, int idx,
     struct sockaddr *sa, ev_socklen_t len);
 
+/**
+   Retrieve the fd of the 'idx'th configured nameserver.
+
+   @param base The evdns_base to examine.
+   @param idx The index of the nameserver to get the address of.
+
+   @return the fd value.  On failure, returns
+     -1 if idx is greater than the number of configured nameservers
+ */
+EVENT2_EXPORT_SYMBOL
+int evdns_base_get_nameserver_fd(struct evdns_base *base, int idx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/regress_dns.c
+++ b/test/regress_dns.c
@@ -1190,6 +1190,7 @@ dns_nameservers_no_default_test(void *arg)
 	dns = evdns_base_new(base, 0);
 	tt_assert(dns);
 	tt_int_op(evdns_base_get_nameserver_addr(dns, 0, NULL, 0), ==, -1);
+	tt_int_op(evdns_base_get_nameserver_fd(dns, 0), ==, -1);
 
 	/* We cannot test
 	 * EVDNS_BASE_INITIALIZE_NAMESERVERS|EVDNS_BASE_NAMESERVERS_NO_DEFAULT
@@ -1198,9 +1199,11 @@ dns_nameservers_no_default_test(void *arg)
 	evdns_base_resolv_conf_parse(dns,
 		DNS_OPTIONS_ALL|DNS_OPTION_NAMESERVERS_NO_DEFAULT, RESOLV_FILE);
 	tt_int_op(evdns_base_get_nameserver_addr(dns, 0, NULL, 0), ==, -1);
+	tt_int_op(evdns_base_get_nameserver_fd(dns, 0), ==, -1);
 
 	evdns_base_resolv_conf_parse(dns, DNS_OPTIONS_ALL, RESOLV_FILE);
 	tt_int_op(evdns_base_get_nameserver_addr(dns, 0, NULL, 0), ==, sizeof(struct sockaddr));
+	tt_int_op(evdns_base_get_nameserver_fd(dns, 0), !=, -1);
 
 end:
 	if (dns)


### PR DESCRIPTION
To get underlying udp socket fd.