### PR TITLE
Install bufferevent_ssl.h with MbedTLS support also

### DIFF
--- a/include/include.am
+++ b/include/include.am
@@ -36,6 +36,9 @@ EVENT2_EXPORT = \
 if OPENSSL
 EVENT2_EXPORT += include/event2/bufferevent_ssl.h
 endif
+if MBEDTLS
+EVENT2_EXPORT += include/event2/bufferevent_ssl.h
+endif
 
 ## Without the nobase_ prefixing, Automake would strip "include/event2/" from
 ## the source header filename to derive the installed header filename.


### PR DESCRIPTION
This small fix resolves a problem when MbedTLS library used with Libevent and `bufferevent_ssl.h` is not installed into the target system when the library is built with autotools (everything is ok for CMake build option).