### PR TITLE
regress_ssl: Use intptr_t when shoving an int into a void *

### DIFF
--- a/test/regress_ssl.c
+++ b/test/regress_ssl.c
@@ -295,9 +295,9 @@ open_ssl_bufevs(struct bufferevent **bev1_out, struct bufferevent **bev2_out,
 
 	}
 	bufferevent_setcb(*bev1_out, respond_to_number, done_writing_cb,
-	    eventcb, (void*)(REGRESS_OPENSSL_CLIENT | (long)type));
+	    eventcb, (void*)(REGRESS_OPENSSL_CLIENT | (intptr_t)type));
 	bufferevent_setcb(*bev2_out, respond_to_number, done_writing_cb,
-	    eventcb, (void*)(REGRESS_OPENSSL_SERVER | (long)type));
+	    eventcb, (void*)(REGRESS_OPENSSL_SERVER | (intptr_t)type));
 
 	bufferevent_ssl_set_allow_dirty_shutdown(*bev1_out, dirty_shutdown);
 	bufferevent_ssl_set_allow_dirty_shutdown(*bev2_out, dirty_shutdown);


### PR DESCRIPTION
Currently the code uses long, but long does not always have the same
representation as a pointer, such as on 64-bit Windows where long is
only 32-bit due to its unususal LLP64 ABI, but also on CHERI, and thus
Arm's prototype Morello architecture, where C language pointers are
represented as hardware capabilities, which have bounds, permissions and
other metadata to enforce spatial memory safety. Both of these cases
warn when casting a long to a pointer (Windows due to long being shorter
and thus it being likely you've truncated the address, and CHERI due to
long not having any capability metadata like pointers and thus it being
likely you've stripped the metadata, with the resulting "null-derived"
capability destined to trap if dereferenced), and in both cases casting
to intptr_t as the intermediate type instead will get rid of those
warnings.