### PR TITLE
Fix make install failed when Automake used and both OpenSSL and MbedTLS are activated

### DIFF
--- a/include/include.am
+++ b/include/include.am
@@ -35,9 +35,10 @@ EVENT2_EXPORT = \
 
 if OPENSSL
 EVENT2_EXPORT += include/event2/bufferevent_ssl.h
-endif
-if MBEDTLS
-EVENT2_EXPORT += include/event2/bufferevent_ssl.h
+else
+    if MBEDTLS
+    EVENT2_EXPORT += include/event2/bufferevent_ssl.h
+    endif
 endif
 
 ## Without the nobase_ prefixing, Automake would strip "include/event2/" from


### PR DESCRIPTION
The issue described by @danmih-ixia
https://github.com/libevent/libevent/pull/1241#commitcomment-63865496

It turns out that both OpenSSL and MbedTLS couldn't be used at the same time by a developer so I made it close to CMake build behavior