### PR TITLE
ci: fix mingw build

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -72,7 +72,7 @@ jobs:
           [[ $? -ne 0 ]] && exit 1
           exit 0
           '
-          D:\a\_temp\msys\msys64\usr\bin\bash.exe -c $script
+          C:\msys64\usr\bin\bash.exe -c $script
 
       - name: Test
         shell: powershell
@@ -83,7 +83,7 @@ jobs:
           export PATH="/mingw64/bin:/usr/bin:/bin:/usr/local/bin:/opt/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:$PATH"
           cd build
           make verify -j $EVENT_TESTS_PARALLEL 2>&1 '
-          D:\a\_temp\msys\msys64\usr\bin\bash.exe -c $script
+          C:\msys64\usr\bin\bash.exe -c $script
 
       - uses: actions/upload-artifact@v1
         if: failure()
@@ -130,7 +130,7 @@ jobs:
           elseif ( "${{ matrix.EVENT_MATRIX }}" -ne "NONE" ) {
             $EVENT_CONFIGURE_OPTIONS="-DEVENT__${{ matrix.EVENT_MATRIX }}=ON"
           }
-          $env:PATH="D:\a\_temp\msys\msys64\mingw64\bin;D:\a\_temp\msys\msys64\usr\bin;$env:PATH"
+          $env:PATH="C:\msys64\mingw64\bin;C:\msys64\usr\bin;$env:PATH"
           mkdir build -ea 0
           cd build
           function cmake_configure($retry)

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -58,9 +58,10 @@ jobs:
             $env:EVENT_CONFIGURE_OPTIONS="--${{ matrix.EVENT_MATRIX }}"
           }
           $env:EVENT_BUILD_PARALLEL=10
+          $env:PATH="C:\msys64\mingw64\bin;C:\msys64\usr\bin;$env:PATH"
 
           $script='
-          export PATH="/mingw64/bin:/usr/bin:/bin:/usr/local/bin:/opt/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:$PATH"
+          export PATH="/usr/bin:/bin:/usr/local/bin:/opt/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:$PATH"
           ./autogen.sh 2>&1 3>&1
           [[ $? -ne 0 ]] && exit 1
           mkdir -p build
@@ -78,9 +79,10 @@ jobs:
         shell: powershell
         run: |
           $env:EVENT_TESTS_PARALLEL=1
+          $env:PATH="C:\msys64\mingw64\bin;C:\msys64\usr\bin;$env:PATH"
 
           $script='
-          export PATH="/mingw64/bin:/usr/bin:/bin:/usr/local/bin:/opt/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:$PATH"
+          export PATH="/usr/bin:/bin:/usr/local/bin:/opt/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:$PATH"
           cd build
           make verify -j $EVENT_TESTS_PARALLEL 2>&1 '
           C:\msys64\usr\bin\bash.exe -c $script


### PR DESCRIPTION
Right now it fails with:

    D:\a\_temp\msys\msys64\usr\bin\bash.exe : The term 'D:\a\_temp\msys\msys64\usr\bin\bash.exe' is not recognized as the
    name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was
    included, verify that the path is correct and try again.
    At D:\a\_temp\7a054922-fbaf-4e63-ab95-fd7f778d29f2.ps1:24 char:1
    + D:\a\_temp\msys\msys64\usr\bin\bash.exe -c $script
    + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        + CategoryInfo          : ObjectNotFound: (D:\a\_temp\msys\msys64\usr\bin\bash.exe:String) [], ParentContainsError
       RecordException
        + FullyQualifiedErrorId : CommandNotFoundException

And according to documentation [1] path to bash.exe is:

    C:\msys64\usr\bin\bash.exe

  [1]: https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md