### PR TITLE
Windows: Add ProcessSocketNotifications backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,6 +576,7 @@ unset(SYMBOLS_TO_CHECK)
 set(EVENT__HAVE_EPOLL ${EVENT__HAVE_EPOLL_CREATE})
 if(WIN32 AND NOT CYGWIN)
     set(EVENT__HAVE_WEPOLL 1)
+    set(EVENT__HAVE_PSN 1)
 endif()
 
 # Get the gethostbyname_r prototype.
@@ -896,6 +897,10 @@ if(EVENT__HAVE_WEPOLL)
     list(APPEND SRC_CORE
         epoll.c
         wepoll.c)
+endif()
+
+if(EVENT__HAVE_PSN)
+    list(APPEND SRC_CORE psn.c)
 endif()
 
 if(EVENT__HAVE_EVENT_PORTS)
@@ -1340,6 +1345,10 @@ if (NOT EVENT__DISABLE_TESTS)
         list(APPEND BACKENDS WEPOLL)
     endif()
 
+    if (EVENT__HAVE_PSN)
+        list(APPEND BACKENDS PSN)
+    endif()
+
     if (WIN32)
         list(APPEND BACKENDS WIN32)
     endif()
@@ -1488,6 +1497,7 @@ if (NOT EVENT__DISABLE_TESTS)
             "
             set EVENT_NOWIN32=
             set EVENT_NOWEPOLL=
+            set EVENT_NOPSN=
             \"${WINDOWS_CTEST_COMMAND}\"
             ")
 

--- a/event-config.h.cmake
+++ b/event-config.h.cmake
@@ -105,6 +105,9 @@
 /* Define if your system supports the wepoll module */
 #cmakedefine EVENT__HAVE_WEPOLL 1
 
+/* Define if your system supports the ProcessSocketNotifications system call. */
+#cmakedefine EVENT__HAVE_PSN 1
+
 /* Define to 1 if you have the `eventfd' function. */
 #cmakedefine EVENT__HAVE_EVENTFD 1
 

--- a/event.c
+++ b/event.c
@@ -126,15 +126,18 @@ static const struct eventop *eventops[] = {
 #ifdef EVENT__HAVE_SELECT
 	&selectops,
 #endif
-#ifdef _WIN32
-	&win32ops,
-#endif
-#ifdef EVENT__HAVE_WEPOLL
-	&wepollops,
-#endif
 #ifdef EVENT__HAVE_PSN
 	&psnops,
 #endif
+
+#ifdef EVENT__HAVE_WEPOLL
+	&wepollops,
+#endif
+
+#ifdef _WIN32
+	&win32ops,
+#endif
+
 	NULL
 };
 

--- a/event.c
+++ b/event.c
@@ -96,6 +96,9 @@ extern const struct eventop kqops;
 #ifdef EVENT__HAVE_DEVPOLL
 extern const struct eventop devpollops;
 #endif
+#ifdef EVENT__HAVE_PSN
+extern const struct eventop psnops;
+#endif
 #ifdef EVENT__HAVE_WEPOLL
 extern const struct eventop wepollops;
 #endif
@@ -128,6 +131,9 @@ static const struct eventop *eventops[] = {
 #endif
 #ifdef EVENT__HAVE_WEPOLL
 	&wepollops,
+#endif
+#ifdef EVENT__HAVE_PSN
+	&psnops,
 #endif
 	NULL
 };

--- a/make_psn_table.py
+++ b/make_psn_table.py
@@ -1,0 +1,64 @@
+#!/usr/bin/python2
+
+def get(old,wc,rc,cc):
+    if ('xxx' in (rc, wc, cc)):
+        return "0",255
+
+    if ('add' in (rc, wc, cc)):
+        events = []
+        if rc == 'add' or (rc != 'del' and 'r' in old):
+            events.append("SOCK_NOTIFY_REGISTER_EVENT_IN")
+        if wc == 'add' or (wc != 'del' and 'w' in old):
+            events.append("SOCK_NOTIFY_REGISTER_EVENT_OUT")
+        if cc == 'add' or (cc != 'del' and 'c' in old):
+            events.append("SOCK_NOTIFY_REGISTER_EVENT_HANGUP")
+
+        if old == "0":
+            op = "SOCK_NOTIFY_OP_ENABLE"
+        else:
+            op = "SOCK_NOTIFY_OP_ENABLE"
+        return "|".join(events), op
+
+    if ('del' in (rc, wc, cc)):
+        delevents = []
+        modevents = []
+        op = "SOCK_NOTIFY_OP_REMOVE"
+
+        if 'r' in old:
+            modevents.append("SOCK_NOTIFY_REGISTER_EVENT_IN")
+        if 'w' in old:
+            modevents.append("SOCK_NOTIFY_REGISTER_EVENT_OUT")
+        if 'c' in old:
+            modevents.append("SOCK_NOTIFY_REGISTER_EVENT_HANGUP")
+
+        for item, event in [(rc,"SOCK_NOTIFY_REGISTER_EVENT_IN"),
+                            (wc,"SOCK_NOTIFY_REGISTER_EVENT_OUT"),
+                            (cc,"SOCK_NOTIFY_REGISTER_EVENT_HANGUP")]:
+            if item == 'del':
+                delevents.append(event)
+                if event in modevents:
+                    modevents.remove(event)
+
+        if modevents:
+            return "|".join(modevents), "SOCK_NOTIFY_OP_ENABLE"
+        else:
+            return "|".join(delevents), "SOCK_NOTIFY_OP_REMOVE"
+
+    return 0, 0
+
+
+def fmt(op, ev, old, wc, rc, cc):
+    entry = "{ %s, %s },"%(op, ev)
+    comment = "/* old=%3s, write:%3s, read:%3s, close:%3s */" % (old, wc, rc, cc)
+    total = "\t%s\n\t%s" % (comment, entry)
+    print(total)
+    return len(entry)
+
+for old in ('0','r','w','rw','c','cr','cw','crw'):
+    for wc in ('0', 'add', 'del', 'xxx'):
+        for rc in ('0', 'add', 'del', 'xxx'):
+            for cc in ('0', 'add', 'del', 'xxx'):
+
+                op,ev = get(old,wc,rc,cc)
+
+                fmt(op, ev, old, wc, rc, cc)

--- a/psn.c
+++ b/psn.c
@@ -66,7 +66,7 @@ const struct eventop psnops = {
 	psn_dispatch,
 	psn_dealloc,
 	1 /* need reinit */,
-    EV_FEATURE_O1,
+    EV_FEATURE_ET | EV_FEATURE_O1,
 	EVENT_CHANGELIST_FDINFO_SIZE
 };
 
@@ -257,26 +257,6 @@ psn_dispatch(struct event_base *base, struct timeval *tv)
 
 	event_debug(("%s: calling event_changelist_remove_all_", __func__));
 	event_changelist_remove_all_(&base->changelist, base);
-
-	/* Make sure that 'events' is at least as long as the list of changes:
-	 * otherwise errors in the changes can get reported as a -1 return
-	 * value from kevent() rather than as EV_ERROR events in the events
-	 * array.
-	 *
-	 * (We could instead handle -1 return values from kevent() by
-	 * retrying with a smaller changes array or a larger events array,
-	 * but this approach seems less risky for now.)
-	 */
-	// event_debug(("%s: overs_size=%d, n_changes=%d", __func__, op->overs_size, n_changes));
-	// if (op->overs_size < n_changes) {
-	// 	int new_size = op->overs_size;
-	// 	do {
-	// 		new_size *= 2;
-	// 	} while (new_size < n_changes);
-
-	// 	psn_grow_overs(op, new_size);
-	// 	overs = op->overs;
-	// }
 
 	EVBASE_RELEASE_LOCK(base, th_base_lock);
 

--- a/psn.c
+++ b/psn.c
@@ -28,7 +28,6 @@
  */
 #include "event2/event-config.h"
 #include "evconfig-private.h"
-#define EVENT__HAVE_PSN ""
 #ifdef EVENT__HAVE_PSN
 
 #include <winsock2.h>
@@ -188,7 +187,7 @@ psn_apply_one_change(struct event_base *base,
 	reg.socket = ch->fd;
 	reg.completionKey = (PVOID)ch->fd;
 	reg.eventFilter = events;
-	reg.operationFlags = operation;
+	reg.operation = operation;
 	reg.triggerFlags = SOCK_NOTIFY_TRIGGER_PERSISTENT | SOCK_NOTIFY_TRIGGER_LEVEL;
 
 	if ((res = ProcessSocketNotifications(op->cp, 1, &reg, 0, 0, NULL, NULL)) == 0) {

--- a/psn.c
+++ b/psn.c
@@ -1,0 +1,352 @@
+/*	$OpenBSD: kqueue.c,v 1.5 2002/07/10 14:41:31 art Exp $	*/
+
+/*
+ * Copyright 2000-2007 Niels Provos <provos@citi.umich.edu>
+ * Copyright 2007-2012 Niels Provos and Nick Mathewson
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "event2/event-config.h"
+#include "evconfig-private.h"
+#define EVENT__HAVE_PSN ""
+#ifdef EVENT__HAVE_PSN
+
+#include <winsock2.h>
+#include <windows.h>
+
+#include "event-internal.h"
+#include "log-internal.h"
+#include "evmap-internal.h"
+// #include "event2/thread.h"
+// #include "event2/util.h"
+#include "evthread-internal.h"
+#include "changelist-internal.h"
+
+#include "psntable-internal.h"
+
+#define NEVENT		64
+
+struct psnop {
+	HANDLE cp;
+	SOCK_NOTIFY_REGISTRATION* regs;
+	int regs_size;
+	OVERLAPPED_ENTRY* overs;
+	int overs_size;
+};
+
+
+static void *psn_init(struct event_base *);
+static int psn_dispatch(struct event_base *, struct timeval *);
+static void psn_dealloc(struct event_base *);
+
+const struct eventop psnops = {
+	"psn",
+	psn_init,
+	event_changelist_add_,
+	event_changelist_del_,
+	psn_dispatch,
+	psn_dealloc,
+	1 /* need reinit */,
+    EV_FEATURE_O1,
+	EVENT_CHANGELIST_FDINFO_SIZE
+};
+
+static const char *
+change_to_string(int change)
+{
+	change &= (EV_CHANGE_ADD|EV_CHANGE_DEL);
+	if (change == EV_CHANGE_ADD) {
+		return "add";
+	} else if (change == EV_CHANGE_DEL) {
+		return "del";
+	} else if (change == 0) {
+		return "none";
+	} else {
+		return "???";
+	}
+}
+
+static const char *
+psn_op_to_string(int op)
+{
+	return op == SOCK_NOTIFY_OP_ENABLE?"ENABLE":
+	    op == SOCK_NOTIFY_OP_REMOVE?"REMOVE":
+	    "???";
+}
+
+#define PRINT_CHANGES(op, events, ch, status)  \
+	"PSN %s(%d) on fd %d " status ". "         \
+	"Old events were %d; "                     \
+	"read change was %d (%s); "                \
+	"write change was %d (%s); "               \
+	"close change was %d (%s)",                \
+	psn_op_to_string(op),                      \
+	events,                                    \
+	ch->fd,                                    \
+	ch->old_events,                            \
+	ch->read_change,                           \
+	change_to_string(ch->read_change),         \
+	ch->write_change,                          \
+	change_to_string(ch->write_change),        \
+	ch->close_change,                          \
+	change_to_string(ch->close_change)
+
+static void *
+psn_init(struct event_base *base)
+{
+	struct psnop *op = NULL;
+	HANDLE cp = NULL;
+
+	event_debug(("%s: entry", __func__));
+
+	if (!(op = mm_calloc(1, sizeof(struct psnop)))) {
+		event_debug(("%s: mm_calloc failed", __func__));
+		goto err;
+	}
+
+	memset(op, 0, sizeof(struct psnop));
+
+	if ((op->cp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 0)) == NULL) {
+		event_debug(("%s: CreateIoCompletionPort failed", __func__));
+		goto err;
+	}
+
+	if (!(op->regs = mm_calloc(NEVENT, sizeof(SOCK_NOTIFY_REGISTRATION)))) {
+		event_debug(("%s: mm_calloc failed", __func__));
+		goto err;
+	}
+	if (!(op->overs = mm_calloc(NEVENT, sizeof(OVERLAPPED_ENTRY)))) {
+		event_debug(("%s: mm_calloc failed", __func__));
+		goto err;
+	}
+	op->overs_size = op->regs_size = NEVENT;
+
+	if (evsig_init_(base) < 0) {
+		event_debug(("%s: evsig_init_ failed", __func__));
+		goto err;
+	}
+
+	return (op);
+
+err:
+	if (op != NULL) {
+		if (op->cp != NULL)
+			CloseHandle(op->cp);
+		if (op->regs != NULL)
+			mm_free(op->regs);
+		if (op->overs != NULL)
+			mm_free(op->overs);
+
+		mm_free(op);
+	}
+	return (NULL);
+}
+
+static int
+psn_apply_one_change(struct event_base *base,
+    struct psnop *op,
+    const struct event_change *ch)
+{
+	SOCK_NOTIFY_REGISTRATION reg;
+	int operation, events = 0;
+	int idx, res;
+
+	idx = PSN_OP_TABLE_INDEX(ch);
+	operation = psn_op_table[idx].op;
+	events = psn_op_table[idx].events;
+
+	if (!events) {
+		EVUTIL_ASSERT(operation == 0);
+		return 0;
+	}
+
+	if (events & SOCK_NOTIFY_REGISTER_EVENT_IN || events & SOCK_NOTIFY_REGISTER_EVENT_OUT) {
+		events |= SOCK_NOTIFY_REGISTER_EVENT_HANGUP;
+	}
+
+	memset(&reg, 0, sizeof(reg));
+	reg.socket = ch->fd;
+	reg.completionKey = (PVOID)ch->fd;
+	reg.eventFilter = events;
+	reg.operationFlags = operation;
+	reg.triggerFlags = SOCK_NOTIFY_TRIGGER_PERSISTENT | SOCK_NOTIFY_TRIGGER_LEVEL;
+
+	if ((res = ProcessSocketNotifications(op->cp, 1, &reg, 0, 0, NULL, NULL)) == 0) {
+		event_debug((PRINT_CHANGES(operation, events, ch, "okay")));
+		return 0;
+	}
+
+	event_debug((PRINT_CHANGES(operation, events, ch, "failed")));
+	event_debug(("ProcessSocketNotifications res=%d, registrationResult=%d", res, reg.registrationResult));
+	return -1;
+}
+
+static int
+psn_apply_changes(struct event_base *base)
+{
+	struct event_changelist *changelist = &base->changelist;
+	struct psnop *op = base->evbase;
+	struct event_change *ch;
+
+	int r = 0;
+	int i;
+
+	for (i = 0; i < changelist->n_changes; ++i) {
+		ch = &changelist->changes[i];
+		if (psn_apply_one_change(base, op, ch) < 0)
+			r = -1;
+	}
+
+	return (r);
+}
+
+static int
+psn_grow_overs(struct psnop *op, int new_size)
+{
+	OVERLAPPED_ENTRY *newresult;
+
+	event_debug(("%s: entry", __func__));
+
+	newresult = mm_realloc(op->overs,
+	    new_size * sizeof(OVERLAPPED_ENTRY));
+
+	if (newresult) {
+		op->overs = newresult;
+		op->overs_size = new_size;
+		return 0;
+	} else {
+		return -1;
+	}
+}
+
+static int
+psn_dispatch(struct event_base *base, struct timeval *tv)
+{
+	struct psnop *op = base->evbase;
+	OVERLAPPED_ENTRY *overs = op->overs;
+	int timeout = 0;
+	int i, res, n_returned = 0;
+
+	event_debug(("%s: entry", __func__));
+
+	if (tv != NULL) {
+		timeout = tv->tv_sec * 1000 + tv->tv_usec / 1000;
+	}
+
+	/* Register all changes first */
+	psn_apply_changes(base);
+
+	event_debug(("%s: calling event_changelist_remove_all_", __func__));
+	event_changelist_remove_all_(&base->changelist, base);
+
+	/* Make sure that 'events' is at least as long as the list of changes:
+	 * otherwise errors in the changes can get reported as a -1 return
+	 * value from kevent() rather than as EV_ERROR events in the events
+	 * array.
+	 *
+	 * (We could instead handle -1 return values from kevent() by
+	 * retrying with a smaller changes array or a larger events array,
+	 * but this approach seems less risky for now.)
+	 */
+	// event_debug(("%s: overs_size=%d, n_changes=%d", __func__, op->overs_size, n_changes));
+	// if (op->overs_size < n_changes) {
+	// 	int new_size = op->overs_size;
+	// 	do {
+	// 		new_size *= 2;
+	// 	} while (new_size < n_changes);
+
+	// 	psn_grow_overs(op, new_size);
+	// 	overs = op->overs;
+	// }
+
+	EVBASE_RELEASE_LOCK(base, th_base_lock);
+
+	event_debug(("%s: calling ProcessSocketNotifications completionPort=%d, registrationCount=%d, timeoutMs=%d, completionCount=%d",
+		__func__, op->cp, 0, timeout, op->overs_size));
+
+	res = ProcessSocketNotifications(op->cp, 0, NULL, timeout, op->overs_size, overs, &n_returned);
+
+	EVBASE_ACQUIRE_LOCK(base, th_base_lock);
+
+	event_debug(("%s: ProcessSocketNotifications reports res=%d, n_returned=%d", __func__, res, n_returned));
+
+	if (res != NO_ERROR && res != WAIT_TIMEOUT) {
+		event_warn("ProcessSocketNotifications");
+		return (-1);
+	}
+
+	for (i = 0; i < n_returned; i++) {
+		int events;
+		int which = 0;
+
+		events = SocketNotificationRetrieveEvents(&overs[i]);
+
+		if (events & SOCK_NOTIFY_EVENT_ERR) {
+			event_debug(("%s: ProcessSocketNotifications ERR on sock %d", __func__, overs[i].lpCompletionKey));
+		}
+		if (events & SOCK_NOTIFY_EVENT_HANGUP) {
+			event_debug(("%s: ProcessSocketNotifications HANGUP on sock %d", __func__, overs[i].lpCompletionKey));
+			which |= EV_READ;
+			which |= EV_WRITE;
+		}
+		if (events & SOCK_NOTIFY_EVENT_IN) {
+			event_debug(("%s: ProcessSocketNotifications IN on sock %d", __func__, overs[i].lpCompletionKey));
+			which |= EV_READ;
+		}
+		if (events & SOCK_NOTIFY_EVENT_OUT) {
+			event_debug(("%s: ProcessSocketNotifications OUT on sock %d", __func__, overs[i].lpCompletionKey));
+			which |= EV_WRITE;
+		}
+		if (events & SOCK_NOTIFY_EVENT_REMOVE) {
+			event_debug(("%s: ProcessSocketNotifications REMOVE on sock %d", __func__, overs[i].lpCompletionKey));
+		}
+
+		if (which) {
+			evmap_io_active_(base, overs[i].lpCompletionKey, which);
+		}
+	}
+
+	if (n_returned == op->overs_size) {
+		/* We used all the events space that we have. Maybe we should
+		   make it bigger. */
+		psn_grow_overs(op, op->overs_size * 2);
+	}
+
+	return (0);
+}
+
+static void
+psn_dealloc(struct event_base *base)
+{
+	struct psnop *op = base->evbase;
+
+	event_debug(("%s: entry", __func__));
+
+	EVUTIL_ASSERT(op != NULL);
+	EVUTIL_ASSERT(op->cp != NULL);
+
+	CloseHandle(op->cp);
+	mm_free(op);
+}
+
+#endif /* EVENT__HAVE_PSN */

--- a/psntable-internal.h
+++ b/psntable-internal.h
@@ -1,0 +1,1077 @@
+/*
+ * Copyright (c) 2000-2007 Niels Provos <provos@citi.umich.edu>
+ * Copyright (c) 2007-2012 Niels Provos and Nick Mathewson
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef PSNTABLE_INTERNAL_H_INCLUDED_
+#define PSNTABLE_INTERNAL_H_INCLUDED_
+
+/*
+  Produced by make_psn_table.py.
+*/
+
+#define PSN_OP_TABLE_INDEX(c) \
+	(   (((c)->close_change&(EV_CHANGE_ADD|EV_CHANGE_DEL))) |		\
+	    (((c)->read_change&(EV_CHANGE_ADD|EV_CHANGE_DEL)) << 2) |	\
+	    (((c)->write_change&(EV_CHANGE_ADD|EV_CHANGE_DEL)) << 4) |	\
+	    (((c)->old_events&(EV_READ|EV_WRITE)) << 5) |		\
+	    (((c)->old_events&(EV_CLOSED)) << 1)				\
+	    )
+
+#if EV_READ != 2 || EV_WRITE != 4 || EV_CLOSED != 0x80 || EV_CHANGE_ADD != 1 || EV_CHANGE_DEL != 2
+#error "Libevent's internals changed!  Regenerate the op_table in psntable-internal.h"
+#endif
+
+static const struct operation {
+	int events;
+	int op;
+} psn_op_table[] = {
+	/* old=  0, write:  0, read:  0, close:  0 */
+	{ 0, 0 },
+	/* old=  0, write:  0, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:  0, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  0, write:  0, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=  0, write:  0, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:  0, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:  0, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:  0, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=  0, write:  0, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  0, write:  0, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:  0, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  0, write:  0, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=  0, write:  0, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=  0, write:  0, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=  0, write:  0, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=  0, write:  0, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=  0, write:add, read:  0, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:add, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:add, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:add, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=  0, write:add, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:add, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:add, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:add, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=  0, write:add, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:add, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:add, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:add, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=  0, write:add, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=  0, write:add, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=  0, write:add, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=  0, write:add, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=  0, write:del, read:  0, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  0, write:del, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:del, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  0, write:del, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=  0, write:del, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:del, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:del, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:del, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=  0, write:del, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  0, write:del, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  0, write:del, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  0, write:del, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=  0, write:del, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=  0, write:del, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=  0, write:del, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=  0, write:del, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=  0, write:xxx, read:  0, close:  0 */
+	{ 0, 255 },
+	/* old=  0, write:xxx, read:  0, close:add */
+	{ 0, 255 },
+	/* old=  0, write:xxx, read:  0, close:del */
+	{ 0, 255 },
+	/* old=  0, write:xxx, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=  0, write:xxx, read:add, close:  0 */
+	{ 0, 255 },
+	/* old=  0, write:xxx, read:add, close:add */
+	{ 0, 255 },
+	/* old=  0, write:xxx, read:add, close:del */
+	{ 0, 255 },
+	/* old=  0, write:xxx, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=  0, write:xxx, read:del, close:  0 */
+	{ 0, 255 },
+	/* old=  0, write:xxx, read:del, close:add */
+	{ 0, 255 },
+	/* old=  0, write:xxx, read:del, close:del */
+	{ 0, 255 },
+	/* old=  0, write:xxx, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=  0, write:xxx, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=  0, write:xxx, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=  0, write:xxx, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=  0, write:xxx, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=  r, write:  0, read:  0, close:  0 */
+	{ 0, 0 },
+	/* old=  r, write:  0, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:  0, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:  0, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=  r, write:  0, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:  0, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:  0, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:  0, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=  r, write:  0, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  r, write:  0, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:  0, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  r, write:  0, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=  r, write:  0, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=  r, write:  0, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=  r, write:  0, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=  r, write:  0, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=  r, write:add, read:  0, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:add, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:add, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:add, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=  r, write:add, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:add, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:add, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:add, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=  r, write:add, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:add, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:add, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:add, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=  r, write:add, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=  r, write:add, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=  r, write:add, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=  r, write:add, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=  r, write:del, read:  0, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:del, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:del, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:del, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=  r, write:del, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:del, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:del, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:del, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=  r, write:del, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  r, write:del, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  r, write:del, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  r, write:del, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=  r, write:del, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=  r, write:del, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=  r, write:del, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=  r, write:del, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=  r, write:xxx, read:  0, close:  0 */
+	{ 0, 255 },
+	/* old=  r, write:xxx, read:  0, close:add */
+	{ 0, 255 },
+	/* old=  r, write:xxx, read:  0, close:del */
+	{ 0, 255 },
+	/* old=  r, write:xxx, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=  r, write:xxx, read:add, close:  0 */
+	{ 0, 255 },
+	/* old=  r, write:xxx, read:add, close:add */
+	{ 0, 255 },
+	/* old=  r, write:xxx, read:add, close:del */
+	{ 0, 255 },
+	/* old=  r, write:xxx, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=  r, write:xxx, read:del, close:  0 */
+	{ 0, 255 },
+	/* old=  r, write:xxx, read:del, close:add */
+	{ 0, 255 },
+	/* old=  r, write:xxx, read:del, close:del */
+	{ 0, 255 },
+	/* old=  r, write:xxx, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=  r, write:xxx, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=  r, write:xxx, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=  r, write:xxx, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=  r, write:xxx, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=  w, write:  0, read:  0, close:  0 */
+	{ 0, 0 },
+	/* old=  w, write:  0, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:  0, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:  0, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=  w, write:  0, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:  0, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:  0, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:  0, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=  w, write:  0, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:  0, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:  0, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:  0, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=  w, write:  0, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=  w, write:  0, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=  w, write:  0, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=  w, write:  0, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=  w, write:add, read:  0, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:add, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:add, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:add, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=  w, write:add, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:add, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:add, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:add, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=  w, write:add, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:add, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:add, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:add, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=  w, write:add, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=  w, write:add, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=  w, write:add, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=  w, write:add, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=  w, write:del, read:  0, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  w, write:del, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:del, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  w, write:del, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=  w, write:del, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:del, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:del, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:del, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=  w, write:del, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  w, write:del, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  w, write:del, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  w, write:del, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=  w, write:del, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=  w, write:del, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=  w, write:del, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=  w, write:del, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=  w, write:xxx, read:  0, close:  0 */
+	{ 0, 255 },
+	/* old=  w, write:xxx, read:  0, close:add */
+	{ 0, 255 },
+	/* old=  w, write:xxx, read:  0, close:del */
+	{ 0, 255 },
+	/* old=  w, write:xxx, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=  w, write:xxx, read:add, close:  0 */
+	{ 0, 255 },
+	/* old=  w, write:xxx, read:add, close:add */
+	{ 0, 255 },
+	/* old=  w, write:xxx, read:add, close:del */
+	{ 0, 255 },
+	/* old=  w, write:xxx, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=  w, write:xxx, read:del, close:  0 */
+	{ 0, 255 },
+	/* old=  w, write:xxx, read:del, close:add */
+	{ 0, 255 },
+	/* old=  w, write:xxx, read:del, close:del */
+	{ 0, 255 },
+	/* old=  w, write:xxx, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=  w, write:xxx, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=  w, write:xxx, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=  w, write:xxx, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=  w, write:xxx, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old= rw, write:  0, read:  0, close:  0 */
+	{ 0, 0 },
+	/* old= rw, write:  0, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:  0, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:  0, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old= rw, write:  0, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:  0, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:  0, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:  0, read:add, close:xxx */
+	{ 0, 255 },
+	/* old= rw, write:  0, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:  0, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:  0, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:  0, read:del, close:xxx */
+	{ 0, 255 },
+	/* old= rw, write:  0, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old= rw, write:  0, read:xxx, close:add */
+	{ 0, 255 },
+	/* old= rw, write:  0, read:xxx, close:del */
+	{ 0, 255 },
+	/* old= rw, write:  0, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old= rw, write:add, read:  0, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:add, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:add, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:add, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old= rw, write:add, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:add, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:add, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:add, read:add, close:xxx */
+	{ 0, 255 },
+	/* old= rw, write:add, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:add, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:add, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:add, read:del, close:xxx */
+	{ 0, 255 },
+	/* old= rw, write:add, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old= rw, write:add, read:xxx, close:add */
+	{ 0, 255 },
+	/* old= rw, write:add, read:xxx, close:del */
+	{ 0, 255 },
+	/* old= rw, write:add, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old= rw, write:del, read:  0, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:del, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:del, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:del, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old= rw, write:del, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:del, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:del, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:del, read:add, close:xxx */
+	{ 0, 255 },
+	/* old= rw, write:del, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_REMOVE },
+	/* old= rw, write:del, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= rw, write:del, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old= rw, write:del, read:del, close:xxx */
+	{ 0, 255 },
+	/* old= rw, write:del, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old= rw, write:del, read:xxx, close:add */
+	{ 0, 255 },
+	/* old= rw, write:del, read:xxx, close:del */
+	{ 0, 255 },
+	/* old= rw, write:del, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old= rw, write:xxx, read:  0, close:  0 */
+	{ 0, 255 },
+	/* old= rw, write:xxx, read:  0, close:add */
+	{ 0, 255 },
+	/* old= rw, write:xxx, read:  0, close:del */
+	{ 0, 255 },
+	/* old= rw, write:xxx, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old= rw, write:xxx, read:add, close:  0 */
+	{ 0, 255 },
+	/* old= rw, write:xxx, read:add, close:add */
+	{ 0, 255 },
+	/* old= rw, write:xxx, read:add, close:del */
+	{ 0, 255 },
+	/* old= rw, write:xxx, read:add, close:xxx */
+	{ 0, 255 },
+	/* old= rw, write:xxx, read:del, close:  0 */
+	{ 0, 255 },
+	/* old= rw, write:xxx, read:del, close:add */
+	{ 0, 255 },
+	/* old= rw, write:xxx, read:del, close:del */
+	{ 0, 255 },
+	/* old= rw, write:xxx, read:del, close:xxx */
+	{ 0, 255 },
+	/* old= rw, write:xxx, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old= rw, write:xxx, read:xxx, close:add */
+	{ 0, 255 },
+	/* old= rw, write:xxx, read:xxx, close:del */
+	{ 0, 255 },
+	/* old= rw, write:xxx, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=  c, write:  0, read:  0, close:  0 */
+	{ 0, 0 },
+	/* old=  c, write:  0, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:  0, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  c, write:  0, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=  c, write:  0, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:  0, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:  0, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:  0, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=  c, write:  0, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:  0, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:  0, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  c, write:  0, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=  c, write:  0, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=  c, write:  0, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=  c, write:  0, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=  c, write:  0, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=  c, write:add, read:  0, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:add, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:add, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:add, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=  c, write:add, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:add, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:add, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:add, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=  c, write:add, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:add, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:add, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:add, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=  c, write:add, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=  c, write:add, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=  c, write:add, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=  c, write:add, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=  c, write:del, read:  0, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:del, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:del, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  c, write:del, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=  c, write:del, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:del, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:del, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:del, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=  c, write:del, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:del, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=  c, write:del, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old=  c, write:del, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=  c, write:del, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=  c, write:del, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=  c, write:del, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=  c, write:del, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=  c, write:xxx, read:  0, close:  0 */
+	{ 0, 255 },
+	/* old=  c, write:xxx, read:  0, close:add */
+	{ 0, 255 },
+	/* old=  c, write:xxx, read:  0, close:del */
+	{ 0, 255 },
+	/* old=  c, write:xxx, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=  c, write:xxx, read:add, close:  0 */
+	{ 0, 255 },
+	/* old=  c, write:xxx, read:add, close:add */
+	{ 0, 255 },
+	/* old=  c, write:xxx, read:add, close:del */
+	{ 0, 255 },
+	/* old=  c, write:xxx, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=  c, write:xxx, read:del, close:  0 */
+	{ 0, 255 },
+	/* old=  c, write:xxx, read:del, close:add */
+	{ 0, 255 },
+	/* old=  c, write:xxx, read:del, close:del */
+	{ 0, 255 },
+	/* old=  c, write:xxx, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=  c, write:xxx, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=  c, write:xxx, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=  c, write:xxx, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=  c, write:xxx, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old= cr, write:  0, read:  0, close:  0 */
+	{ 0, 0 },
+	/* old= cr, write:  0, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:  0, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:  0, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old= cr, write:  0, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:  0, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:  0, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:  0, read:add, close:xxx */
+	{ 0, 255 },
+	/* old= cr, write:  0, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:  0, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:  0, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old= cr, write:  0, read:del, close:xxx */
+	{ 0, 255 },
+	/* old= cr, write:  0, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old= cr, write:  0, read:xxx, close:add */
+	{ 0, 255 },
+	/* old= cr, write:  0, read:xxx, close:del */
+	{ 0, 255 },
+	/* old= cr, write:  0, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old= cr, write:add, read:  0, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:add, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:add, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:add, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old= cr, write:add, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:add, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:add, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:add, read:add, close:xxx */
+	{ 0, 255 },
+	/* old= cr, write:add, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:add, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:add, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:add, read:del, close:xxx */
+	{ 0, 255 },
+	/* old= cr, write:add, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old= cr, write:add, read:xxx, close:add */
+	{ 0, 255 },
+	/* old= cr, write:add, read:xxx, close:del */
+	{ 0, 255 },
+	/* old= cr, write:add, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old= cr, write:del, read:  0, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:del, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:del, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:del, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old= cr, write:del, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:del, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:del, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:del, read:add, close:xxx */
+	{ 0, 255 },
+	/* old= cr, write:del, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:del, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cr, write:del, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old= cr, write:del, read:del, close:xxx */
+	{ 0, 255 },
+	/* old= cr, write:del, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old= cr, write:del, read:xxx, close:add */
+	{ 0, 255 },
+	/* old= cr, write:del, read:xxx, close:del */
+	{ 0, 255 },
+	/* old= cr, write:del, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old= cr, write:xxx, read:  0, close:  0 */
+	{ 0, 255 },
+	/* old= cr, write:xxx, read:  0, close:add */
+	{ 0, 255 },
+	/* old= cr, write:xxx, read:  0, close:del */
+	{ 0, 255 },
+	/* old= cr, write:xxx, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old= cr, write:xxx, read:add, close:  0 */
+	{ 0, 255 },
+	/* old= cr, write:xxx, read:add, close:add */
+	{ 0, 255 },
+	/* old= cr, write:xxx, read:add, close:del */
+	{ 0, 255 },
+	/* old= cr, write:xxx, read:add, close:xxx */
+	{ 0, 255 },
+	/* old= cr, write:xxx, read:del, close:  0 */
+	{ 0, 255 },
+	/* old= cr, write:xxx, read:del, close:add */
+	{ 0, 255 },
+	/* old= cr, write:xxx, read:del, close:del */
+	{ 0, 255 },
+	/* old= cr, write:xxx, read:del, close:xxx */
+	{ 0, 255 },
+	/* old= cr, write:xxx, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old= cr, write:xxx, read:xxx, close:add */
+	{ 0, 255 },
+	/* old= cr, write:xxx, read:xxx, close:del */
+	{ 0, 255 },
+	/* old= cr, write:xxx, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old= cw, write:  0, read:  0, close:  0 */
+	{ 0, 0 },
+	/* old= cw, write:  0, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:  0, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:  0, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old= cw, write:  0, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:  0, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:  0, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:  0, read:add, close:xxx */
+	{ 0, 255 },
+	/* old= cw, write:  0, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:  0, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:  0, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:  0, read:del, close:xxx */
+	{ 0, 255 },
+	/* old= cw, write:  0, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old= cw, write:  0, read:xxx, close:add */
+	{ 0, 255 },
+	/* old= cw, write:  0, read:xxx, close:del */
+	{ 0, 255 },
+	/* old= cw, write:  0, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old= cw, write:add, read:  0, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:add, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:add, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:add, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old= cw, write:add, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:add, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:add, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:add, read:add, close:xxx */
+	{ 0, 255 },
+	/* old= cw, write:add, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:add, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:add, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:add, read:del, close:xxx */
+	{ 0, 255 },
+	/* old= cw, write:add, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old= cw, write:add, read:xxx, close:add */
+	{ 0, 255 },
+	/* old= cw, write:add, read:xxx, close:del */
+	{ 0, 255 },
+	/* old= cw, write:add, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old= cw, write:del, read:  0, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:del, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:del, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old= cw, write:del, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old= cw, write:del, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:del, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:del, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:del, read:add, close:xxx */
+	{ 0, 255 },
+	/* old= cw, write:del, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:del, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old= cw, write:del, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old= cw, write:del, read:del, close:xxx */
+	{ 0, 255 },
+	/* old= cw, write:del, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old= cw, write:del, read:xxx, close:add */
+	{ 0, 255 },
+	/* old= cw, write:del, read:xxx, close:del */
+	{ 0, 255 },
+	/* old= cw, write:del, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old= cw, write:xxx, read:  0, close:  0 */
+	{ 0, 255 },
+	/* old= cw, write:xxx, read:  0, close:add */
+	{ 0, 255 },
+	/* old= cw, write:xxx, read:  0, close:del */
+	{ 0, 255 },
+	/* old= cw, write:xxx, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old= cw, write:xxx, read:add, close:  0 */
+	{ 0, 255 },
+	/* old= cw, write:xxx, read:add, close:add */
+	{ 0, 255 },
+	/* old= cw, write:xxx, read:add, close:del */
+	{ 0, 255 },
+	/* old= cw, write:xxx, read:add, close:xxx */
+	{ 0, 255 },
+	/* old= cw, write:xxx, read:del, close:  0 */
+	{ 0, 255 },
+	/* old= cw, write:xxx, read:del, close:add */
+	{ 0, 255 },
+	/* old= cw, write:xxx, read:del, close:del */
+	{ 0, 255 },
+	/* old= cw, write:xxx, read:del, close:xxx */
+	{ 0, 255 },
+	/* old= cw, write:xxx, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old= cw, write:xxx, read:xxx, close:add */
+	{ 0, 255 },
+	/* old= cw, write:xxx, read:xxx, close:del */
+	{ 0, 255 },
+	/* old= cw, write:xxx, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=crw, write:  0, read:  0, close:  0 */
+	{ 0, 0 },
+	/* old=crw, write:  0, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:  0, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:  0, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=crw, write:  0, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:  0, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:  0, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:  0, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=crw, write:  0, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:  0, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:  0, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:  0, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=crw, write:  0, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=crw, write:  0, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=crw, write:  0, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=crw, write:  0, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=crw, write:add, read:  0, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:add, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:add, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:add, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=crw, write:add, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:add, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:add, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:add, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=crw, write:add, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:add, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:add, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_OUT, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:add, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=crw, write:add, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=crw, write:add, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=crw, write:add, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=crw, write:add, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=crw, write:del, read:  0, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:del, read:  0, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:del, read:  0, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:del, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=crw, write:del, read:add, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:del, read:add, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:del, read:add, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:del, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=crw, write:del, read:del, close:  0 */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:del, read:del, close:add */
+	{ SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_ENABLE },
+	/* old=crw, write:del, read:del, close:del */
+	{ SOCK_NOTIFY_REGISTER_EVENT_IN|SOCK_NOTIFY_REGISTER_EVENT_OUT|SOCK_NOTIFY_REGISTER_EVENT_HANGUP, SOCK_NOTIFY_OP_REMOVE },
+	/* old=crw, write:del, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=crw, write:del, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=crw, write:del, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=crw, write:del, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=crw, write:del, read:xxx, close:xxx */
+	{ 0, 255 },
+	/* old=crw, write:xxx, read:  0, close:  0 */
+	{ 0, 255 },
+	/* old=crw, write:xxx, read:  0, close:add */
+	{ 0, 255 },
+	/* old=crw, write:xxx, read:  0, close:del */
+	{ 0, 255 },
+	/* old=crw, write:xxx, read:  0, close:xxx */
+	{ 0, 255 },
+	/* old=crw, write:xxx, read:add, close:  0 */
+	{ 0, 255 },
+	/* old=crw, write:xxx, read:add, close:add */
+	{ 0, 255 },
+	/* old=crw, write:xxx, read:add, close:del */
+	{ 0, 255 },
+	/* old=crw, write:xxx, read:add, close:xxx */
+	{ 0, 255 },
+	/* old=crw, write:xxx, read:del, close:  0 */
+	{ 0, 255 },
+	/* old=crw, write:xxx, read:del, close:add */
+	{ 0, 255 },
+	/* old=crw, write:xxx, read:del, close:del */
+	{ 0, 255 },
+	/* old=crw, write:xxx, read:del, close:xxx */
+	{ 0, 255 },
+	/* old=crw, write:xxx, read:xxx, close:  0 */
+	{ 0, 255 },
+	/* old=crw, write:xxx, read:xxx, close:add */
+	{ 0, 255 },
+	/* old=crw, write:xxx, read:xxx, close:del */
+	{ 0, 255 },
+	/* old=crw, write:xxx, read:xxx, close:xxx */
+	{ 0, 255 },
+
+};
+
+#endif

--- a/psntable-internal.h
+++ b/psntable-internal.h
@@ -26,7 +26,7 @@
  */
 #ifndef PSNTABLE_INTERNAL_H_INCLUDED_
 #define PSNTABLE_INTERNAL_H_INCLUDED_
-
+#include <winsock2.h>
 /*
   Produced by make_psn_table.py.
 */


### PR DESCRIPTION
A scalable backend using latest Windows API: https://docs.microsoft.com/en-us/windows/win32/winsock/winsock-socket-state-notifications aimed at replacing wepoll's unofficial use of  *IOCTL_AFD_POLL*; it also supports edge-triggered notifications.

Fixes https://github.com/libevent/libevent/issues/1216