### PR TITLE
[Windows CI] Fix pipeline - update vcpkg version to latest.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,7 +54,7 @@ jobs:
           vcpkgArguments: zlib:x64-windows openssl:x64-windows mbedtls:x64-windows
           vcpkgDirectory: ${{ runner.workspace }}/vcpkg/
           vcpkgTriplet: x64-windows
-          vcpkgGitCommitId: 7bc5b8cdfaf35329c1520b2af8d368e2b1cb78e6
+          vcpkgGitCommitId: af2287382b1991dbdcb7e5112d236f3323b9dd7a
 
       - name: Build
         shell: powershell


### PR DESCRIPTION
The Windows CI is failing at the `prepare vcpkg` step while installing `zlib`
Changing the vcpkg commit hash to point to latest release https://github.com/microsoft/vcpkg/releases/tag/2022.03.10 as opposed to sometime in 2019 to see if that fixes it.