### PR TITLE
[Windows CI] Fix failing mingw build tasks.

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -72,7 +72,7 @@ jobs:
           [[ $? -ne 0 ]] && exit 1
           exit 0
           '
-          D:\a\_temp\msys\msys64\usr\bin\bash.exe -c $script
+          D:\a\_temp\msys64\usr\bin\bash.exe -c $script
 
       - name: Test
         shell: powershell
@@ -83,7 +83,7 @@ jobs:
           export PATH="/mingw64/bin:/usr/bin:/bin:/usr/local/bin:/opt/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:$PATH"
           cd build
           make verify -j $EVENT_TESTS_PARALLEL 2>&1 '
-          D:\a\_temp\msys\msys64\usr\bin\bash.exe -c $script
+          D:\a\_temp\msys64\usr\bin\bash.exe -c $script
 
       - uses: actions/upload-artifact@v1
         if: failure()
@@ -130,7 +130,7 @@ jobs:
           elseif ( "${{ matrix.EVENT_MATRIX }}" -ne "NONE" ) {
             $EVENT_CONFIGURE_OPTIONS="-DEVENT__${{ matrix.EVENT_MATRIX }}=ON"
           }
-          $env:PATH="D:\a\_temp\msys\msys64\mingw64\bin;D:\a\_temp\msys\msys64\usr\bin;$env:PATH"
+          $env:PATH="D:\a\_temp\msys64\mingw64\bin;D:\a\_temp\msys64\usr\bin;$env:PATH"
           mkdir build -ea 0
           cd build
           function cmake_configure($retry)


### PR DESCRIPTION
I found the correct path by looking at the _Disable Key Refresh_ step in _mingw::autotools::set up msys2_ task (https://github.com/rectified95/libevent/runs/5858227589?check_suite_focus=true)

_C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe "((Get-Content -path **D:\a\_temp\msys64**\etc\post-install\07-pacman-key.post -Raw) ..._