### PR TITLE
Restore the last error code int evconnlistener_new_bind()

### DIFF
--- a/listener.c
+++ b/listener.c
@@ -275,8 +275,13 @@ evconnlistener_new_bind(struct event_base *base, evconnlistener_cb cb,
 
 	return listener;
 err:
-	evutil_closesocket(fd);
-	return NULL;
+	{
+		int saved_errno = EVUTIL_SOCKET_ERROR();
+		evutil_closesocket(fd);
+		if (saved_errno)
+			EVUTIL_SET_SOCKET_ERROR(saved_errno);
+		return NULL;
+	}
 }
 
 void


### PR DESCRIPTION
In function evconnlistener_new_bind() after go to "err:", The evutil_closesocket()  would clear the error code( I found this under Windows ). User can not use EVUTIL_SOCKET_ERROR() to get the evconnlistener_new_bind()'s failing error.
I add a err_code variable to store and restore the last error code.
