### PR TITLE
Initial OpenSSL 3.0 support

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,7 +31,6 @@ jobs:
           - NONE
           - NO_SSL
           - DISABLE_OPENSSL
-          - OPENSSL_3
           - DISABLE_THREAD_SUPPORT
           - DISABLE_DEBUG_MODE
           - DISABLE_MM_REPLACEMENT
@@ -41,6 +40,9 @@ jobs:
           - ASAN
           - TSAN
           - UBSAN
+        include:
+          - os: ubuntu-22.04
+            EVENT_MATRIX: OPENSSL_3
 
     steps:
       - uses: actions/checkout@v2.0.0
@@ -59,32 +61,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libmbedtls-dev
-
-          if [ "${{ matrix.EVENT_MATRIX }}" == "OPENSSL_3" ]; then
-            OPENSSL_VERSION=3.0.3
-            JOBS=20
-
-            echo [openssl-${OPENSSL_VERSION}]: Downloading
-            wget "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"
-
-            echo [openssl-${OPENSSL_VERSION}]: Extracting
-            tar xzf "openssl-${OPENSSL_VERSION}.tar.gz"
-            rm "openssl-${OPENSSL_VERSION}.tar.gz"
-            mv "openssl-${OPENSSL_VERSION}" /tmp/openssl-3
-
-            echo [openssl-${OPENSSL_VERSION}]: Building
-            pushd /tmp/openssl-3
-            ./Configure --prefix=$PWD/install
-            make -j ${JOBS}
-            make install
-            cd install
-            if [ ! -d lib ]; then
-              ln -s lib64 lib
-            fi
-
-            echo [openssl-${OPENSSL_VERSION}]: Installed to $PWD
-            popd
-          fi
 
       - name: Build
         shell: bash
@@ -105,8 +81,6 @@ jobs:
             EVENT_CMAKE_OPTIONS="-DEVENT__DISABLE_OPENSSL=ON"
           elif [ "${{ matrix.EVENT_MATRIX }}" == "NO_SSL" ]; then
             EVENT_CMAKE_OPTIONS="-DEVENT__DISABLE_OPENSSL=ON -DEVENT__DISABLE_MBEDTLS=ON"
-          elif [ "${{ matrix.EVENT_MATRIX }}" == "OPENSSL_3" ]; then
-            EVENT_CMAKE_OPTIONS="-DOPENSSL_ROOT_DIR=/tmp/openssl-3/install -DOPENSSL_USE_STATIC_LIBS=TRUE"
           elif [ "${{ matrix.EVENT_MATRIX }}" == "DISABLE_THREAD_SUPPORT" ]; then
             EVENT_CMAKE_OPTIONS="-DEVENT__DISABLE_THREAD_SUPPORT=ON"
           elif [ "${{ matrix.EVENT_MATRIX }}" == "DISABLE_DEBUG_MODE" ]; then
@@ -184,11 +158,13 @@ jobs:
           - NONE
           - NO_SSL
           - DISABLE_OPENSSL
-          - OPENSSL_3
           - DISABLE_THREAD_SUPPORT
           - DISABLE_DEBUG_MODE
           - DISABLE_MM_REPLACEMENT
           - COMPILER_CLANG
+        include:
+          - os: ubuntu-22.04
+            EVENT_MATRIX: OPENSSL_3
 
     steps:
       - uses: actions/checkout@v2.0.0
@@ -208,32 +184,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libmbedtls-dev
 
-          if [ "${{ matrix.EVENT_MATRIX }}" == "OPENSSL_3" ]; then
-            OPENSSL_VERSION=3.0.3
-            JOBS=20
-
-            echo [openssl-${OPENSSL_VERSION}]: Downloading
-            wget "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"
-
-            echo [openssl-${OPENSSL_VERSION}]: Extracting
-            tar xzf "openssl-${OPENSSL_VERSION}.tar.gz"
-            rm "openssl-${OPENSSL_VERSION}.tar.gz"
-            mv "openssl-${OPENSSL_VERSION}" /tmp/openssl-3
-
-            echo [openssl-${OPENSSL_VERSION}]: Building
-            pushd /tmp/openssl-3
-            ./Configure --prefix=$PWD/install
-            make -j ${JOBS}
-            make install
-            cd install
-            if [ ! -d lib ]; then
-              ln -s lib64 lib
-            fi
-
-            echo [openssl-${OPENSSL_VERSION}]: Installed to $PWD
-            popd
-          fi
-
       - name: Build
         shell: bash
         run: |
@@ -242,9 +192,6 @@ jobs:
 
           elif [ "${{ matrix.EVENT_MATRIX }}" == "NO_SSL" ]; then
             EVENT_CONFIGURE_OPTIONS="--disable-openssl --disable-mbedtls"
-
-          elif [ "${{ matrix.EVENT_MATRIX }}" == "OPENSSL_3" ]; then
-            export PKG_CONFIG_PATH=/tmp/openssl-3/install/lib/pkgconfig
 
           elif [ "${{ matrix.EVENT_MATRIX }}" == "DISABLE_THREAD_SUPPORT" ]; then
             EVENT_CONFIGURE_OPTIONS="--disable-thread-support"
@@ -289,10 +236,7 @@ jobs:
             cd dist
             archive=$(echo *.tar.gz)
             cd $(basename $archive .tar.gz)
-          elif [ "${{ matrix.EVENT_MATRIX }}" == "OPENSSL_3" ]; then
-            export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/tmp/openssl-3/install/lib
           fi
-
           cd build
           make -j $JOBS verify
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -289,7 +289,10 @@ jobs:
             cd dist
             archive=$(echo *.tar.gz)
             cd $(basename $archive .tar.gz)
+          elif [ "${{ matrix.EVENT_MATRIX }}" == "OPENSSL_3" ]; then
+            export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/tmp/openssl-3/install/lib
           fi
+
           cd build
           make -j $JOBS verify
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,6 +31,7 @@ jobs:
           - NONE
           - NO_SSL
           - DISABLE_OPENSSL
+          - OPENSSL_3
           - DISABLE_THREAD_SUPPORT
           - DISABLE_DEBUG_MODE
           - DISABLE_MM_REPLACEMENT
@@ -59,6 +60,32 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libmbedtls-dev
 
+          if [ "${{ matrix.EVENT_MATRIX }}" == "OPENSSL_3" ]; then
+            OPENSSL_VERSION=3.0.3
+            JOBS=20
+
+            echo [openssl-${OPENSSL_VERSION}]: Downloading
+            wget "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"
+
+            echo [openssl-${OPENSSL_VERSION}]: Extracting
+            tar xzf "openssl-${OPENSSL_VERSION}.tar.gz"
+            rm "openssl-${OPENSSL_VERSION}.tar.gz"
+            mv "openssl-${OPENSSL_VERSION}" /tmp/openssl-3
+
+            echo [openssl-${OPENSSL_VERSION}]: Building
+            pushd /tmp/openssl-3
+            ./Configure --prefix=$PWD/install
+            make -j ${JOBS}
+            make install
+            cd install
+            if [ ! -d lib ]; then
+              ln -s lib64 lib
+            fi
+
+            echo [openssl-${OPENSSL_VERSION}]: Installed to $PWD
+            popd
+          fi
+
       - name: Build
         shell: bash
         run: |
@@ -78,6 +105,8 @@ jobs:
             EVENT_CMAKE_OPTIONS="-DEVENT__DISABLE_OPENSSL=ON"
           elif [ "${{ matrix.EVENT_MATRIX }}" == "NO_SSL" ]; then
             EVENT_CMAKE_OPTIONS="-DEVENT__DISABLE_OPENSSL=ON -DEVENT__DISABLE_MBEDTLS=ON"
+          elif [ "${{ matrix.EVENT_MATRIX }}" == "OPENSSL_3" ]; then
+            EVENT_CMAKE_OPTIONS="-DOPENSSL_ROOT_DIR=/tmp/openssl-3/install -DOPENSSL_USE_STATIC_LIBS=TRUE"
           elif [ "${{ matrix.EVENT_MATRIX }}" == "DISABLE_THREAD_SUPPORT" ]; then
             EVENT_CMAKE_OPTIONS="-DEVENT__DISABLE_THREAD_SUPPORT=ON"
           elif [ "${{ matrix.EVENT_MATRIX }}" == "DISABLE_DEBUG_MODE" ]; then
@@ -155,6 +184,7 @@ jobs:
           - NONE
           - NO_SSL
           - DISABLE_OPENSSL
+          - OPENSSL_3
           - DISABLE_THREAD_SUPPORT
           - DISABLE_DEBUG_MODE
           - DISABLE_MM_REPLACEMENT
@@ -178,6 +208,32 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libmbedtls-dev
 
+          if [ "${{ matrix.EVENT_MATRIX }}" == "OPENSSL_3" ]; then
+            OPENSSL_VERSION=3.0.3
+            JOBS=20
+
+            echo [openssl-${OPENSSL_VERSION}]: Downloading
+            wget "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"
+
+            echo [openssl-${OPENSSL_VERSION}]: Extracting
+            tar xzf "openssl-${OPENSSL_VERSION}.tar.gz"
+            rm "openssl-${OPENSSL_VERSION}.tar.gz"
+            mv "openssl-${OPENSSL_VERSION}" /tmp/openssl-3
+
+            echo [openssl-${OPENSSL_VERSION}]: Building
+            pushd /tmp/openssl-3
+            ./Configure --prefix=$PWD/install
+            make -j ${JOBS}
+            make install
+            cd install
+            if [ ! -d lib ]; then
+              ln -s lib64 lib
+            fi
+
+            echo [openssl-${OPENSSL_VERSION}]: Installed to $PWD
+            popd
+          fi
+
       - name: Build
         shell: bash
         run: |
@@ -186,6 +242,9 @@ jobs:
 
           elif [ "${{ matrix.EVENT_MATRIX }}" == "NO_SSL" ]; then
             EVENT_CONFIGURE_OPTIONS="--disable-openssl --disable-mbedtls"
+
+          elif [ "${{ matrix.EVENT_MATRIX }}" == "OPENSSL_3" ]; then
+            export PKG_CONFIG_PATH=/tmp/openssl-3/install/lib/pkgconfig
 
           elif [ "${{ matrix.EVENT_MATRIX }}" == "DISABLE_THREAD_SUPPORT" ]; then
             EVENT_CONFIGURE_OPTIONS="--disable-thread-support"

--- a/bufferevent_openssl.c
+++ b/bufferevent_openssl.c
@@ -259,7 +259,9 @@ conn_closed(struct bufferevent_ssl *bev_ssl, int when, int errcode, int ret)
 		bufferevent_ssl_put_error(bev_ssl, errcode);
 		break;
 	case SSL_ERROR_SSL:
-		/* Protocol error. */
+		/* Protocol error; possibly a dirty shutdown. */
+		if (ret == 0 && SSL_is_init_finished(bev_ssl->ssl) == 0)
+			dirty_shutdown = 1;
 		bufferevent_ssl_put_error(bev_ssl, errcode);
 		break;
 	case SSL_ERROR_WANT_X509_LOOKUP:

--- a/bufferevent_openssl.c
+++ b/bufferevent_openssl.c
@@ -477,7 +477,7 @@ bufferevent_openssl_socket_new(struct event_base *base,
 			   This is probably an error on our part.  Fail. */
 			goto err;
 		}
-		BIO_set_close(bio, 0);
+		(void)BIO_set_close(bio, 0);
 	} else {
 		/* The SSL isn't configured with a BIO with an fd. */
 		if (fd >= 0) {

--- a/m4/libevent_openssl.m4
+++ b/m4/libevent_openssl.m4
@@ -76,6 +76,8 @@ case "$enable_openssl" in
 	done
 	;;
     esac
+    AC_MSG_NOTICE([OPENSSL_LIBS is $OPENSSL_LIBS])
+    AC_MSG_NOTICE([OPENSSL_INCS is $OPENSSL_INCS])
     CPPFLAGS_SAVE=$CPPFLAGS
     CPPFLAGS="$CPPFLAGS $OPENSSL_INCS"
     AC_CHECK_HEADERS([openssl/ssl.h], [], [have_openssl=no])

--- a/sample/becat.c
+++ b/sample/becat.c
@@ -188,6 +188,10 @@ static void ssl_ctx_free(struct ssl_context *ssl)
 static int ssl_load_key(struct ssl_context *ssl)
 {
 	int err = 1;
+#if OPENSSL_VERSION_MAJOR >= 3
+	ssl->pkey = EVP_RSA_gen(4096);
+	err = ssl->pkey == NULL;
+#else
 	BIGNUM *bn;
 	RSA *key;
 
@@ -205,6 +209,7 @@ static int ssl_load_key(struct ssl_context *ssl)
 	err = 0;
 err:
 	BN_free(bn);
+#endif
 	return err;
 }
 static int ssl_load_cert(struct ssl_context *ssl)
@@ -386,8 +391,12 @@ static void be_ssl_errors(struct bufferevent *bev)
 	while ((err = bufferevent_get_openssl_error(bev))) {
 		const char *msg = ERR_reason_error_string(err);
 		const char *lib = ERR_lib_error_string(err);
+#if OPENSSL_VERSION_MAJOR >= 3
+		error("ssl/err=%d/%s in %s\n", err, msg, lib);
+#else
 		const char *func = ERR_func_error_string(err);
 		error("ssl/err=%d/%s in %s %s\n", err, msg, lib, func);
+#endif
 	}
 }
 static int event_cb_(struct bufferevent *bev, short what, int ssl, int stop)

--- a/sample/becat.c
+++ b/sample/becat.c
@@ -188,7 +188,7 @@ static void ssl_ctx_free(struct ssl_context *ssl)
 static int ssl_load_key(struct ssl_context *ssl)
 {
 	int err = 1;
-#if OPENSSL_VERSION_MAJOR >= 3
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
 	ssl->pkey = EVP_RSA_gen(4096);
 	err = ssl->pkey == NULL;
 #else
@@ -391,7 +391,7 @@ static void be_ssl_errors(struct bufferevent *bev)
 	while ((err = bufferevent_get_openssl_error(bev))) {
 		const char *msg = ERR_reason_error_string(err);
 		const char *lib = ERR_lib_error_string(err);
-#if OPENSSL_VERSION_MAJOR >= 3
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
 		error("ssl/err=%d/%s in %s\n", err, msg, lib);
 #else
 		const char *func = ERR_func_error_string(err);

--- a/sample/le-proxy.c
+++ b/sample/le-proxy.c
@@ -113,10 +113,15 @@ eventcb(struct bufferevent *bev, short what, void *ctx)
 				    ERR_reason_error_string(err);
 				const char *lib = (const char*)
 				    ERR_lib_error_string(err);
+#if OPENSSL_VERSION_MAJOR >= 3
+				fprintf(stderr,
+					"%s in %s\n", msg, lib);
+#else
 				const char *func = (const char*)
 				    ERR_func_error_string(err);
 				fprintf(stderr,
 				    "%s in %s %s\n", msg, lib, func);
+#endif
 			}
 			if (errno)
 				perror("connection error");

--- a/sample/le-proxy.c
+++ b/sample/le-proxy.c
@@ -113,7 +113,7 @@ eventcb(struct bufferevent *bev, short what, void *ctx)
 				    ERR_reason_error_string(err);
 				const char *lib = (const char*)
 				    ERR_lib_error_string(err);
-#if OPENSSL_VERSION_MAJOR >= 3
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
 				fprintf(stderr,
 					"%s in %s\n", msg, lib);
 #else

--- a/test/regress_mbedtls.c
+++ b/test/regress_mbedtls.c
@@ -46,7 +46,9 @@
 
 #define get_ssl_ctx get_mbedtls_config
 
+/* FIXME: clean this up, add some prefix, i.e. le_ssl_ */
 #define SSL_renegotiate mbedtls_ssl_renegotiate
+#undef SSL_get_peer_certificate
 #define SSL_get_peer_certificate mbedtls_ssl_get_peer_cert
 #define SSL_get1_peer_certificate mbedtls_ssl_get_peer_cert
 #define SSL_new mbedtls_ssl_new

--- a/test/regress_mbedtls.c
+++ b/test/regress_mbedtls.c
@@ -48,6 +48,7 @@
 
 #define SSL_renegotiate mbedtls_ssl_renegotiate
 #define SSL_get_peer_certificate mbedtls_ssl_get_peer_cert
+#define SSL_get1_peer_certificate mbedtls_ssl_get_peer_cert
 #define SSL_new mbedtls_ssl_new
 #define SSL_use_certificate(a, b) \
 	do {                          \

--- a/test/regress_ssl.c
+++ b/test/regress_ssl.c
@@ -224,7 +224,7 @@ eventcb(struct bufferevent *bev, short what, void *ctx)
 		++n_connected;
 		ssl = bufferevent_ssl_get_ssl(bev);
 		tt_assert(ssl);
-#if OPENSSL_VERSION_MAJOR >= 3
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
 		/* SSL_get1_peer_certificate() means we want
 		 * to increase the reference count on the cert
 		 * and so we will need to free it ourselves later

--- a/test/regress_ssl.c
+++ b/test/regress_ssl.c
@@ -224,7 +224,16 @@ eventcb(struct bufferevent *bev, short what, void *ctx)
 		++n_connected;
 		ssl = bufferevent_ssl_get_ssl(bev);
 		tt_assert(ssl);
+#if OPENSSL_VERSION_MAJOR >= 3
+		/* SSL_get1_peer_certificate() means we want
+		 * to increase the reference count on the cert
+		 * and so we will need to free it ourselves later
+		 * when we're done with it. The non-reference count
+		 * increasing version is not available in OpenSSL 1.1.1. */
+		peer_cert = SSL_get1_peer_certificate(ssl);
+#else
 		peer_cert = SSL_get_peer_certificate(ssl);
+#endif
 		if (type & REGRESS_OPENSSL_SERVER) {
 			tt_assert(peer_cert == NULL);
 		} else {


### PR DESCRIPTION
* Don't use deprecated functions when building against OpenSSL 3.0.
* Recognise that OpenSSL 3.0 can signal a dirty shutdown as a protocol error in addition to the expected IO error produced by OpenSSL 1.1.1.
* Add missing strndup function on Windows to make https-client sample build on Windows with MSVC 2022.

This fixes #1212 and #1233 in my testing on Ubuntu 20.04 WSL with GCC 9 and on Windows 11 with MSVC 2022, both using the latest commit [`8547cd6790881cbba0f20aa4ce048243065a24bf` from the master branch of OpenSSL](https://github.com/openssl/openssl/tree/8547cd6790881cbba0f20aa4ce048243065a24bf)

Fixes: #1212 
Fixes: #1233 
Fixes: #1250 