### PR TITLE
build: only try and silence warning options if they exist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,13 +313,13 @@ if (${GNUC})
          -Wlogical-op
 
          -Wwrite-strings
-
-         # we use this hack in tests
-         -Wno-void-pointer-to-enum-cast
     )
 
     if (${CLANG})
-        list(APPEND __FLAGS -Wno-unused-function)
+        list(APPEND __FLAGS
+            -Wno-unused-function
+            # we use this hack in tests
+            -Wno-void-pointer-to-enum-cast)
     endif()
 
     if (EVENT__DISABLE_GCC_WARNINGS)

--- a/configure.ac
+++ b/configure.ac
@@ -767,8 +767,8 @@ if test "$enable_gcc_warnings" != "no" && test "$GCC" = "yes"; then
   fi
 
   dnl Disable warnings for unused parameters
-  AX_CHECK_COMPILE_FLAG([-Wno-unused-parameter], [CFLAGS="$CFLAGS -Wno-unused-parameter"],[],[-Werror])
-  AX_CHECK_COMPILE_FLAG([-Wno-void-pointer-to-enum-cast], [CFLAGS="$CFLAGS -Wno-void-pointer-to-enum-cast"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Wunused-parameter], [CFLAGS="$CFLAGS -Wno-unused-parameter"],[],[-Werror])
+  AX_CHECK_COMPILE_FLAG([-Wvoid-pointer-to-enum-cast], [CFLAGS="$CFLAGS -Wno-void-pointer-to-enum-cast"],[],[-Werror])
 
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [
   #if !defined(__clang__)


### PR DESCRIPTION
Otherwise GCC will warn. i.e:
```bash
  CCLD     libevent_openssl.la
cc1: note: unrecognized command-line option ‘-Wno-void-pointer-to-enum-cast’
	may have been intended to silence earlier diagnostics
  CCLD     libevent_mbedtls.la
```

[`-Wvoid-pointer-to-enum-cast`](https://clang.llvm.org/docs/DiagnosticsReference.html#wvoid-pointer-to-enum-cast) is only a Clang warning option.