### PR TITLE
Fix some OpenSSL 3 test issues. 

### DIFF
--- a/test/regress_openssl.c
+++ b/test/regress_openssl.c
@@ -103,7 +103,7 @@ ssl_getcert(EVP_PKEY *key)
 	now += 3600;
 	X509_time_adj(X509_getm_notAfter(x509), 0, &now);
 	X509_set_pubkey(x509, key);
-	tt_assert(0 != X509_sign(x509, key, EVP_sha1()));
+	tt_assert(0 != X509_sign(x509, key, EVP_sha256()));
 
 	return x509;
 end:

--- a/test/regress_openssl.c
+++ b/test/regress_openssl.c
@@ -122,12 +122,26 @@ get_ssl_ctx(void)
 	the_ssl_ctx = SSL_CTX_new(SSLv23_method());
 	if (!the_ssl_ctx)
 		return NULL;
+
+#ifdef SSL_OP_ALLOW_CLIENT_RENEGOTIATION
+	/*
+	 * OpenSSL 3 disables client renegotiation by default. Enable it if
+	 * the option is defined.
+	 */
+	SSL_CTX_set_options(the_ssl_ctx, SSL_OP_ALLOW_CLIENT_RENEGOTIATION);
+#endif
+
 	if (disable_tls_11_and_12) {
 #ifdef SSL_OP_NO_TLSv1_2
 		SSL_CTX_set_options(the_ssl_ctx, SSL_OP_NO_TLSv1_2);
 #endif
 #ifdef SSL_OP_NO_TLSv1_1
 		SSL_CTX_set_options(the_ssl_ctx, SSL_OP_NO_TLSv1_1);
+#endif
+	}
+	if (disable_tls_13) {
+#ifdef SSL_OP_NO_TLSv1_3
+		SSL_CTX_set_options(the_ssl_ctx, SSL_OP_NO_TLSv1_3);
 #endif
 	}
 	return the_ssl_ctx;
@@ -163,7 +177,7 @@ ssl_test_setup(const struct testcase_t *testcase)
 	the_cert = ssl_getcert(the_key);
 	EVUTIL_ASSERT(the_cert);
 
-	disable_tls_11_and_12 = 0;
+	disable_tls_11_and_12 = disable_tls_13 = 0;
 
 	return basic_test_setup(testcase);
 }

--- a/test/regress_ssl.c
+++ b/test/regress_ssl.c
@@ -93,6 +93,7 @@ static const char KEY[] =
     "-----END RSA PRIVATE KEY-----\n";
 
 static int disable_tls_11_and_12 = 0;
+static int disable_tls_13 = 0;
 static int test_is_done;
 static int n_connected;
 static int got_close;
@@ -323,6 +324,12 @@ regress_bufferevent_openssl(void *arg)
 	type = (enum regress_openssl_type)data->setup_data;
 
 	if (type & REGRESS_OPENSSL_RENEGOTIATE) {
+		/*
+		 * Disable TLS 1.3, so we negotiate something older to test
+		 * renegotiation - renegotiation is not supported by the
+		 * protocol any more.
+		 */
+		disable_tls_13 = 1;
 		if (OPENSSL_VERSION_NUMBER >= 0x10001000 &&
 		    OPENSSL_VERSION_NUMBER <  0x1000104f) {
 			/* 1.0.1 up to 1.0.1c has a bug where TLS1.1 and 1.2


### PR DESCRIPTION
These are updates to help with OpenSSL 3 compilation. I found https://github.com/libevent/libevent/pull/1288 after I started this, but these seem independent, and fix a different set of problems:


First off, OpenSSL 3 does not by default allow signing with SHA1 digests - moving this to SHA256 universally at this point seems a better idea than continuing to use the insecure SHA1 for older OpenSSL versions. This fixes X509_sign failing in regress_openssl for a number of tests, eg:

```
 regress: http/https_openssl_basic:                                                                                    
  FAIL ../test/regress_openssl.c:106: assert(0 != X509_sign(x509, key, EVP_sha1()))[Lost connection!] http/https_openssl_filter_basic: 
  FAIL ../test/regress_openssl.c:106: assert(0 != X509_sign(x509, key, EVP_sha1()))[Lost connection!] http/https_openssl_simple: 
...
```

Secondly, when using TLS 1.3, there's no support for renegotiation, so for the renegotiation tests, we need to disable TLS v1.3, and expect to negotiate TLS 1.1 or 1.2

Fixes: #661
