### PR TITLE
add connected callback on http module

### DIFF
--- a/http-internal.h
+++ b/http-internal.h
@@ -184,6 +184,8 @@ struct evhttp {
 	int (*errorcb)(struct evhttp_request *, struct evbuffer *, int, const char *, void *);
 	void *errorcbarg;
 
+	void (*conncb)(struct evhttp_connection *);
+
 	struct event_base *base;
 
 	evhttp_ext_method_cb ext_method_cmp;

--- a/http.c
+++ b/http.c
@@ -1667,6 +1667,9 @@ evhttp_error_cb(struct bufferevent *bufev, short what, void *arg)
 
 		evhttp_connection_fail_(evcon, EVREQ_HTTP_EOF);
 	} else if (what == BEV_EVENT_CONNECTED) {
+		if (http->conncb != NULL) {
+			(*http->conncb)(evcon);
+		}
 	} else {
 		evhttp_connection_fail_(evcon, EVREQ_HTTP_BUFFER_ERROR);
 	}
@@ -5548,4 +5551,9 @@ evhttp_uri_set_fragment(struct evhttp_uri *uri, const char *fragment)
 		return -1;
 	URI_SET_STR_(fragment);
 	return 0;
+}
+
+void evhttp_set_conncb(struct evhttp *http, void(*cb)(struct evhttp_connection *))
+{
+	http->conncb = cb;
 }

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -1454,6 +1454,19 @@ void evhttp_uri_free(struct evhttp_uri *uri);
 EVENT2_EXPORT_SYMBOL
 char *evhttp_uri_join(struct evhttp_uri *uri, char *buf, size_t limit);
 
+/**
+   Set a callback used to notify connected connection
+
+   You can use this to override the default read write event callback 
+   -- for example, to make this evconn sharing by other protocol(http2) 
+
+   @param http the evhttp server object for which to set the callback
+   @param cb the callback to invoke for incoming connections
+   @param arg an context argument for the callback
+ */
+EVENT2_EXPORT_SYMBOL
+void evhttp_set_conncb(struct evhttp *http, void(*cb)(struct evhttp_connection *));
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Our project has been using the libevent library, and recently the project has a requirement to add support for HTTP2. The initial scheme reuses the http module in libevent to implement the HTTP2 protocol (the nghttp2 library is additionally used). The nghttp2 library needs to do some initialization after the https handshake is successful, but we checked the http module source code in the libevent library. There is no such callback If you can add this interface, this will be very useful: 1. You can reuse the http1.0 code in the http module, 2. Based on the first point, http1 & http2 share the same http module, which makes development more convenient , I hope to accept it, thank you