### PR TITLE
https-client: fix strndup() for mingw build

### DIFF
--- a/sample/https-client.c
+++ b/sample/https-client.c
@@ -247,8 +247,9 @@ add_cert_for_store(X509_STORE *store, const char *name)
 }
 #endif
 
-#if defined(_WIN32) && !defined(__MINGW32__)
-char* strndup(const char* src, size_t chars) {
+#if defined(_WIN32)
+static char* strndup(const char* src, size_t chars)
+{
 	char* buffer = (char*) malloc(chars + 1);
 	if (buffer) {
 		strncpy(buffer, src, chars);


### PR DESCRIPTION
Right now it still reports [1]:

    2022-07-09T10:53:05.4152800Z ../sample/https-client.c:558:43: warning: implicit declaration of function 'strndup' [-Wimplicit-function-declaration]
    2022-07-09T10:53:05.4153300Z   558 |                         char *host_ipv6 = strndup(&host[1], strlen(&host[1]) - 1);
    2022-07-09T10:53:05.4153651Z       |                                           ^~~~~~~
    2022-07-09T10:53:05.4154095Z ../sample/https-client.c:558:43: warning: incompatible implicit declaration of built-in function 'strndup' [-Wbuiltin-declaration-

  [1]: https://github.com/libevent/libevent/runs/7263194178?check_suite_focus=true