### PR TITLE
Initial Mbed-TLS 3 support to get the GitHub Actions working again

### DIFF
--- a/bufferevent_mbedtls.c
+++ b/bufferevent_mbedtls.c
@@ -24,8 +24,15 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+
+/* Mbed-TLS 3.x does not currently expose a function to retrieve
+   the bio parameters from the SSL object. When the above issue has been
+   fixed, remove the MBEDTLS_ALLOW_PRIVATE_ACCESS define and use the
+   appropriate getter function in bufferevent_mbedtls_socket_new rather than
+   accessing the struct fields directly. */
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
 #include "mbedtls-compat.h"
-#include <mbedtls/config.h>
+#include <mbedtls/version.h>
 #include <mbedtls/ssl.h>
 #include <mbedtls/error.h>
 

--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -75,16 +75,29 @@ find_path(MBEDTLS_INCLUDE_DIR
           ${_EXTRA_FIND_ARGS})
 
 # based on https://github.com/ARMmbed/mbedtls/issues/298
-if(MBEDTLS_INCLUDE_DIR AND EXISTS "${MBEDTLS_INCLUDE_DIR}/mbedtls/version.h")
-    file(STRINGS "${MBEDTLS_INCLUDE_DIR}/mbedtls/version.h" VERSION_STRING_LINE REGEX "^#define MBEDTLS_VERSION_STRING[ \\t\\n\\r]+\"[^\"]*\"$")
-    file(STRINGS "${MBEDTLS_INCLUDE_DIR}/mbedtls/version.h" VERSION_MAJOR_LINE REGEX "^#define MBEDTLS_VERSION_MAJOR[ \\t\\n\\r]+[0-9]+$")
-    file(STRINGS "${MBEDTLS_INCLUDE_DIR}/mbedtls/version.h" VERSION_MINOR_LINE REGEX "^#define MBEDTLS_VERSION_MINOR[ \\t\\n\\r]+[0-9]+$")
-    file(STRINGS "${MBEDTLS_INCLUDE_DIR}/mbedtls/version.h" VERSION_PATCH_LINE REGEX "^#define MBEDTLS_VERSION_PATCH[ \\t\\n\\r]+[0-9]+$")
+function(mbedtls_get_version_numbers FILE)
+    file(STRINGS "${MBEDTLS_INCLUDE_DIR}/${FILE}" VERSION_STRING_LINE REGEX "^#define MBEDTLS_VERSION_STRING[ \\t\\n\\r]+\"[^\"]*\"$")
+    file(STRINGS "${MBEDTLS_INCLUDE_DIR}/${FILE}" VERSION_MAJOR_LINE REGEX "^#define MBEDTLS_VERSION_MAJOR[ \\t\\n\\r]+[0-9]+$")
+    file(STRINGS "${MBEDTLS_INCLUDE_DIR}/${FILE}" VERSION_MINOR_LINE REGEX "^#define MBEDTLS_VERSION_MINOR[ \\t\\n\\r]+[0-9]+$")
+    file(STRINGS "${MBEDTLS_INCLUDE_DIR}/${FILE}" VERSION_PATCH_LINE REGEX "^#define MBEDTLS_VERSION_PATCH[ \\t\\n\\r]+[0-9]+$")
 
     string(REGEX REPLACE "^#define MBEDTLS_VERSION_STRING[ \\t\\n\\r]+\"([^\"]*)\"$" "\\1" MBEDTLS_VERSION "${VERSION_STRING_LINE}")
     string(REGEX REPLACE "^#define MBEDTLS_VERSION_MAJOR[ \\t\\n\\r]+([0-9]+)$" "\\1" MBEDTLS_VERSION_MAJOR "${VERSION_MAJOR_LINE}")
     string(REGEX REPLACE "^#define MBEDTLS_VERSION_MINOR[ \\t\\n\\r]+([0-9]+)$" "\\1" MBEDTLS_VERSION_MINOR "${VERSION_MINOR_LINE}")
     string(REGEX REPLACE "^#define MBEDTLS_VERSION_PATCH[ \\t\\n\\r]+([0-9]+)$" "\\1" MBEDTLS_VERSION_PATCH "${VERSION_PATCH_LINE}")
+
+    set(MBEDTLS_VERSION "${MBEDTLS_VERSION}" PARENT_SCOPE)
+    set(MBEDTLS_VERSION_MAJOR "${MBEDTLS_VERSION_MAJOR}" PARENT_SCOPE)
+    set(MBEDTLS_VERSION_MINOR "${MBEDTLS_VERSION_MINOR}" PARENT_SCOPE)
+    set(MBEDTLS_VERSION_PATCH "${MBEDTLS_VERSION_PATCH}" PARENT_SCOPE)
+endfunction()
+
+if(MBEDTLS_INCLUDE_DIR AND EXISTS "${MBEDTLS_INCLUDE_DIR}/mbedtls/version.h")
+    mbedtls_get_version_numbers("mbedtls/version.h")
+
+    if ("${MBEDTLS_VERSION}" STREQUAL "")
+        mbedtls_get_version_numbers("mbedtls/build_info.h")
+    endif()
 endif()
 
 

--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -98,21 +98,23 @@ else()
     set(_MBEDTLS_X509_LIB_NAME mbedx509)
 endif()
 
+# lib - standard path suffix
+# library - is the suffix that is used in build tree
 find_library(MBEDTLS_LIBRARY
              NAMES ${_MBEDTLS_LIB_NAME}
-             PATH_SUFFIXES lib
+             PATH_SUFFIXES lib library
              HINTS ${MBEDTLS_ROOT_DIR}
              ${_EXTRA_FIND_ARGS})
 
 find_library(MBEDTLS_CRYPTO_LIBRARY
              NAMES ${_MBEDTLS_CRYPTO_LIB_NAME}
-             PATH_SUFFIXES lib
+             PATH_SUFFIXES lib library
              HINTS ${MBEDTLS_ROOT_DIR}
              ${_EXTRA_FIND_ARGS})
 
 find_library(MBEDTLS_X509_LIBRARY
              NAMES ${_MBEDTLS_X509_LIB_NAME}
-             PATH_SUFFIXES lib
+             PATH_SUFFIXES lib library
              HINTS ${MBEDTLS_ROOT_DIR}
              ${_EXTRA_FIND_ARGS})
 

--- a/mbedtls-compat.h
+++ b/mbedtls-compat.h
@@ -2,10 +2,29 @@
 #define MBEDTLS_COMPAT_H
 
 #include <mbedtls/version.h>
+
+#if MBEDTLS_VERSION_MAJOR >= 3
+# if defined(__clang__)
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wcpp"
+# elif defined(__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wcpp"
+# endif
+
+# include <mbedtls/compat-2.x.h>
+
+# if defined(__clang__)
+#  pragma clang diagnostic pop
+# elif defined(__GNUC__)
+#  pragma GCC diagnostic pop
+# endif
+#endif // MBEDTLS_VERSION_MAJOR >= 3
+
 #if MBEDTLS_VERSION_MAJOR < 2 || (MBEDTLS_VERSION_MAJOR == 2 && MBEDTLS_VERSION_MINOR < 4)
-#include <mbedtls/net.h>
+# include <mbedtls/net.h>
 #else
-#include <mbedtls/net_sockets.h>
+# include <mbedtls/net_sockets.h>
 #endif
 
 #endif // LIBEVENT_MBEDTLS_COMPAT_H

--- a/sample/ssl-client-mbedtls.c
+++ b/sample/ssl-client-mbedtls.c
@@ -70,7 +70,7 @@ readcb(struct bufferevent *bev, void *arg)
 		fprintf(stderr, "readcb %zu\n\n", r);
 		if (r > 1) {
 			fwrite(buf, 1, r, stdout);
-			fwrite("\n", 1, r, stdout);
+			fwrite("\n", 1, 1, stdout);
 			fflush(stdout);
 		}
 	}

--- a/sample/ssl-client-mbedtls.c
+++ b/sample/ssl-client-mbedtls.c
@@ -72,6 +72,9 @@ readcb(struct bufferevent *bev, void *arg)
 			fwrite(buf, 1, r, stdout);
 			fwrite("\n", 1, 1, stdout);
 			fflush(stdout);
+		} else {
+			event_base_loopbreak(bufferevent_get_base(bev));
+			break;
 		}
 	}
 }

--- a/sample/ssl-client-mbedtls.c
+++ b/sample/ssl-client-mbedtls.c
@@ -19,16 +19,21 @@
  *  This file is part of mbed TLS (https://tls.mbed.org)
  */
 
-#include "mbedtls/config.h"
-#include "mbedtls/platform.h"
+#include <mbedtls/version.h>
+#if MBEDTLS_VERSION_MAJOR >= 3
+#include <mbedtls/build_info.h>
+#else
+#include <mbedtls/config.h>
+#include <mbedtls/certs.h>
+#endif
+#include <mbedtls/platform.h>
 
-#include "mbedtls-compat.h"
-#include "mbedtls/debug.h"
-#include "mbedtls/ssl.h"
-#include "mbedtls/entropy.h"
-#include "mbedtls/ctr_drbg.h"
-#include "mbedtls/error.h"
-#include "mbedtls/certs.h"
+#include <mbedtls-compat.h>
+#include <mbedtls/debug.h>
+#include <mbedtls/ssl.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/error.h>
 
 #include <string.h>
 
@@ -37,6 +42,38 @@
 #include <event2/bufferevent.h>
 #include <event2/bufferevent_ssl.h>
 #include <event2/util.h>
+
+/*
+ * Note about these certificates:
+ * - IS NOT SUITABLE FOR PRODUCTION
+ * - copied from mbedtls/tests/src/certs.c
+ * - are not required, and just as an example
+ */
+#if MBEDTLS_VERSION_MAJOR >= 3
+#define TEST_CA_CRT_RSA_SHA256_PEM                                         \
+    "-----BEGIN CERTIFICATE-----\r\n"                                      \
+    "MIIDQTCCAimgAwIBAgIBAzANBgkqhkiG9w0BAQsFADA7MQswCQYDVQQGEwJOTDER\r\n" \
+    "MA8GA1UECgwIUG9sYXJTU0wxGTAXBgNVBAMMEFBvbGFyU1NMIFRlc3QgQ0EwHhcN\r\n" \
+    "MTkwMjEwMTQ0NDAwWhcNMjkwMjEwMTQ0NDAwWjA7MQswCQYDVQQGEwJOTDERMA8G\r\n" \
+    "A1UECgwIUG9sYXJTU0wxGTAXBgNVBAMMEFBvbGFyU1NMIFRlc3QgQ0EwggEiMA0G\r\n" \
+    "CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDA3zf8F7vglp0/ht6WMn1EpRagzSHx\r\n" \
+    "mdTs6st8GFgIlKXsm8WL3xoemTiZhx57wI053zhdcHgH057Zk+i5clHFzqMwUqny\r\n" \
+    "50BwFMtEonILwuVA+T7lpg6z+exKY8C4KQB0nFc7qKUEkHHxvYPZP9al4jwqj+8n\r\n" \
+    "YMPGn8u67GB9t+aEMr5P+1gmIgNb1LTV+/Xjli5wwOQuvfwu7uJBVcA0Ln0kcmnL\r\n" \
+    "R7EUQIN9Z/SG9jGr8XmksrUuEvmEF/Bibyc+E1ixVA0hmnM3oTDPb5Lc9un8rNsu\r\n" \
+    "KNF+AksjoBXyOGVkCeoMbo4bF6BxyLObyavpw/LPh5aPgAIynplYb6LVAgMBAAGj\r\n" \
+    "UDBOMAwGA1UdEwQFMAMBAf8wHQYDVR0OBBYEFLRa5KWz3tJS9rnVppUP6z68x/3/\r\n" \
+    "MB8GA1UdIwQYMBaAFLRa5KWz3tJS9rnVppUP6z68x/3/MA0GCSqGSIb3DQEBCwUA\r\n" \
+    "A4IBAQA4qFSCth2q22uJIdE4KGHJsJjVEfw2/xn+MkTvCMfxVrvmRvqCtjE4tKDl\r\n" \
+    "oK4MxFOek07oDZwvtAT9ijn1hHftTNS7RH9zd/fxNpfcHnMZXVC4w4DNA1fSANtW\r\n" \
+    "5sY1JB5Je9jScrsLSS+mAjyv0Ow3Hb2Bix8wu7xNNrV5fIf7Ubm+wt6SqEBxu3Kb\r\n" \
+    "+EfObAT4huf3czznhH3C17ed6NSbXwoXfby7stWUDeRJv08RaFOykf/Aae7bY5PL\r\n" \
+    "yTVrkAnikMntJ9YI+hNNYt3inqq11A5cN0+rVTst8UKCxzQ4GpvroSwPKTFkbMw4\r\n" \
+    "/anT1dVxr/BtwJfiESoK3/4CeXR1\r\n"                                     \
+    "-----END CERTIFICATE-----\r\n"
+const char mbedtls_test_cas_pem[] = TEST_CA_CRT_RSA_SHA256_PEM;
+const size_t mbedtls_test_cas_pem_len = sizeof( mbedtls_test_cas_pem );
+#endif
 
 #define SERVER_PORT "443"
 #define SERVER_NAME "amazon.com"


### PR DESCRIPTION
mingw has upgraded to Mbed-TLS 3.1.0, so all the mingw tests that need
Mbed-TLS currently don't work.

v2: add missing mbedtls/version.h into test/regress_mbedtls.c
v3: suppress #warning "Including compat-2.x.h is deprecated" for mbedtls/compat-2.x.h
Extracted from: #1288