### PR TITLE
ci: fix MinGW build with cmake (Exit code 0xc0000135)

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -164,7 +164,8 @@ jobs:
         shell: powershell
         run: |
           cd build
-          ctest --output-on-failure
+          cd bin
+          ./regress
 
       - uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -137,7 +137,9 @@ jobs:
           {
             $errcode=0
             try {
-              cmake .. -G "MSYS Makefiles" $EVENT_CONFIGURE_OPTIONS -DCMAKE_C_FLAGS=-w
+              # NOTE: we use STATIC libraries to force regress use static libraries
+              # to avoid "Exit code 0xc0000135" error.
+              cmake .. -DEVENT__LIBRARY_TYPE=STATIC -G "MSYS Makefiles" $EVENT_CONFIGURE_OPTIONS -DCMAKE_C_FLAGS=-w
               $errcode=$LastExitCode
             }
             catch {

--- a/test/regress_dns.c
+++ b/test/regress_dns.c
@@ -2036,10 +2036,10 @@ end:
 }
 
 static void
-gaic_launch(struct event_base *base, struct evdns_base *dns_base)
+gaic_launch(struct event_base *base, struct evdns_base *dns_base, unsigned i)
 {
 	struct gaic_request_status *status = calloc(1,sizeof(*status));
-	struct timeval tv = { 0, 10000 };
+	struct timeval tv = { 0, i % 2 ? 100000 : 1 };
 	status->magic = GAIC_MAGIC;
 	status->base = base;
 	status->dns_base = dns_base;
@@ -2267,13 +2267,14 @@ test_getaddrinfo_async_cancel_stress(void *ptr)
 	    (struct sockaddr*)&ss, slen, 0);
 
 	for (i = 0; i < 1000; ++i) {
-		gaic_launch(base, dns_base);
+		gaic_launch(base, dns_base, i);
 	}
 
 	event_base_dispatch(base);
 
 	// at least some was canceled via external event
 	tt_int_op(gaic_freed, !=, 1000);
+	tt_int_op(gaic_freed, !=, 0);
 
 end:
 	if (dns_base)


### PR DESCRIPTION
Exit code 0xC0000135 seems that it is STATUS_DLL_NOT_FOUND, and it seems
that it cannot find libevent libraries [1].

  [1]: https://stackoverflow.com/questions/59376924/ctest-cmake-mingw-executables-build-but-fail-to-run-because-fresh-dll-is-n

Fixes: #1207