### PR TITLE
ci: use ubuntu 22.04 with clang 11 for sanitizers build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,12 +46,16 @@ jobs:
           - COMPILER_CLANG
           - TEST_EXPORT_STATIC
           - TEST_EXPORT_SHARED
-          - ASAN
-          - TSAN
-          - UBSAN
         include:
           - os: ubuntu-22.04
             EVENT_MATRIX: OPENSSL_3
+          # use recent ubuntu with recent clang for recent sanitizers
+          - os: ubuntu-22.04
+            EVENT_MATRIX: TSAN
+          - os: ubuntu-22.04
+            EVENT_MATRIX: ASAN
+          - os: ubuntu-22.04
+            EVENT_MATRIX: UBSAN
 
     steps:
       - uses: actions/checkout@v2.0.0

--- a/test/regress_util.c
+++ b/test/regress_util.c
@@ -935,7 +935,7 @@ test_evutil_rand(void *arg)
 	char buf1[32];
 	char buf2[32];
 	int counts[256];
-	int i, j, k, n=0;
+	int i, j, k;
 	struct evutil_weakrand_state seed = { 12346789U };
 
 	memset(buf2, 0, sizeof(buf2));
@@ -956,7 +956,6 @@ test_evutil_rand(void *arg)
 			memset(buf1, 0, sizeof(buf1));
 			evutil_secure_rng_get_bytes(buf1 + startpoint,
 			    endpoint-startpoint);
-			n += endpoint - startpoint;
 			for (j=0; j<32; ++j) {
 				if (j >= startpoint && j < endpoint) {
 					buf2[j] |= buf1[j];
@@ -982,8 +981,6 @@ test_evutil_rand(void *arg)
 		tt_int_op(0, <=, r);
 		tt_int_op(r, <, 9999);
 	}
-
-	/* for (i=0;i<256;++i) { printf("%3d %2d\n", i, counts[i]); } */
 end:
 	;
 }


### PR DESCRIPTION
There are periodically some heap-use-after-free reported in ratelim
tests by TSan, which I cannot reproduce locally and even on CI it is
flaky.

Let's try to use recent clang, maybe it fixes some issues in sanitizers.

Refs: #1206