### PR TITLE
http: allow setting bevcb per socket

### DIFF
--- a/http-internal.h
+++ b/http-internal.h
@@ -128,6 +128,10 @@ TAILQ_HEAD(evconq, evhttp_connection);
 struct evhttp_bound_socket {
 	TAILQ_ENTRY(evhttp_bound_socket) next;
 
+	struct evhttp *http;
+	struct bufferevent* (*bevcb)(struct event_base *, void *);
+	void *bevcbarg;
+
 	struct evconnlistener *listener;
 };
 

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -172,6 +172,14 @@ struct evhttp_bound_socket *evhttp_bind_listener(struct evhttp *http, struct evc
 EVENT2_EXPORT_SYMBOL
 struct evconnlistener *evhttp_bound_socket_get_listener(struct evhttp_bound_socket *bound);
 
+/*
+ * Like evhttp_set_bevcb.
+ * If cb returns a non-NULL bufferevent, * the callback supplied through
+ * evhttp_set_bevcb isn't used.
+ */
+EVENT2_EXPORT_SYMBOL
+void evhttp_bound_set_bevcb(struct evhttp_bound_socket *bound, struct bufferevent* (*cb)(struct event_base *, void *), void *cbarg);
+
 typedef void evhttp_bound_socket_foreach_fn(struct evhttp_bound_socket *, void *);
 /**
  * Applies the function specified in the first argument to all
@@ -333,6 +341,8 @@ void evhttp_set_gencb(struct evhttp *http,
 /**
    Set a callback used to create new bufferevents for connections
    to a given evhttp object.
+   cb is not called if a non-NULL bufferevent was supplied by
+   evhttp_bound_set_bevcb.
 
    You can use this to override the default bufferevent type -- for example,
    to make this evhttp object use SSL bufferevents rather than unencrypted

--- a/test/regress_http.c
+++ b/test/regress_http.c
@@ -4309,6 +4309,93 @@ static void http_simple_test(void *arg)
 static void http_simple_nonconformant_test(void *arg)
 { http_simple_test_impl(arg, 0, 0, "/test nonconformant"); }
 
+static int
+https_bind_ssl_bevcb(struct evhttp *http, ev_uint16_t port, ev_uint16_t *pport, int mask)
+{
+	int _port;
+	struct evhttp_bound_socket *sock = NULL;
+	sock = evhttp_bind_socket_with_handle(http, "127.0.0.1", port);
+
+#ifdef EVENT__HAVE_OPENSSL
+	if (mask & HTTP_OPENSSL) {
+		init_ssl();
+		evhttp_bound_set_bevcb(sock, https_bev, NULL);
+	}
+#endif
+#ifdef EVENT__HAVE_MBEDTLS
+	if (mask & HTTP_MBEDTLS) {
+		evhttp_bound_set_bevcb(sock, https_mbedtls_bev, NULL);
+	}
+#endif
+
+	_port = regress_get_socket_port(evhttp_bound_socket_get_fd(sock));
+	if (_port < 0)
+		return -1;
+
+	if (pport)
+		*pport = (ev_uint16_t)_port;
+
+	return 0;
+}
+static void
+https_per_socket_bevcb_impl(void *arg, ev_uint16_t http_port, ev_uint16_t https_port, int mask)
+{
+	struct bufferevent *bev;
+	struct basic_test_data *data = arg;
+	struct evhttp_connection *evcon = NULL;
+	struct evhttp *http = NULL;
+	ev_uint16_t new_https_port = 0;
+	struct evhttp_request *req = NULL;
+
+	http = evhttp_new(data->base);
+	tt_assert(http);
+
+	evhttp_bind_socket_with_handle(http, "127.0.0.1", http_port);
+
+	tt_assert(https_bind_ssl_bevcb(http, https_port, &new_https_port, mask) == 0);
+
+	evhttp_set_gencb(http, http_basic_cb, http);
+
+	bev = create_bev(data->base, -1, mask, 0);
+
+#ifdef EVENT__HAVE_OPENSSL
+	bufferevent_openssl_set_allow_dirty_shutdown(bev, 1);
+#endif
+#ifdef EVENT__HAVE_MBEDTLS
+	bufferevent_mbedtls_set_allow_dirty_shutdown(bev, 1);
+#endif
+
+	evcon = evhttp_connection_base_bufferevent_new(data->base, NULL, bev, "127.0.0.1", new_https_port);
+	tt_assert(evcon);
+
+	evhttp_connection_set_timeout(evcon, 1);
+	/* make sure to use the same address that is used by http */
+	evhttp_connection_set_local_address(evcon, "127.0.0.1");
+
+	req = evhttp_request_new(http_request_done, (void *) BASIC_REQUEST_BODY);
+	tt_assert(req);
+
+	evhttp_add_header(evhttp_request_get_output_headers(req), "Host", "somehost");
+
+	if (evhttp_make_request(evcon, req, EVHTTP_REQ_GET, "/test") == -1) {
+		evhttp_request_free(req);
+		TT_GRIPE(("make_request_failed"));
+		goto end;
+	}
+
+	exit_base = data->base;
+	event_base_dispatch(data->base);
+
+end:
+	if (evcon)
+		evhttp_connection_free(evcon);
+
+	if (http)
+		evhttp_free(http);
+}
+static void https_per_socket_bevcb(void *arg, int ssl)
+{ https_per_socket_bevcb_impl(arg, 0, 0, ssl); }
+
 static void
 http_connection_retry_test_basic(void *arg, const char *addr, struct evdns_base *dns_base, int ssl)
 {
@@ -5758,6 +5845,8 @@ static void https_connection_test(void *arg)
 { http_connection_test_(arg, 0, "127.0.0.1", NULL, 0, AF_UNSPEC, HTTP_OPENSSL); }
 static void https_persist_connection_test(void *arg)
 { http_connection_test_(arg, 1, "127.0.0.1", NULL, 0, AF_UNSPEC, HTTP_OPENSSL); }
+static void https_per_socket_bevcb_test(void *arg)
+{ https_per_socket_bevcb_impl(arg, 0, 0, HTTP_OPENSSL); }
 #endif
 
 #ifdef EVENT__HAVE_MBEDTLS
@@ -5791,6 +5880,8 @@ static void https_mbedtls_connection_test(void *arg)
 { http_connection_test_(arg, 0, "127.0.0.1", NULL, 0, AF_UNSPEC, HTTP_MBEDTLS); }
 static void https_mbedtls_persist_connection_test(void *arg)
 { http_connection_test_(arg, 1, "127.0.0.1", NULL, 0, AF_UNSPEC, HTTP_MBEDTLS); }
+static void https_mbedtls_per_socket_bevcb_test(void *arg)
+{ https_per_socket_bevcb_impl(arg, 0, 0, HTTP_MBEDTLS); }
 #endif
 
 struct testcase_t http_testcases[] = {
@@ -5910,6 +6001,7 @@ struct testcase_t http_testcases[] = {
 	HTTPS(write_during_read),
 	HTTPS(connection),
 	HTTPS(persist_connection),
+	HTTPS(per_socket_bevcb),
 #endif
 
 #ifdef EVENT__HAVE_MBEDTLS
@@ -5929,6 +6021,7 @@ struct testcase_t http_testcases[] = {
 	HTTPS_MBEDTLS(write_during_read),
 	HTTPS_MBEDTLS(connection),
 	HTTPS_MBEDTLS(persist_connection),
+	HTTPS_MBEDTLS(per_socket_bevcb),
 #endif
 
 	END_OF_TESTCASES

--- a/test/regress_openssl.c
+++ b/test/regress_openssl.c
@@ -150,6 +150,11 @@ get_ssl_ctx(void)
 void
 init_ssl(void)
 {
+	static int initialized;
+	if (initialized)
+		return;
+	initialized = 1;
+
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L) || \
 	(defined(LIBRESSL_VERSION_NUMBER) &&      \
 		LIBRESSL_VERSION_NUMBER < 0x20700000L)


### PR DESCRIPTION
In it's current form, libevent requires multiple `struct evhttp` objects to be created in order to enable listening on sockets with more than one type of encryption.

This change allows specifying per-socket how the associated bufferevents should be created.
Thus, it becomes possible to have multiple listening sockets with different encryption parameters using only one `evttp`.