### PR TITLE
handle empty answers as EAI_ADDRFAMILY

### DIFF
--- a/bufferevent_sock.c
+++ b/bufferevent_sock.c
@@ -467,9 +467,6 @@ bufferevent_connect_getaddrinfo_cb(int result, struct evutil_addrinfo *ai,
 		bufferevent_decref_and_unlock_(bev);
 		return;
 	}
-	if (!ai) {
-		result = EAI_ADDRFAMILY;
-	}
 	if (result != 0) {
 		bev_p->dns_error = result;
 		bufferevent_run_eventcb_(bev, BEV_EVENT_ERROR, 0);

--- a/bufferevent_sock.c
+++ b/bufferevent_sock.c
@@ -467,6 +467,9 @@ bufferevent_connect_getaddrinfo_cb(int result, struct evutil_addrinfo *ai,
 		bufferevent_decref_and_unlock_(bev);
 		return;
 	}
+	if (!ai) {
+		result = EAI_ADDRFAMILY;
+	}
 	if (result != 0) {
 		bev_p->dns_error = result;
 		bufferevent_run_eventcb_(bev, BEV_EVENT_ERROR, 0);

--- a/evdns.c
+++ b/evdns.c
@@ -5564,8 +5564,9 @@ evdns_getaddrinfo_fromhosts(struct evdns_base *base,
 	EVDNS_UNLOCK(base);
 out:
 	if (n_found) {
-		/* Note that we return an empty answer if we found entries for
-		 * this hostname but none were of the right address type. */
+		if (!ai) {
+			return EVUTIL_EAI_ADDRFAMILY;
+		}
 		*res = ai;
 		return 0;
 	} else {


### PR DESCRIPTION
When dns resolution retrieves answers but not of the requested address family, it passes NULL as the answer. Then `bufferevent_connect_getaddrinfo_cb` crashes. This is documented here: https://github.com/libevent/libevent/blob/99fd68abde4a59b90148db733fc51a7256cbd320/evdns.c#L5567

To address this, this patch returns the error `EAI_ADDRFAMILY` instead.

(I'm not particularly fond of evdns returning empty answers; it's probable that the `EAI_ADDRFAMILY` response should be moved into evdns itself)