### PR TITLE
Fixed CMake configuration failure (libevent#1321)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,8 +178,8 @@ macro(Configure_RPATH)
     # - "///" -> "/"
     # - "/////usr///" -> "//usr"
     # So it should be normalized again.
-    file(REAL_PATH "${CMAKE_INSTALL_PREFIX}" CMAKE_INSTALL_PREFIX_NORMALIZED)
 
+    get_filename_component(CMAKE_INSTALL_PREFIX_NORMALIZED "${CMAKE_INSTALL_PREFIX}" REALPATH)
     list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX_NORMALIZED}/lib" isSystemDir)
 
     if("${isSystemDir}" STREQUAL "-1")


### PR DESCRIPTION
Deleted usage of CMake feature 'file(REAL_PATH'
which is available from version 3.19
with an old 'get_filename_component' so that
older version of CMake can still be used
to configure the project.

Fixes: #1321 