### PR TITLE
Fix non-std printf %p arguments

### DIFF
--- a/bufferevent.c
+++ b/bufferevent.c
@@ -501,7 +501,7 @@ bufferevent_enable(struct bufferevent *bufev, short event)
 	if (impl_events && bufev->be_ops->enable(bufev, impl_events) < 0)
 		r = -1;
 	if (r)
-		event_debug(("%s: cannot enable 0x%hx on %p", __func__, event, bufev));
+		event_debug(("%s: cannot enable 0x%hx on %p", __func__, event, (void *)bufev));
 
 	bufferevent_decref_and_unlock_(bufev);
 	return r;
@@ -585,7 +585,7 @@ bufferevent_disable(struct bufferevent *bufev, short event)
 	if (bufev->be_ops->disable(bufev, event) < 0)
 		r = -1;
 	if (r)
-		event_debug(("%s: cannot disable 0x%hx on %p", __func__, event, bufev));
+		event_debug(("%s: cannot disable 0x%hx on %p", __func__, event, (void *)bufev));
 
 	BEV_UNLOCK(bufev);
 	return r;
@@ -876,7 +876,7 @@ bufferevent_setfd(struct bufferevent *bev, evutil_socket_t fd)
 	if (bev->be_ops->ctrl)
 		res = bev->be_ops->ctrl(bev, BEV_CTRL_SET_FD, &d);
 	if (res)
-		event_debug(("%s: cannot set fd for %p to "EV_SOCK_FMT, __func__, bev, fd));
+		event_debug(("%s: cannot set fd for %p to "EV_SOCK_FMT, __func__, (void *)bev, fd));
 	BEV_UNLOCK(bev);
 	return res;
 }
@@ -903,7 +903,7 @@ bufferevent_replacefd(struct bufferevent *bev, evutil_socket_t fd)
 		}
 	}
 	if (err)
-		event_debug(("%s: cannot replace fd for %p from "EV_SOCK_FMT" to "EV_SOCK_FMT, __func__, bev, old_fd, fd));
+		event_debug(("%s: cannot replace fd for %p from "EV_SOCK_FMT" to "EV_SOCK_FMT, __func__, (void *)bev, old_fd, fd));
 	BEV_UNLOCK(bev);
 
 	return err;
@@ -919,7 +919,7 @@ bufferevent_getfd(struct bufferevent *bev)
 	if (bev->be_ops->ctrl)
 		res = bev->be_ops->ctrl(bev, BEV_CTRL_GET_FD, &d);
 	if (res)
-		event_debug(("%s: cannot get fd for %p", __func__, bev));
+		event_debug(("%s: cannot get fd for %p", __func__, (void *)bev));
 	BEV_UNLOCK(bev);
 	return (res<0) ? -1 : d.fd;
 }

--- a/event.c
+++ b/event.c
@@ -302,7 +302,7 @@ static void event_debug_note_add_(const struct event *ev)
 		    "%s: noting an add on a non-setup event %p"
 		    " (events: 0x%x, fd: "EV_SOCK_FMT
 		    ", flags: 0x%x)",
-		    __func__, ev, ev->ev_events,
+		    __func__, (void *)ev, ev->ev_events,
 		    EV_SOCK_ARG(ev->ev_fd), ev->ev_flags);
 	}
 	EVLOCK_UNLOCK(event_debug_map_lock_, 0);
@@ -328,7 +328,7 @@ static void event_debug_note_del_(const struct event *ev)
 		    "%s: noting a del on a non-setup event %p"
 		    " (events: 0x%x, fd: "EV_SOCK_FMT
 		    ", flags: 0x%x)",
-		    __func__, ev, ev->ev_events,
+		    __func__, (void *)ev, ev->ev_events,
 		    EV_SOCK_ARG(ev->ev_fd), ev->ev_flags);
 	}
 	EVLOCK_UNLOCK(event_debug_map_lock_, 0);
@@ -352,7 +352,7 @@ static void event_debug_assert_is_setup_(const struct event *ev)
 		    "%s called on a non-initialized event %p"
 		    " (events: 0x%x, fd: "EV_SOCK_FMT
 		    ", flags: 0x%x)",
-		    __func__, ev, ev->ev_events,
+		    __func__, (void *)ev, ev->ev_events,
 		    EV_SOCK_ARG(ev->ev_fd), ev->ev_flags);
 	}
 	EVLOCK_UNLOCK(event_debug_map_lock_, 0);
@@ -373,7 +373,7 @@ static void event_debug_assert_not_added_(const struct event *ev)
 		    "%s called on an already added event %p"
 		    " (events: 0x%x, fd: "EV_SOCK_FMT", "
 		    "flags: 0x%x)",
-		    __func__, ev, ev->ev_events,
+		    __func__, (void *)ev, ev->ev_events,
 		    EV_SOCK_ARG(ev->ev_fd), ev->ev_flags);
 	}
 	EVLOCK_UNLOCK(event_debug_map_lock_, 0);
@@ -1673,16 +1673,16 @@ event_process_active_single_queue(struct event_base *base,
 				event_del_nolock_(ev, EVENT_DEL_NOBLOCK);
 			event_debug((
 			    "event_process_active: event: %p, %s%s%scall %p",
-			    ev,
+			    (void *)ev,
 			    ev->ev_res & EV_READ ? "EV_READ " : " ",
 			    ev->ev_res & EV_WRITE ? "EV_WRITE " : " ",
 			    ev->ev_res & EV_CLOSED ? "EV_CLOSED " : " ",
-			    ev->ev_callback));
+			    (void *)ev->ev_callback));
 		} else {
 			event_queue_remove_active(base, evcb);
 			event_debug(("event_process_active: event_callback %p, "
 				"closure %d, call %p",
-				evcb, evcb->evcb_closure, evcb->evcb_cb_union.evcb_callback));
+				(void *)evcb, evcb->evcb_closure, (void *)evcb->evcb_cb_union.evcb_callback));
 		}
 
 		if (!(evcb->evcb_flags & EVLIST_INTERNAL))
@@ -2600,7 +2600,7 @@ event_remove_timer_nolock_(struct event *ev)
 	EVENT_BASE_ASSERT_LOCKED(base);
 	event_debug_assert_is_setup_(ev);
 
-	event_debug(("event_remove_timer_nolock: event: %p", ev));
+	event_debug(("event_remove_timer_nolock: event: %p", (void *)ev));
 
 	/* If it's not pending on a timeout, we don't need to do anything. */
 	if (ev->ev_flags & EVLIST_TIMEOUT) {
@@ -2647,13 +2647,13 @@ event_add_nolock_(struct event *ev, const struct timeval *tv,
 
 	event_debug((
 		 "event_add: event: %p (fd "EV_SOCK_FMT"), %s%s%s%scall %p",
-		 ev,
+		 (void *)ev,
 		 EV_SOCK_ARG(ev->ev_fd),
 		 ev->ev_events & EV_READ ? "EV_READ " : " ",
 		 ev->ev_events & EV_WRITE ? "EV_WRITE " : " ",
 		 ev->ev_events & EV_CLOSED ? "EV_CLOSED " : " ",
 		 tv ? "EV_TIMEOUT " : " ",
-		 ev->ev_callback));
+		 (void *)ev->ev_callback));
 
 	EVUTIL_ASSERT(!(ev->ev_flags & ~EVLIST_ALL));
 
@@ -2767,7 +2767,7 @@ event_add_nolock_(struct event *ev, const struct timeval *tv,
 
 		event_debug((
 			 "event_add: event %p, timeout in %d seconds %d useconds, call %p",
-			 ev, (int)tv->tv_sec, (int)tv->tv_usec, ev->ev_callback));
+			 (void *)ev, (int)tv->tv_sec, (int)tv->tv_usec, (void *)ev->ev_callback));
 
 #ifdef USE_REINSERT_TIMEOUT
 		event_queue_reinsert_timeout(base, ev, was_common, common_timeout, old_timeout_idx);
@@ -2854,7 +2854,7 @@ event_del_nolock_(struct event *ev, int blocking)
 	int res = 0, notify = 0;
 
 	event_debug(("event_del: %p (fd "EV_SOCK_FMT"), callback %p",
-		ev, EV_SOCK_ARG(ev->ev_fd), ev->ev_callback));
+		(void *)ev, EV_SOCK_ARG(ev->ev_fd), (void *)ev->ev_callback));
 
 	/* An event without a base has not been added */
 	if (ev->ev_base == NULL)
@@ -2962,7 +2962,7 @@ event_active_nolock_(struct event *ev, int res, short ncalls)
 	struct event_base *base;
 
 	event_debug(("event_active: %p (fd "EV_SOCK_FMT"), res %d, callback %p",
-		ev, EV_SOCK_ARG(ev->ev_fd), (int)res, ev->ev_callback));
+		(void *)ev, EV_SOCK_ARG(ev->ev_fd), (int)res, (void *)ev->ev_callback));
 
 	base = ev->ev_base;
 	EVENT_BASE_ASSERT_LOCKED(base);
@@ -3211,7 +3211,7 @@ timeout_next(struct event_base *base, struct timeval **tv_p)
 
 	EVUTIL_ASSERT(tv->tv_sec >= 0);
 	EVUTIL_ASSERT(tv->tv_usec >= 0);
-	event_debug(("timeout_next: event: %p, in %d seconds, %d useconds", ev, (int)tv->tv_sec, (int)tv->tv_usec));
+	event_debug(("timeout_next: event: %p, in %d seconds, %d useconds", (void *)ev, (int)tv->tv_sec, (int)tv->tv_usec));
 
 out:
 	return (res);
@@ -3239,7 +3239,7 @@ timeout_process(struct event_base *base)
 		event_del_nolock_(ev, EVENT_DEL_NOBLOCK);
 
 		event_debug(("timeout_process: event: %p, call %p",
-			 ev, ev->ev_callback));
+			 (void *)ev, (void *)ev->ev_callback));
 		event_active_nolock_(ev, EV_TIMEOUT, 1);
 	}
 }

--- a/event.c
+++ b/event.c
@@ -3267,7 +3267,7 @@ event_queue_remove_inserted(struct event_base *base, struct event *ev)
 	EVENT_BASE_ASSERT_LOCKED(base);
 	if (EVUTIL_FAILURE_CHECK(!(ev->ev_flags & EVLIST_INSERTED))) {
 		event_errx(1, "%s: %p(fd "EV_SOCK_FMT") not on queue %x", __func__,
-		    ev, EV_SOCK_ARG(ev->ev_fd), EVLIST_INSERTED);
+                   (void *)ev, EV_SOCK_ARG(ev->ev_fd), EVLIST_INSERTED);
 		return;
 	}
 	DECR_EVENT_COUNT(base, ev->ev_flags);
@@ -3279,7 +3279,7 @@ event_queue_remove_active(struct event_base *base, struct event_callback *evcb)
 	EVENT_BASE_ASSERT_LOCKED(base);
 	if (EVUTIL_FAILURE_CHECK(!(evcb->evcb_flags & EVLIST_ACTIVE))) {
 		event_errx(1, "%s: %p not on queue %x", __func__,
-			   evcb, EVLIST_ACTIVE);
+                          (void *)evcb, EVLIST_ACTIVE);
 		return;
 	}
 	DECR_EVENT_COUNT(base, evcb->evcb_flags);
@@ -3295,7 +3295,7 @@ event_queue_remove_active_later(struct event_base *base, struct event_callback *
 	EVENT_BASE_ASSERT_LOCKED(base);
 	if (EVUTIL_FAILURE_CHECK(!(evcb->evcb_flags & EVLIST_ACTIVE_LATER))) {
 		event_errx(1, "%s: %p not on queue %x", __func__,
-			   evcb, EVLIST_ACTIVE_LATER);
+                          (void *)evcb, EVLIST_ACTIVE_LATER);
 		return;
 	}
 	DECR_EVENT_COUNT(base, evcb->evcb_flags);
@@ -3310,7 +3310,7 @@ event_queue_remove_timeout(struct event_base *base, struct event *ev)
 	EVENT_BASE_ASSERT_LOCKED(base);
 	if (EVUTIL_FAILURE_CHECK(!(ev->ev_flags & EVLIST_TIMEOUT))) {
 		event_errx(1, "%s: %p(fd "EV_SOCK_FMT") not on queue %x", __func__,
-		    ev, EV_SOCK_ARG(ev->ev_fd), EVLIST_TIMEOUT);
+                   (void *)ev, EV_SOCK_ARG(ev->ev_fd), EVLIST_TIMEOUT);
 		return;
 	}
 	DECR_EVENT_COUNT(base, ev->ev_flags);
@@ -3405,7 +3405,7 @@ event_queue_insert_inserted(struct event_base *base, struct event *ev)
 
 	if (EVUTIL_FAILURE_CHECK(ev->ev_flags & EVLIST_INSERTED)) {
 		event_errx(1, "%s: %p(fd "EV_SOCK_FMT") already inserted", __func__,
-		    ev, EV_SOCK_ARG(ev->ev_fd));
+                   (void *)ev, EV_SOCK_ARG(ev->ev_fd));
 		return;
 	}
 
@@ -3459,7 +3459,7 @@ event_queue_insert_timeout(struct event_base *base, struct event *ev)
 
 	if (EVUTIL_FAILURE_CHECK(ev->ev_flags & EVLIST_TIMEOUT)) {
 		event_errx(1, "%s: %p(fd "EV_SOCK_FMT") already on timeout", __func__,
-		    ev, EV_SOCK_ARG(ev->ev_fd));
+                   (void *)ev, EV_SOCK_ARG(ev->ev_fd));
 		return;
 	}
 

--- a/http.c
+++ b/http.c
@@ -1742,7 +1742,7 @@ evhttp_parse_http_version(const char *version, struct evhttp_request *req)
 	int n = sscanf(version, "HTTP/%d.%d%c", &major, &minor, &ch);
 	if (n != 2 || major > 1) {
 		event_debug(("%s: bad version %s on message %p from %s",
-			__func__, version, req, req->remote_host));
+			__func__, version, (void *)req, req->remote_host));
 		return (-1);
 	}
 	req->major = major;
@@ -2014,7 +2014,7 @@ evhttp_parse_request_line(struct evhttp_request *req, char *line, size_t len)
 
 	if (!type) {
 		event_debug(("%s: bad method %s on request %p from %s",
-		            __func__, method, req, req->remote_host));
+		            __func__, method, (void *)req, req->remote_host));
 		/* No error yet; we'll give a better error later when
 		 * we see that req->type is unsupported. */
 	}
@@ -4433,7 +4433,7 @@ evhttp_request_set_on_complete_cb(struct evhttp_request *req,
 const char *
 evhttp_request_get_uri(const struct evhttp_request *req) {
 	if (req->uri == NULL)
-		event_debug(("%s: request %p has no uri\n", __func__, req));
+		event_debug(("%s: request %p has no uri\n", __func__, (void *)req));
 	return (req->uri);
 }
 
@@ -4441,7 +4441,7 @@ const struct evhttp_uri *
 evhttp_request_get_evhttp_uri(const struct evhttp_request *req) {
 	if (req->uri_elems == NULL)
 		event_debug(("%s: request %p has no uri elems\n",
-			    __func__, req));
+			    __func__, (void *)req));
 	return (req->uri_elems);
 }
 

--- a/signal.c
+++ b/signal.c
@@ -295,7 +295,7 @@ evsig_add(struct event_base *base, evutil_socket_t evsignal, short old, short ev
 		    "the most recently added signal or the most recent "
 		    "event_base_loop() call gets preference; do "
 		    "not rely on this behavior in future Libevent versions.",
-		    base, evsig_base, base->evsel->name);
+                   (void *)base, (void *)evsig_base, base->evsel->name);
 	}
 	evsig_base = base;
 	evsig_base_n_signals_added = ++sig->ev_n_signals_added;


### PR DESCRIPTION
Fix non-std printf %p arguments when compiler is running with -Werror -pedantic-errors flags set:

event.c:3270:7: error: format specifies type 'void *' but the argument has type 'struct event *' [-Werror,-Wformat-pedantic]
                    ev, EV_SOCK_ARG(ev->ev_fd), EVLIST_INSERTED);
                    ^~