### PR TITLE
ci: fix FreeBSD 13.0 by setting IGNORE_OSVERSION=yes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -771,6 +771,7 @@ jobs:
         with:
           release: ${{ matrix.release }}
           prepare: |
+            export IGNORE_OSVERSION=yes
             pkg install -y  mbedtls cmake python3
           usesh: true
           run: |
@@ -864,6 +865,7 @@ jobs:
         with:
           release: ${{ matrix.release }}
           prepare: |
+            export IGNORE_OSVERSION=yes
             pkg install -y  mbedtls  python3 autoconf automake libtool pkgconf
           usesh: true
           run: |


### PR DESCRIPTION
Otherwise right now it fails:

```
   exec ssh: pkg install -y  mbedtls cmake python3
    /bin/bash /Users/runner/work/_actions/vmactions/freebsd-vm/v0/run.sh execSSH
    Config file: freebsd-13.0.conf
    Pseudo-terminal will not be allocated because stdin is not a terminal.
    Warning: no access to tty (Bad file descriptor).
    Thus no job control in this shell.
    Installing pkg-1.18.3...
    Newer FreeBSD version for package pkg:
    To ignore this error set IGNORE_OSVERSION=yes
    - package: 1301000
    - running kernel: 1300139
    Ignore the mismatch and continue? [y/N]:
    Failed to install the following 1 package(s): /tmp//pkg.txz.18yvwm
    Bootstrapping pkg from pkg+http://pkg.FreeBSD.org/FreeBSD:13:amd64/quarterly, please wait...
    Verifying signature with trusted certificate pkg.freebsd.org.2013102301... done
    Error: The process '/bin/bash' failed with exit code 1
```

Cc: @Neilpang 

P.S. Actually I'm not sure that we need such huge matrix for FreeBSD, we don't have enough CI time anyway.