### PR TITLE
epoll: use epoll_pwait2() if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -518,6 +518,7 @@ else()
         select
         epoll_create
         epoll_create1
+        epoll_pwait2
         epoll_ctl
         eventfd
         poll

--- a/configure.ac
+++ b/configure.ac
@@ -272,7 +272,7 @@ dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE
 
 dnl Checks for library functions.
-AC_CHECK_FUNCS([accept4 arc4random arc4random_buf arc4random_addrandom eventfd epoll_create1 fcntl getegid geteuid getifaddrs gettimeofday issetugid mach_absolute_time mmap nanosleep pipe pipe2 putenv sendfile setenv setrlimit sigaction signal strsignal strlcpy strsep strtok_r strtoll sysctl timerfd_create umask unsetenv usleep getrandom mmap64])
+AC_CHECK_FUNCS([accept4 arc4random arc4random_buf arc4random_addrandom eventfd epoll_create1 epoll_pwait2 fcntl getegid geteuid getifaddrs gettimeofday issetugid mach_absolute_time mmap nanosleep pipe pipe2 putenv sendfile setenv setrlimit sigaction signal strsignal strlcpy strsep strtok_r strtoll sysctl timerfd_create umask unsetenv usleep getrandom mmap64])
 
 AS_IF([test "$bwin32" = "true"],
   AC_CHECK_FUNCS(_gmtime64_s, , [AC_CHECK_FUNCS(_gmtime64)])

--- a/event-config.h.cmake
+++ b/event-config.h.cmake
@@ -99,6 +99,9 @@
 /* Define to 1 if you have the `epoll_create1' function. */
 #cmakedefine EVENT__HAVE_EPOLL_CREATE1 1
 
+/* Define to 1 if you have the `epoll_pwait2' function. */
+#cmakedefine EVENT__HAVE_EPOLL_PWAIT2 1
+
 /* Define to 1 if you have the `epoll_ctl' function. */
 #cmakedefine EVENT__HAVE_EPOLL_CTL 1
 


### PR DESCRIPTION
On GNU/Linux with epoll backend, prefer `epoll_pwait2()` if available, which is useful to support the timeout with microsecond precision (not nanosecond because an existing code uses `struct timeval` rather than `struct timespec` everywhere).