### PR TITLE
Add manual CMAKE_C_BYTE_ORDER set for old CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -972,6 +972,15 @@ set(SRC_EXTRA
     sha1.c
     evrpc.c)
 
+if("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" LESS 3.20)
+  include(TestBigEndian)
+  TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
+  if(IS_BIG_ENDIAN)
+    set(CMAKE_C_BYTE_ORDER BIG_ENDIAN)
+  else()
+    set(CMAKE_C_BYTE_ORDER LITTLE_ENDIAN)
+  endif()
+endif()
 set_source_files_properties(sha1.c PROPERTIES COMPILE_FLAGS
     -D${CMAKE_C_BYTE_ORDER}=1)
 add_definitions(-DHAVE_CONFIG_H)


### PR DESCRIPTION
This fixes #1348 