### PR TITLE
fix: arc4_getword integer overflow, detected by -fsanitize=undefined

### DIFF
--- a/arc4random.c
+++ b/arc4random.c
@@ -418,7 +418,7 @@ arc4_getword(void)
 {
 	unsigned int val;
 
-	val = arc4_getbyte() << 24;
+	val = (unsigned)arc4_getbyte() << 24;
 	val |= arc4_getbyte() << 16;
 	val |= arc4_getbyte() << 8;
 	val |= arc4_getbyte();


### PR DESCRIPTION
after use `-fsanitize=undefined` to run my program, get follow error:
```
libevent-src/./arc4random.c:421:23: runtime error: left shift of 163 by 24 places cannot be represented in type 'int'
    #0 0x7fdf64 in arc4_stir (/data/src/enet_1.4/build_undefined/enet-net-test+0x7fdf64)
    #1 0x7fdfc2 in evutil_secure_rng_get_bytes (/data/src/enet_1.4/build_undefined/enet-net-test+0x7fdfc2)
    ...
```

after https://github.com/libevent/libevent/pull/1331 `arc4_getword` will call more frequently.