### PR TITLE
Bugfix for ff99f67: missing ")" before "{"

### DIFF
--- a/evutil.c
+++ b/evutil.c
@@ -2248,7 +2248,7 @@ evutil_inet_pton_scope(int af, const char *src, void *dst, unsigned *indexp)
 			return 0;
 	}
 	*indexp = if_index;
-	if (!(tmp_src = mm_strdup(src)) {
+	if (!(tmp_src = mm_strdup(src))) {
 		return -1;
 	}
 	cp = strchr(tmp_src, '%');


### PR DESCRIPTION
Fix issue #1368