### PR TITLE
Exclude arc4random_buf implementation if it's already present in the platform

### DIFF
--- a/arc4random.c
+++ b/arc4random.c
@@ -471,7 +471,7 @@ arc4random(void)
 }
 #endif
 
-#ifndef EVENT__HAVE_ARC4_RANDOM_BUF
+#ifndef EVENT__HAVE_ARC4RANDOM_BUF
 ARC4RANDOM_EXPORT void
 arc4random_buf(void *buf_, size_t n)
 {

--- a/arc4random.c
+++ b/arc4random.c
@@ -471,6 +471,7 @@ arc4random(void)
 }
 #endif
 
+#ifndef EVENT__HAVE_ARC4_RANDOM_BUF
 ARC4RANDOM_EXPORT void
 arc4random_buf(void *buf_, size_t n)
 {
@@ -484,6 +485,7 @@ arc4random_buf(void *buf_, size_t n)
 	}
 	ARC4_UNLOCK_();
 }
+#endif  // #ifndef EVENT__HAVE_ARC4_RANDOM_BUF
 
 #ifndef ARC4RANDOM_NOUNIFORM
 /*

--- a/arc4random.c
+++ b/arc4random.c
@@ -485,7 +485,7 @@ arc4random_buf(void *buf_, size_t n)
 	}
 	ARC4_UNLOCK_();
 }
-#endif  // #ifndef EVENT__HAVE_ARC4_RANDOM_BUF
+#endif  /* #ifndef EVENT__HAVE_ARC4RANDOM_BUF */
 
 #ifndef ARC4RANDOM_NOUNIFORM
 /*


### PR DESCRIPTION
This patch excludes definition of arc4random_buf on systems where it is already present. When the symbol is found, the macro `EVENT__HAVE_ARC4RANDOM_BUF` is set via CMake's `configure_file(..)`.