### PR TITLE
Silence weird GCC warning about an uninitialized variable

### DIFF
--- a/event.c
+++ b/event.c
@@ -2172,6 +2172,10 @@ event_base_once(struct event_base *base, evutil_socket_t fd, short events,
 }
 
 int
+/* workaround for -Werror=maybe-uninitialized bug in gcc 11/12 */
+#if defined(__GNUC__) && (__GNUC__ == 11 || __GNUC__ == 12)
+__attribute__((noinline))
+#endif
 event_assign(struct event *ev, struct event_base *base, evutil_socket_t fd, short events, void (*callback)(evutil_socket_t, short, void *), void *arg)
 {
 	if (!base)


### PR DESCRIPTION
For the CMake release build with `-DEVENT__ENABLE_GCC_WARNINGS=ON` and `-DEVENT__DISABLE_MM_REPLACEMENT=ON`, GCC version 11 and 12 may complain about possibly uninitialized variable:
```
In function ‘event_debug_assert_not_added_’,
    inlined from ‘event_assign’ at event.c:2184:2,
    inlined from ‘event_new’ at event.c:2276:6:
cc1: error: ‘ev’ may be used uninitialized [-Werror=maybe-uninitialized] event.c: In function ‘event_new’:
event.c:361:13: note: by argument 1 of type ‘const struct event *’ to  event_debug_assert_not_added_.part.0’ declared here
  361 | static void event_debug_assert_not_added_(const struct event *ev)
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
This warning is most likely a false positive and can be silenced by explicitly disabling inlining for `event_assign()`.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>