### PR TITLE
Use GNUInstallDirs for mapping installation directories (continued)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1621,8 +1621,10 @@ endif()
 # Installation preparation.
 #
 
+include(GNUInstallDirs)
+
 set(EVENT_INSTALL_CMAKE_DIR
-    "${CMAKE_INSTALL_PREFIX}/lib/cmake/libevent")
+    "${CMAKE_INSTALL_LIBDIR}/cmake/libevent")
 
 export(PACKAGE libevent)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1628,18 +1628,9 @@ set(EVENT_INSTALL_CMAKE_DIR
 
 export(PACKAGE libevent)
 
-function(gen_package_config forinstall)
-    if(${forinstall})
-        set(CONFIG_FOR_INSTALL_TREE 1)
-        set(dir "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}")
-    else()
-        set(CONFIG_FOR_INSTALL_TREE 0)
-        set(dir "${PROJECT_BINARY_DIR}")
-    endif()
-    configure_file(${PROJECT_SOURCE_DIR}/cmake/LibeventConfig.cmake.in
-                "${dir}/LibeventConfig.cmake"
-                @ONLY)
-endfunction()
+configure_file(${PROJECT_SOURCE_DIR}/cmake/LibeventConfig.cmake.in
+    "${PROJECT_BINARY_DIR}/LibeventConfig.cmake"
+    @ONLY)
 
 # Generate the config file for the build-tree.
 set(EVENT__INCLUDE_DIRS
@@ -1649,11 +1640,6 @@ set(EVENT__INCLUDE_DIRS
 set(LIBEVENT_INCLUDE_DIRS
     ${EVENT__INCLUDE_DIRS}
     CACHE PATH "Libevent include directories")
-
-gen_package_config(0)
-
-# Generate the config file for the installation tree.
-gen_package_config(1)
 
 # Generate version info for both build-tree and install-tree.
 configure_file(${PROJECT_SOURCE_DIR}/cmake/LibeventConfigVersion.cmake.in
@@ -1672,7 +1658,7 @@ install(FILES ${HDR_PUBLIC}
 
 # Install the configs.
 install(FILES
-        ${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/LibeventConfig.cmake
+        ${PROJECT_BINARY_DIR}/LibeventConfig.cmake
         ${PROJECT_BINARY_DIR}/LibeventConfigVersion.cmake
         DESTINATION "${EVENT_INSTALL_CMAKE_DIR}"
         COMPONENT dev)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,20 +172,21 @@ if (NOT DEFINED CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 endif()
 
+include(GNUInstallDirs)
+
 # The RPATH to be used when installing, but only if it's not a system directory
 #
 # Refs: https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling
 macro(Configure_RPATH)
-    # NOTE: that CMAKE_INSTALL_PREFIX not always normalized correctly, i.e.:
+    # NOTE: that CMAKE_INSTALL_LIBDIR not always normalized correctly, i.e.:
     # - "///" -> "/"
     # - "/////usr///" -> "//usr"
     # So it should be normalized again.
-
-    get_filename_component(CMAKE_INSTALL_PREFIX_NORMALIZED "${CMAKE_INSTALL_PREFIX}" REALPATH)
-    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX_NORMALIZED}/lib" isSystemDir)
+    get_filename_component(CMAKE_INSTALL_LIBDIR_NORMALIZED "${CMAKE_INSTALL_PREFIX}" REALPATH)
+    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_LIBDIR_NORMALIZED}/lib" isSystemDir)
 
     if("${isSystemDir}" STREQUAL "-1")
-        set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX_NORMALIZED}/lib")
+        set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR_NORMALIZED}")
     endif()
 endmacro()
 Configure_RPATH()
@@ -1620,8 +1621,6 @@ endif()
 #
 # Installation preparation.
 #
-
-include(GNUInstallDirs)
 
 set(EVENT_INSTALL_CMAKE_DIR
     "${CMAKE_INSTALL_LIBDIR}/cmake/libevent")

--- a/cmake/AddEventLibrary.cmake
+++ b/cmake/AddEventLibrary.cmake
@@ -13,8 +13,8 @@ endmacro()
 macro(generate_pkgconfig LIB_NAME)
     set(prefix      ${CMAKE_INSTALL_PREFIX})
     set(exec_prefix ${CMAKE_INSTALL_PREFIX})
-    set(libdir      ${CMAKE_INSTALL_PREFIX}/lib)
-    set(includedir  ${CMAKE_INSTALL_PREFIX}/include)
+    set(libdir      ${CMAKE_INSTALL_LIBDIR})
+    set(includedir  ${CMAKE_INSTALL_INCLUDEDIR})
 
     set(VERSION ${EVENT_ABI_LIBVERSION})
 
@@ -31,7 +31,7 @@ macro(generate_pkgconfig LIB_NAME)
     configure_file("lib${LIB_NAME}.pc.in" "lib${LIB_NAME}.pc" @ONLY)
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/lib${LIB_NAME}.pc"
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
     )
 endmacro()
 
@@ -151,7 +151,7 @@ macro(add_event_library LIB_NAME)
             set_target_properties(
                 "${LIB_NAME}_shared" PROPERTIES
                 OUTPUT_NAME "${LIB_NAME}-${EVENT_PACKAGE_RELEASE}.${CURRENT_MINUS_AGE}"
-                INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib"
+                INSTALL_NAME_DIR "${CMAKE_INSTALL_LIBDIR}"
                 LINK_FLAGS "-compatibility_version ${COMPATIBILITY_VERSION} -current_version ${COMPATIBILITY_VERSION}.${EVENT_ABI_LIBVERSION_REVISION}")
         else()
             math(EXPR CURRENT_MINUS_AGE "${EVENT_ABI_LIBVERSION_CURRENT}-${EVENT_ABI_LIBVERSION_AGE}")

--- a/cmake/LibeventConfig.cmake.in
+++ b/cmake/LibeventConfig.cmake.in
@@ -58,7 +58,6 @@ endif()
 
 # Get the path of the current file.
 get_filename_component(LIBEVENT_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-get_filename_component(_INSTALL_PREFIX "${LIBEVENT_CMAKE_DIR}/../../.." ABSOLUTE)
 
 macro(message_if_needed _flag _msg)
     if (NOT ${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
@@ -116,7 +115,7 @@ if(CONFIG_FOR_INSTALL_TREE)
     unset(_event_h CACHE)
     find_path(_event_h
               NAMES event2/event.h
-              PATHS "${_INSTALL_PREFIX}/include"
+              PATHS "@CMAKE_INSTALL_INCLUDEDIR@"
               NO_DEFAULT_PATH)
     if(_event_h)
         set(LIBEVENT_INCLUDE_DIRS "${_event_h}")
@@ -135,7 +134,7 @@ if(CONFIG_FOR_INSTALL_TREE)
                     NO_DEFAULT_PATH)
         find_library(_event_lib_rel
                     NAMES "event_${_comp}"
-                    PATHS "${_INSTALL_PREFIX}/lib"
+                    PATHS "@CMAKE_INSTALL_LIBDIR@"
                     NO_DEFAULT_PATH)
         if(_event_lib_rel OR _event_lib_dbg)
             list(APPEND LIBEVENT_LIBRARIES "libevent::${_comp}")
@@ -167,7 +166,7 @@ set(LIBEVENT_INCLUDE_DIR ${LIBEVENT_INCLUDE_DIRS})
 if(LIBEVENT_LIBRARIES)
     set(LIBEVENT_LIBRARY ${LIBEVENT_LIBRARIES})
     if(CONFIG_FOR_INSTALL_TREE)
-        message_if_needed(STATUS "Found libevent ${LIBEVENT_VERSION} in ${_INSTALL_PREFIX}")
+        message_if_needed(STATUS "Found libevent ${LIBEVENT_VERSION} in @CMAKE_INSTALL_LIBDIR@")
     else()
         message_if_needed(STATUS "Found libevent ${LIBEVENT_VERSION} in ${LIBEVENT_CMAKE_DIR}")
     endif()
@@ -190,4 +189,3 @@ unset(_LIB_TYPE)
 unset(_AVAILABLE_LIBS)
 unset(_EVENT_COMPONENTS)
 unset(_POSSIBLE_PKG_NAMES)
-unset(_INSTALL_PREFIX)

--- a/cmake/LibeventConfig.cmake.in
+++ b/cmake/LibeventConfig.cmake.in
@@ -32,8 +32,6 @@
 # find_package() can handle dependencies automatically. For example, given the 'openssl' component,
 # all dependencies (libevent_core, libssl, libcrypto and openssl include directories) will be found.
 
-set(CONFIG_FOR_INSTALL_TREE @CONFIG_FOR_INSTALL_TREE@)
-
 set(LIBEVENT_VERSION @EVENT_PACKAGE_VERSION@)
 
 # IMPORTED targets from LibeventTargets.cmake
@@ -45,19 +43,13 @@ if(NOT DEFINED LIBEVENT_STATIC_LINK)
     set(LIBEVENT_STATIC_LINK NOT @EVENT_LIBRARY_SHARED@)
 endif()
 
-set(CMAKE_FIND_LIBRARY_SUFFIXES_SAVE "${CMAKE_FIND_LIBRARY_SUFFIXES}")
 if(${LIBEVENT_STATIC_LINK})
     set(_LIB_TYPE static)
-    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
     set(_AVAILABLE_LIBS "${LIBEVENT_STATIC_LIBRARIES}")
 else()
     set(_LIB_TYPE shared)
-    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX})
     set(_AVAILABLE_LIBS "${LIBEVENT_SHARED_LIBRARIES}")
 endif()
-
-# Get the path of the current file.
-get_filename_component(LIBEVENT_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
 macro(message_if_needed _flag _msg)
     if (NOT ${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
@@ -109,73 +101,22 @@ macro(set_case_insensitive_found _comp)
     endforeach()
 endmacro()
 
-if(CONFIG_FOR_INSTALL_TREE)
-    ## Config for install tree ----------------------------------------
-    # Find includes
-    unset(_event_h CACHE)
-    find_path(_event_h
-              NAMES event2/event.h
-              PATHS "@CMAKE_INSTALL_INCLUDEDIR@"
-              NO_DEFAULT_PATH)
-    if(_event_h)
-        set(LIBEVENT_INCLUDE_DIRS "${_event_h}")
-        message_if_needed(STATUS "Found libevent include directory: ${_event_h}")
-    else()
-        message_if_needed(WARNING "Your libevent library does not contain header files!")
-    endif()
+foreach(_comp ${_EVENT_COMPONENTS})
+    list(APPEND LIBEVENT_LIBRARIES "libevent::${_comp}")
+    set_case_insensitive_found(${_comp})
+endforeach()
 
-    # Find libraries
-    macro(find_event_lib _comp)
-        unset(_event_lib_dbg CACHE)
-        unset(_event_lib_rel CACHE)
-        find_library(_event_lib_dbg
-                    NAMES "event_${_comp}d"
-                    PATHS "${_INSTALL_PREFIX}/lib"
-                    NO_DEFAULT_PATH)
-        find_library(_event_lib_rel
-                    NAMES "event_${_comp}"
-                    PATHS "@CMAKE_INSTALL_LIBDIR@"
-                    NO_DEFAULT_PATH)
-        if(_event_lib_rel OR _event_lib_dbg)
-            list(APPEND LIBEVENT_LIBRARIES "libevent::${_comp}")
-            set_case_insensitive_found(${_comp})
-            if(_event_lib_dbg)
-                message_if_needed(STATUS "Found libevent component: ${_event_lib_dbg}")
-            endif()
-            if(_event_lib_rel)
-                message_if_needed(STATUS "Found libevent component: ${_event_lib_rel}")
-            endif()
-        else()
-            no_component_msg(${_comp})
-        endif()
-    endmacro()
-
-    foreach(comp ${_EVENT_COMPONENTS})
-        find_event_lib(${comp})
-    endforeach()
-else()
-    ## Config for build tree ----------------------------------------
-    set(LIBEVENT_INCLUDE_DIRS "@EVENT__INCLUDE_DIRS@")
-    foreach(_comp ${_EVENT_COMPONENTS})
-        list(APPEND LIBEVENT_LIBRARIES "libevent::${_comp}")
-        set_case_insensitive_found(${_comp})
-    endforeach()
-endif()
-
-set(LIBEVENT_INCLUDE_DIR ${LIBEVENT_INCLUDE_DIRS})
 if(LIBEVENT_LIBRARIES)
     set(LIBEVENT_LIBRARY ${LIBEVENT_LIBRARIES})
-    if(CONFIG_FOR_INSTALL_TREE)
-        message_if_needed(STATUS "Found libevent ${LIBEVENT_VERSION} in @CMAKE_INSTALL_LIBDIR@")
-    else()
-        message_if_needed(STATUS "Found libevent ${LIBEVENT_VERSION} in ${LIBEVENT_CMAKE_DIR}")
-    endif()
 
-    # Avoid including targets more than one times
-    if(NOT TARGET event_core_${_LIB_TYPE})
+    # Avoid including targets more than once.
+    if(NOT TARGET libevent::core)
         # Include the project Targets file, this contains definitions for IMPORTED targets.
-        include(${LIBEVENT_CMAKE_DIR}/LibeventTargets-${_LIB_TYPE}.cmake)
+        include(${CMAKE_CURRENT_LIST_DIR}/LibeventTargets-${_LIB_TYPE}.cmake)
     endif()
+    get_target_property(LIBEVENT_INCLUDE_DIRS libevent::core INTERFACE_INCLUDE_DIRECTORIES)
+    get_filename_component(LIBEVENT_INSTALL_PREFIX "${LIBEVENT_INCLUDE_DIRS}" PATH)
+    message_if_needed(STATUS "Found libevent ${LIBEVENT_VERSION} in ${LIBEVENT_INSTALL_PREFIX}")
 else()
     if(${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED)
         message(FATAL_ERROR "Can not find any libraries for libevent.")
@@ -183,8 +124,8 @@ else()
         message_if_needed(WARNING "Can not find any libraries for libevent.")
     endif()
 endif()
+set(LIBEVENT_INCLUDE_DIR ${LIBEVENT_INCLUDE_DIRS})
 
-set(CMAKE_FIND_LIBRARY_SUFFIXES "${CMAKE_FIND_LIBRARY_SUFFIXES_SAVE}")
 unset(_LIB_TYPE)
 unset(_AVAILABLE_LIBS)
 unset(_EVENT_COMPONENTS)

--- a/cmake/UseDoxygen.cmake
+++ b/cmake/UseDoxygen.cmake
@@ -90,7 +90,7 @@ macro(UseDoxygen)
       if ("${DOXYGEN_GENERATE_HTML}" STREQUAL "YES")
         install(DIRECTORY
           ${PROJECT_BINARY_DIR}/${DOXYGEN_OUTPUT_DIRECTORY}/html
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/share/doc/${PROJECT_NAME}
+          DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}
           COMPONENT doc
         )
       endif()
@@ -106,7 +106,7 @@ macro(UseDoxygen)
         # Install manual into <prefix>/share/man/man3
         install(DIRECTORY
           ${MAN_PAGES_DIR}
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man
+          DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/man
           COMPONENT doc
         )
       endif()

--- a/test-export/test-export.py
+++ b/test-export/test-export.py
@@ -109,18 +109,6 @@ def test_group():
         testcase("mbedtls", "pthreads", 1)
 
 
-def config_restore():
-    if os.path.isfile("tempconfig") and not os.path.isfile("LibeventConfig.cmake"):
-        os.rename("tempconfig", "LibeventConfig.cmake")
-
-
-def config_backup():
-    if os.path.isfile("tempconfig"):
-        os.remove("tempconfig")
-    if os.path.isfile("LibeventConfig.cmake"):
-        os.rename("LibeventConfig.cmake", "tempconfig")
-
-
 shutil.rmtree(os.path.join(script_dir, "build"), ignore_errors=True)
 
 
@@ -158,7 +146,6 @@ print("[test-export] use %s library" % link_type)
 # Test for build tree.
 print("[test-export] test for build tree")
 dllpath = os.path.join(working_dir, "bin", "Debug")
-config_restore()
 os.environ["CMAKE_PREFIX_PATH"] = working_dir
 export_dll(dllpath)
 run_test_group()
@@ -175,7 +162,6 @@ else:
     prefix = "/usr/local"
 exec_cmd('cmake -DCMAKE_SKIP_INSTALL_RPATH=OFF -DCMAKE_INSTALL_PREFIX="%s" ..' % prefix, True)
 exec_cmd('cmake --build . -v --target install', True)
-config_backup()
 os.environ["CMAKE_PREFIX_PATH"] = os.path.join(prefix, "lib/cmake/libevent")
 export_dll(dllpath)
 run_test_group()
@@ -191,13 +177,11 @@ tempdir = tempfile.TemporaryDirectory()
 cmd = 'cmake -DCMAKE_SKIP_INSTALL_RPATH=OFF -DCMAKE_INSTALL_PREFIX="%s" ..' % tempdir.name
 exec_cmd(cmd, True)
 exec_cmd("cmake --build . -v --target install", True)
-config_backup()
 os.environ["CMAKE_PREFIX_PATH"] = os.path.join(tempdir.name, "lib/cmake/libevent")
 dllpath = os.path.join(tempdir.name, "lib")
 export_dll(dllpath)
 run_test_group()
 unexport_dll(dllpath)
 del os.environ["CMAKE_PREFIX_PATH"]
-config_restore()
 
 print("[test-export] all testcases have run successfully")


### PR DESCRIPTION
Continuation of #1221.

The last commit updates `LibeventConfig.cmake` to always get `LIBEVENT_INSTALL_DIR(S)` from the `event::core` target.
I took the liberty to fix the guard against multiple target definitions (although I believe it would be better to just remove it).