### PR TITLE
Fix compilation on non recent windows SDKs

### DIFF
--- a/evutil.c
+++ b/evutil.c
@@ -31,7 +31,6 @@
 #include <winsock2.h>
 #include <winerror.h>
 #include <ws2tcpip.h>
-#include <stringapiset.h>
 #ifdef EVENT__HAVE_AFUNIX_H
 #include <afunix.h>
 #endif


### PR DESCRIPTION
In commit https://github.com/libevent/libevent/commit/f8bb9d84845be12b3ffb709bf9a26df4f40f898f the header ``stringapiset.h`` was included, very likely because the user who made the change saw that the funciton ``WideCharToMultiByte`` is "declared" in there.
That header tho is a recent addition to the windows headers added in the last years in an attempt from microsoft to split the windows.h header in multiple files, so the inclusion fails when the library is not built with the latest visual studio using the latest windows 10 sdk.
That inclusion can be safely removed as in any case the function ``WideCharToMultiByte`` was already included by the windows.h header that is included few lines below.