### PR TITLE
Only use relative paths for install DESTINATION option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1622,8 +1622,7 @@ endif()
 # Installation preparation.
 #
 
-set(EVENT_INSTALL_CMAKE_DIR
-    "${CMAKE_INSTALL_LIBDIR}/cmake/libevent")
+set(EVENT_INSTALL_CMAKE_DIR "lib/cmake/libevent")
 
 export(PACKAGE libevent)
 

--- a/cmake/AddEventLibrary.cmake
+++ b/cmake/AddEventLibrary.cmake
@@ -31,7 +31,7 @@ macro(generate_pkgconfig LIB_NAME)
     configure_file("lib${LIB_NAME}.pc.in" "lib${LIB_NAME}.pc" @ONLY)
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/lib${LIB_NAME}.pc"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+        DESTINATION "lib/pkgconfig"
     )
 endmacro()
 
@@ -151,7 +151,7 @@ macro(add_event_library LIB_NAME)
             set_target_properties(
                 "${LIB_NAME}_shared" PROPERTIES
                 OUTPUT_NAME "${LIB_NAME}-${EVENT_PACKAGE_RELEASE}.${CURRENT_MINUS_AGE}"
-                INSTALL_NAME_DIR "${CMAKE_INSTALL_LIBDIR}"
+                INSTALL_NAME_DIR "lib"
                 LINK_FLAGS "-compatibility_version ${COMPATIBILITY_VERSION} -current_version ${COMPATIBILITY_VERSION}.${EVENT_ABI_LIBVERSION_REVISION}")
         else()
             math(EXPR CURRENT_MINUS_AGE "${EVENT_ABI_LIBVERSION_CURRENT}-${EVENT_ABI_LIBVERSION_AGE}")


### PR DESCRIPTION
As described in #1404, the explicit use of `CMAKE_INSTALL_PREFIX` conflicts with using command-line `--prefix`.

This simply removes all explicit use of `CMAKE_INSTALL_PREFIX`.

Fixes: #1404