### PR TITLE
build: use FORTIFY_SOURCE=3 in hardening option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,7 +341,7 @@ if (${GNUC})
              -Wstack-protector
              "--param ssp-buffer-size=1")
 
-        add_definitions(-D_FORTIFY_SOURCE=2)
+        add_definitions(-D_FORTIFY_SOURCE=3)
     endif()
 
     if (EVENT__ENABLE_GCC_FUNCTION_SECTIONS)

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ AC_ARG_ENABLE([gcc-warnings],
 AC_ARG_ENABLE([gcc-hardening],
      AS_HELP_STRING([--enable-gcc-hardening, enable compiler security checks]),
 [if test "$enableval" = "yes"; then
-    CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=2 -fstack-protector-all"
+    CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=3 -fstack-protector-all"
     CFLAGS="$CFLAGS -fwrapv -fPIE -Wstack-protector"
     CFLAGS="$CFLAGS --param ssp-buffer-size=1"
 fi])


### PR DESCRIPTION
FORTIFY_SOURCE=3 is available for use with newer glibcs ([2.33+](https://sourceware.org/pipermail/libc-alpha/2021-February/122207.html)). Switch to using it. Note that it's use also requires LLVM Clang 9+ or GCC 12+:

> A new fortification level _FORTIFY_SOURCE=3 is available.  At this level,
  glibc may use additional checks that may have an additional performance
  overhead.  At present these checks are available only on LLVM 9 and later.
  The latest GCC available at this time (10.2) does not support this level of
  fortification.

Any value `>= 2` will also continue to enable fortification for glibcs older than 2.33.