### PR TITLE
fix "Branch condition evaluates to a garbage value" in reply_parse

### DIFF
--- a/evdns.c
+++ b/evdns.c
@@ -1265,6 +1265,8 @@ reply_parse(struct evdns_base *base, u8 *packet, int length)
 	struct request *req = NULL;
 	unsigned int i, buf_size;
 
+	memset(&reply, 0, sizeof(reply));
+
 	ASSERT_LOCKED(base);
 
 	GET16(trans_id);
@@ -1279,8 +1281,6 @@ reply_parse(struct evdns_base *base, u8 *packet, int length)
 	req = request_find_from_trans_id(base, trans_id);
 	if (!req) return -1;
 	EVUTIL_ASSERT(req->base == base);
-
-	memset(&reply, 0, sizeof(reply));
 
 	/* If it's not an answer, it doesn't correspond to any request. */
 	if (!(flags & _QR_MASK)) return -1;  /* must be an answer */


### PR DESCRIPTION
This fixes an Xcode analyzer warning where the error code path (from GET16) would look at `reply` before initialization.
![Capture d’écran 2023-03-02 à 13 35 49](https://user-images.githubusercontent.com/839992/222341084-b57a1259-95ba-46b8-a82e-cc11d1a87432.png)
