### PR TITLE
fix: the value is never actually read from 'argument'

### DIFF
--- a/http.c
+++ b/http.c
@@ -3555,7 +3555,6 @@ evhttp_parse_query_impl(const char *str, struct evkeyvalq *headers,
     int is_whole_uri, unsigned flags)
 {
 	char *line=NULL;
-	char *argument;
 	char *p;
 	const char *query_part;
 	int result = -1;
@@ -3583,13 +3582,12 @@ evhttp_parse_query_impl(const char *str, struct evkeyvalq *headers,
 		goto error;
 	}
 
-	p = argument = line;
+	p = line;
 	while (p != NULL && *p != '\0') {
 		char *key, *value, *decoded_value;
 		int err;
-		argument = strsep(&p, "&");
 
-		value = argument;
+		value = strsep(&p, "&");
 		key = strsep(&value, "=");
 		if (flags & EVHTTP_URI_QUERY_NONCONFORMANT) {
 			if (value == NULL)


### PR DESCRIPTION
Fix Xcode analyzer warning:
>Although the value stored to 'argument' is used in the enclosing expression, the value is never actually read from 'argument'

![Capture d’écran 2023-03-02 à 13 57 01](https://user-images.githubusercontent.com/839992/222344221-ea55ecd8-91f5-469a-b663-4731d10aa34a.png)
