### PR TITLE
Fix "Value stored to 'a' is never read"

### DIFF
--- a/sha1.c
+++ b/sha1.c
@@ -198,8 +198,6 @@ static void SHA1Transform(uint32_t state[5], const unsigned char buffer[64]) {
     state[2] += c;
     state[3] += d;
     state[4] += e;
-    /* Wipe variables */
-    a = b = c = d = e = 0;
 #ifdef SHA1HANDSOFF
     memset(block, '\0', sizeof(block));
 #endif


### PR DESCRIPTION
Fix compiler analyzer warning:
>Value stored to 'a' is never read

![Capture d’écran 2023-03-02 à 14 06 52](https://user-images.githubusercontent.com/839992/222345285-078a0581-931b-4a2d-bc0d-d0f7a0873ffe.png)

Using same fix as Google do:
https://android.googlesource.com/platform/dalvik/+/android-4.4.2_r2/libdex/sha1.cpp#193