### PR TITLE
Always have evutil_secure_rng_add_bytes available

### DIFF
--- a/evutil_rand.c
+++ b/evutil_rand.c
@@ -190,14 +190,14 @@ evutil_secure_rng_get_bytes(void *buf, size_t n)
 	ev_arc4random_buf(buf, n);
 }
 
-#if !defined(EVENT__HAVE_ARC4RANDOM) || defined(EVENT__HAVE_ARC4RANDOM_ADDRANDOM)
 void
 evutil_secure_rng_add_bytes(const char *buf, size_t n)
 {
+#if !defined(EVENT__HAVE_ARC4RANDOM) || defined(EVENT__HAVE_ARC4RANDOM_ADDRANDOM)
 	arc4random_addrandom((unsigned char*)buf,
 	    n>(size_t)INT_MAX ? INT_MAX : (int)n);
-}
 #endif
+}
 
 void
 evutil_free_secure_rng_globals_(void)

--- a/include/event2/util.h
+++ b/include/event2/util.h
@@ -878,7 +878,6 @@ int evutil_secure_rng_init(void);
 EVENT2_EXPORT_SYMBOL
 int evutil_secure_rng_set_urandom_device_file(char *fname);
 
-#if !defined(EVENT__HAVE_ARC4RANDOM) || defined(EVENT__HAVE_ARC4RANDOM_ADDRANDOM)
 /** Seed the random number generator with extra random bytes.
 
     You should almost never need to call this function; it should be
@@ -890,12 +889,14 @@ int evutil_secure_rng_set_urandom_device_file(char *fname);
     contains a fairly large amount of strong entropy.  Doing so is
     notoriously hard: most people who try get it wrong.  Watch out!
 
+    This function does nothing when the system provides arc4random()
+    function because it will provide proper entropy.
+
     @param dat a buffer full of a strong source of random numbers
     @param datlen the number of bytes to read from datlen
  */
 EVENT2_EXPORT_SYMBOL
 void evutil_secure_rng_add_bytes(const char *dat, size_t datlen);
-#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When libevent doesn't provide random the arc4 function, but they come from libc, there is no need to call this function, so make it do nothing.

Fixes: #1393