### PR TITLE
test: fix potential null dereference in https_bind_ssl_bevcb

### DIFF
--- a/test/regress_http.c
+++ b/test/regress_http.c
@@ -4318,9 +4318,10 @@ https_bind_ssl_bevcb(struct evhttp *http, ev_uint16_t port, ev_uint16_t *pport, 
 	int _port;
 	struct evhttp_bound_socket *sock = NULL;
 	sock = evhttp_bind_socket_with_handle(http, "127.0.0.1", port);
-	if (!sock)
+	if (!sock) {
 		event_errx(1, "Couldn't open web port");
 		return -1;
+	}
 
 #ifdef EVENT__HAVE_OPENSSL
 	if (mask & HTTP_OPENSSL) {

--- a/test/regress_http.c
+++ b/test/regress_http.c
@@ -4318,6 +4318,9 @@ https_bind_ssl_bevcb(struct evhttp *http, ev_uint16_t port, ev_uint16_t *pport, 
 	int _port;
 	struct evhttp_bound_socket *sock = NULL;
 	sock = evhttp_bind_socket_with_handle(http, "127.0.0.1", port);
+	if (!sock)
+		event_errx(1, "Couldn't open web port");
+		return -1;
 
 #ifdef EVENT__HAVE_OPENSSL
 	if (mask & HTTP_OPENSSL) {


### PR DESCRIPTION
**Description**
Fix the null dereference warning detected by static analyse tool infer@facebook

**Warning Type**
Null Dereference

**Component Name**
libevents/test/regress_https.c (line:4320)

**Additional Information**
pointer `sock` last assigned on line 4320 could be null and is dereferenced at line 4328.