### PR TITLE
Fix potential resource leak

### DIFF
--- a/sample/ws-chat-server.c
+++ b/sample/ws-chat-server.c
@@ -202,6 +202,8 @@ on_html(struct evhttp_request *req, void *arg)
 
 err:
 	evhttp_send_error(req, HTTP_NOTFOUND, NULL);
+	if (fd >= 0)
+		close(fd);
 }
 
 #ifndef EVENT__HAVE_STRSIGNAL


### PR DESCRIPTION
**Description**
Fix the resource leak warning detected by static analyse tool infer@facebook

**Warning Type**
Resource Leak

**Component Name**
lbevent/sample/ws-chat-server.c (line:184)

**Additional Information**
resource acquired by call to `open()` at line 184 is not released after line 198.