### PR TITLE
Fix potential null dereference in http-server

### DIFF
--- a/sample/http-server.c
+++ b/sample/http-server.c
@@ -258,7 +258,7 @@ send_document_cb(struct evhttp_request *req, void *arg)
 #ifdef _WIN32
 		dirlen = strlen(whole_path);
 		pattern = malloc(dirlen+3);
-		if(!pattern) 
+		if (!pattern)
 			goto err;
 		memcpy(pattern, whole_path, dirlen);
 		pattern[dirlen] = '\\';

--- a/sample/http-server.c
+++ b/sample/http-server.c
@@ -258,6 +258,8 @@ send_document_cb(struct evhttp_request *req, void *arg)
 #ifdef _WIN32
 		dirlen = strlen(whole_path);
 		pattern = malloc(dirlen+3);
+		if(!pattern) 
+			goto err;
 		memcpy(pattern, whole_path, dirlen);
 		pattern[dirlen] = '\\';
 		pattern[dirlen+1] = '*';


### PR DESCRIPTION
**Description**
Fix the null dereference warning detected by static analyse tool infer@facebook

**Warning Type**
Null Dereference

**Component Name**
libevents/sample/http-server.c (line:260)

**Additional Information**
pointer `pattern` last assigned on line 260 could be null and is dereferenced at line 261.