### PR TITLE
ci: set minimal permissions on GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ on:
       - 'whatsnew*'
       - 'LICENSE'
 
+permissions: read-all
+
 jobs:
   linux-cmake-job:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - master
+permisisons: read-all
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,8 +6,13 @@ on:
     branches:
       - master
 
+permissions: read-all
+
 jobs:
   coverage-job:
+    permissions:
+      checks: write  # for coverallsapp/github-action to create new checks
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2.0.0
@@ -49,6 +54,8 @@ jobs:
           name: coverage-build
           path: build
   abi-job:
+    permissions:
+      contents: write # for Git to git push
     runs-on: ubuntu-18.04
     ## TODO: use docker image, but for now this is not possible without hacks
     ## due to even public registry require some authentication:
@@ -112,6 +119,8 @@ jobs:
           path: /tmp/le-abi-root/work/abi-check
 
   doxygen-job:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
Change made by setting top-level read-only permissions to all workflows. If a job requires any write permissions, the necessary permissions are given as job-level.

WARN: I could not know for sure if some external jobs on [build.yml](https://github.com/libevent/libevent/blob/master/.github/workflows/build.yml) needed any specific write permission, so I let all of them with only read-only permissions. If you wish, I can enable the actions at my fork and test them there before merging the PR. 

Closes #1421