### PR TITLE
ci: switch to ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         EVENT_MATRIX:
           - DIST
           - NONE
@@ -171,7 +171,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         include:
           # openssl 3.0
           - os: ubuntu-22.04


### PR DESCRIPTION
github action reports "internal error" for builds on ubuntu 18.04:

    linux-cmake-job (ubuntu-18.04, COMPILER_CLANG)
    This is a scheduled Ubuntu-18.04 brownout. The Ubuntu-18.04 environment is deprecated and will be removed on April 1st, 2023. For more details, see https://github.com/actions/runner-images/issues/6002

    linux-cmake-job (ubuntu-18.04, COMPILER_CLANG)
    GitHub Actions has encountered an internal error when running your job.