### PR TITLE
doc: minor autoconf/formatting improvements

### DIFF
--- a/Documentation/Building.md
+++ b/Documentation/Building.md
@@ -3,36 +3,37 @@
 ### Jump to:
 
 - [Prerequisites](#Prerequisites)
-- [Autoconf](#autoconf)
-  - [Flags](#autoconf-flags)
+- [Building on Unix using CMake](#building-on-unix-cmake)
+- [Autotools (deprecated)](#autotools-deprecated)
+  - [Flags](#autotools-flags)
 - [Building on Windows](#building-on-windows)
-- [Building on Unix (With CMake)](#building-on-unix-cmake)
 - [CMake Variables](#cmake-variables)
 
 ## Prerequisites
 
 ### Linux deb-like (ubuntu/debian/...)
 
-Just install tools using your preferred package manager if you build using autotools:
-
-```sh
-sudo apt-get install automake autoconf libtool pkg-config
-```
-
-or build using cmake:
+Install build tools using your preferred package manager. For CMake:
 
 ```sh
 sudo apt-get install cmake
 ```
 
-Doxygen is a tool for generating documentation. Git is used to fetch the package version.
+or using Autotools (deprecated):
+
+```sh
+sudo apt-get install automake autoconf libtool pkg-config
+```
+
+Doxygen is used for generating documentation.
+Git is used to fetch the package version.
 Install them if needed:
 
-```
+```sh
 sudo apt-get install doxygen git
 ```
 
-libevent has encryption layer, you need openssl or mbedTLS for it, you can
+libevent has encryption layer, you need OpenSSL or MbedTLS for it, you can
 install one of this using:
 
 ```sh
@@ -47,7 +48,10 @@ To run the tests, you should install zlib:
 sudo apt-get install zlib1g-dev
 ```
 
-Finally, python interpreter should be installed if you want to run regression tests.
+Finally, a python interpreter should be installed if you want to run regression tests:
+```sh
+sudo apt-get install python3
+```
 
 ### MacOS
 
@@ -82,11 +86,19 @@ or add `OPENSSL_ROOT_DIR` definition to the cmake command:
 cmake -DOPENSSL_ROOT_DIR=C:/path/to/OpenSSL ...
 ```
 
-## Autoconf
-
+## Building on Unix (CMake)
+```sh
+mkdir build && cd build
+cmake .. # Default to Unix Makefiles
+make
+make verify # Optional
 ```
-$ ./configure
-$ make
+
+## Autotools (deprecated)
+
+```sh
+./configure
+make
 ```
 
 **Note: If you had downloaded libevent from the Git repository, then you have to run `./autogen.sh` first!**
@@ -107,7 +119,7 @@ To enable low-level tracing, build the library as:
 $ CFLAGS=-DUSE_DEBUG ./configure [...]
 ```
 
-### Autoconf flags
+### Autotools flags
 
 Standard configure flags should work. In particular, see:
 ```
@@ -140,15 +152,6 @@ It is highly recommended to build "out of source" when using CMake instead of "i
 The "NMake Makefiles" CMake generator can be used to build entirely via the command line:
 ```
 > cmake -LH ..
-```
-
-## Building on Unix (CMake)
-__Install Cmake with your distribution's package manager `apt-get`/`dnf`/etc__
-```
-$ mkdir build && cd build
-$ cmake .. # Default to Unix Makefiles
-$ make
-$ make verify # Optional
 ```
 
 ## CMake Variables

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@
 
 # 1. BUILDING AND INSTALLATION
 
-See [Documentation/Building#Autoconf](/Documentation/Building.md#autoconf) for more information
-
 ## CMake (Unix)
 
 ```
@@ -24,7 +22,7 @@ $ make
 $ make verify  # (optional)
 ```
 
-See [Documentation/Building#Building on Unix (With CMake)](/Documentation/Building.md#building-on-unix-cmake) for more information
+See [Documentation/Building#Building on Unix (With CMake)](/Documentation/Building.md#building-on-unix-cmake) for more information.
 
 ## CMake (Windows)
 
@@ -36,7 +34,7 @@ $ cmake -G "Visual Studio 10" ..   # Or use any generator you want to use. Run c
 $ cmake --build . --config Release # Or "start libevent.sln" and build with menu in Visual Studio.
 ```
 
-See [Documentation/Building#Building on Windows](/Documentation/Building.md#building-on-windows) for more information
+See [Documentation/Building#Building on Windows](/Documentation/Building.md#building-on-windows) for more information.
 
 ## Package Managers
 
@@ -60,6 +58,8 @@ $ make
 $ make verify   # (optional)
 $ sudo make install
 ```
+
+See [Documentation/Building#Autoconf](/Documentation/Building.md#autoconf) for more information.
 
 # 2. USEFUL LINKS:
 

--- a/README.md
+++ b/README.md
@@ -15,23 +15,23 @@
 
 ## CMake (Unix)
 
-```
-$ mkdir build && cd build
-$ cmake ..     # Default to Unix Makefiles.
-$ make
-$ make verify  # (optional)
+```sh
+mkdir build && cd build
+cmake ..     # Default to Unix Makefiles.
+make
+make verify  # (optional)
 ```
 
-See [Documentation/Building#Building on Unix (With CMake)](/Documentation/Building.md#building-on-unix-cmake) for more information.
+See [Documentation/Building#Building on Unix using CMake](/Documentation/Building.md#building-on-unix-cmake) for more information.
 
 ## CMake (Windows)
 
 Install CMake: <https://www.cmake.org>
 
-```
-$ md build && cd build
-$ cmake -G "Visual Studio 10" ..   # Or use any generator you want to use. Run cmake --help for a list
-$ cmake --build . --config Release # Or "start libevent.sln" and build with menu in Visual Studio.
+```sh
+md build && cd build
+cmake -G "Visual Studio 10" ..   # Or use any generator you want to use. Run cmake --help for a list
+cmake --build . --config Release # Or "start libevent.sln" and build with menu in Visual Studio.
 ```
 
 See [Documentation/Building#Building on Windows](/Documentation/Building.md#building-on-windows) for more information.
@@ -39,12 +39,13 @@ See [Documentation/Building#Building on Windows](/Documentation/Building.md#buil
 ## Package Managers
 
 You can download and install libevent using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
-
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    ./vcpkg install libevent
+```sh
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install libevent
+```
 
 The libevent port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
@@ -52,11 +53,11 @@ The libevent port in vcpkg is kept up to date by Microsoft team members and comm
 
 *Note, since 2.2 it is deprecated*
 
-```
-$ ./configure
-$ make
-$ make verify   # (optional)
-$ sudo make install
+```sh
+./configure
+make
+make verify   # (optional)
+sudo make install
 ```
 
 See [Documentation/Building#Autoconf](/Documentation/Building.md#autoconf) for more information.
@@ -72,7 +73,7 @@ There's a pretty good work-in-progress manual up at
 For the latest development versions of Libevent, access our Git repository
 via
 
-```
+```sh
 $ git clone https://github.com/libevent/libevent.git
 ```
 
@@ -92,7 +93,7 @@ __Bugs, Features [RFC], and Issues__: https://github.com/libevent/libevent/issue
 There's also a libevent-users mailing list for talking about Libevent
 use and development: 
 
-<http://archives.seul.org/libevent/users/>
+<https://archives.seul.org/libevent/users/>
 
 # 3. ACKNOWLEDGMENTS
 


### PR DESCRIPTION
Minor changes to make it clearer that the autotools build is deprecated, and improve some formatting throughout the docs.