### PR TITLE
actions: use supported version of Ubuntu

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       checks: write  # for coverallsapp/github-action to create new checks
       contents: read  # for actions/checkout to fetch code
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2.0.0
       - name: Cache
@@ -56,7 +56,7 @@ jobs:
   abi-job:
     permissions:
       contents: write # for Git to git push
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     ## TODO: use docker image, but for now this is not possible without hacks
     ## due to even public registry require some authentication:
     ## - https://github.community/t5/GitHub-Actions/docker-pull-from-public-GitHub-Package-Registry-fail-with-quot/td-p/32782/page/5
@@ -121,7 +121,7 @@ jobs:
   doxygen-job:
     permissions:
       contents: write  # for Git to git push
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
 


### PR DESCRIPTION
It looks like these jobs are failing to run, because support for ubuntu-18.04 has been removed entirely (from April 3rd), see: https://github.com/actions/runner-images/issues/6002.

Migrate to `ubuntu-20.04`.

See also: https://github.com/libevent/libevent/actions/runs/4758640443:
> This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.
> The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002