### PR TITLE
ci: use OpenBSD 7.2 over 7.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -824,7 +824,7 @@ jobs:
           # 6.9 has some issues with autoconf/autotools [1].
           #   [1]: https://github.com/libevent/libevent/pull/1326#issuecomment-1229531718
           #"6.9",
-          "7.1",
+          "7.2",
         ]
         EVENT_MATRIX:
           - NONE
@@ -922,7 +922,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ["7.1"]
+        release: ["7.2"]
 
     steps:
       - uses: actions/checkout@v3
@@ -939,7 +939,7 @@ jobs:
         with:
           release: ${{ matrix.release }}
           prepare: |
-            pkg_add  mbedtls  python3 automake-1.16.3  autoconf-2.71  libtool pkgconf
+            pkg_add  mbedtls  python3 automake-1.16.5  autoconf-2.71  libtool pkgconf
           usesh: true
           run: |
             export AUTOMAKE_VERSION=1.16


### PR DESCRIPTION
In the most recent CI run, all the OpenBSD CI jobs failed, i.e https://github.com/libevent/libevent/actions/runs/4876367885/jobs/8699759831, this seems to be due to the fact that packages for 7.1 have been removed from https://cdn.openbsd.org/pub/OpenBSD/ (only has 7.2 & 7.3):
```bash
  Config file: openbsd-7.1.conf
  https://cdn.openbsd.org/pub/OpenBSD/7.1/packages/amd64/: no such dir
  Can't find rsync-3.2.3p0
  Couldn't install rsync-3.2.3p0
  exec shell: bash run.sh showDebugInfo
```

Switch to using 7.2, which is available, so that the CI will run.