### PR TITLE
ci: use newer actions/x versions for master jobs

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,9 +15,9 @@ jobs:
       contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v3
       - name: Cache
-        uses: actions/cache@v1.0.3
+        uses: actions/cache@v3
         with:
           path: build
           key: ${{ matrix.os }}-coverage-v2
@@ -43,7 +43,7 @@ jobs:
             make verify_coverage
 
       - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@v1.0.1
+        uses: coverallsapp/github-action@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./build/coverage.info.cleaned
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v3
 
       - name: Install Dependencies
         run:
@@ -126,7 +126,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v3
       - name: Install Depends
         run: |
           sudo apt install doxygen libmbedtls-dev


### PR DESCRIPTION
Now that the jobs are running again, a number of deprecation warnings have surfaced, i.e https://github.com/libevent/libevent/actions/runs/4876367881:
```bash
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2.0.0.
```

Looks like the most straightforward thing todo here is just use the newer version of various actions (which is also already the case for other CI jobs here).

Also move to the v1 tag for the coveralls job, rather than a pinned, much older version (the latest release is [1.2.5](https://github.com/coverallsapp/github-action/releases)).

Same again for actions/cache.