### PR TITLE
ssl: do not triger EOF if some data had been successfully read

### DIFF
--- a/bufferevent_mbedtls.c
+++ b/bufferevent_mbedtls.c
@@ -121,8 +121,9 @@ mbedtls_set_ssl_noops(void *ssl)
 {
 }
 static int
-mbedtls_is_ok(int err)
+mbedtls_handshake_is_ok(int err)
 {
+	/* What mbedtls_ssl_handshake() return on success */
 	return err == 0;
 }
 static int
@@ -320,7 +321,7 @@ static struct le_ssl_ops le_mbedtls_ops = {
 	mbedtls_clear,
 	mbedtls_set_ssl_noops,
 	mbedtls_set_ssl_noops,
-	mbedtls_is_ok,
+	mbedtls_handshake_is_ok,
 	mbedtls_is_want_read,
 	mbedtls_is_want_write,
 	be_mbedtls_get_fd,

--- a/bufferevent_mbedtls.c
+++ b/bufferevent_mbedtls.c
@@ -136,6 +136,11 @@ mbedtls_is_want_write(int err)
 {
 	return err == MBEDTLS_ERR_SSL_WANT_WRITE;
 }
+static int mbedtls_err_is_ok(int err)
+{
+	/* What mbedtls_ssl_read() returns when the we can proceed existing data */
+	return err == 0;
+}
 
 static evutil_socket_t
 be_mbedtls_get_fd(void *ssl)
@@ -324,6 +329,7 @@ static struct le_ssl_ops le_mbedtls_ops = {
 	mbedtls_handshake_is_ok,
 	mbedtls_is_want_read,
 	mbedtls_is_want_write,
+	mbedtls_err_is_ok,
 	be_mbedtls_get_fd,
 	be_mbedtls_bio_set_fd,
 	(void (*)(struct bufferevent_ssl *))mbedtls_set_ssl_noops,

--- a/bufferevent_openssl.c
+++ b/bufferevent_openssl.c
@@ -346,6 +346,13 @@ SSL_handshake_is_ok(int err)
 }
 
 static int
+SSL_err_is_ok(int err)
+{
+	/* What SSL_read() returns when the we can proceed existing data */
+	return err == SSL_ERROR_ZERO_RETURN;
+}
+
+static int
 SSL_is_want_read(int err)
 {
 	return err == SSL_ERROR_WANT_READ;
@@ -417,6 +424,7 @@ static struct le_ssl_ops le_openssl_ops = {
 	SSL_handshake_is_ok,
 	SSL_is_want_read,
 	SSL_is_want_write,
+	SSL_err_is_ok,
 	(int (*)(void *))be_openssl_get_fd,
 	be_openssl_bio_set_fd,
 	init_bio_counts,

--- a/bufferevent_openssl.c
+++ b/bufferevent_openssl.c
@@ -339,8 +339,9 @@ SSL_context_free(void *ssl, int flags)
 }
 
 static int
-SSL_is_ok(int err)
+SSL_handshake_is_ok(int err)
 {
+	/* What SSL_do_handshake() return on success */
 	return err == 1;
 }
 
@@ -413,7 +414,7 @@ static struct le_ssl_ops le_openssl_ops = {
 	(int (*)(void *))SSL_clear,
 	(void (*)(void *))SSL_set_connect_state,
 	(void (*)(void *))SSL_set_accept_state,
-	SSL_is_ok,
+	SSL_handshake_is_ok,
 	SSL_is_want_read,
 	SSL_is_want_write,
 	(int (*)(void *))be_openssl_get_fd,

--- a/bufferevent_ssl.c
+++ b/bufferevent_ssl.c
@@ -284,7 +284,10 @@ do_read(struct bufferevent_ssl *bev_ssl, int n_to_read) {
 		} else {
 			int err = bev_ssl->ssl_ops->get_error(bev_ssl->ssl, r);
 			bev_ssl->ssl_ops->print_err(err);
-			if (bev_ssl->ssl_ops->err_is_want_read(err)) {
+			if (bev_ssl->ssl_ops->err_is_ok(err) && result & OP_MADE_PROGRESS) {
+				/* Process existing data */
+				break;
+			} else if (bev_ssl->ssl_ops->err_is_want_read(err)) {
 				/* Can't read until underlying has more data. */
 				if (bev_ssl->read_blocked_on_write)
 					if (clear_rbow(bev_ssl) < 0)

--- a/bufferevent_ssl.c
+++ b/bufferevent_ssl.c
@@ -706,7 +706,7 @@ do_handshake(struct bufferevent_ssl *bev_ssl)
 	}
 	bev_ssl->ssl_ops->decrement_buckets(bev_ssl);
 
-	if (bev_ssl->ssl_ops->err_is_ok(r)) {
+	if (bev_ssl->ssl_ops->handshake_is_ok(r)) {
 		evutil_socket_t fd = event_get_fd(&bev_ssl->bev.bev.ev_read);
 		/* We're done! */
 		bev_ssl->state = BUFFEREVENT_SSL_OPEN;

--- a/ssl-compat.h
+++ b/ssl-compat.h
@@ -20,7 +20,7 @@ struct le_ssl_ops {
 	int (*clear)(void *ssl);
 	void (*set_connect_state)(void *ssl);
 	void (*set_accept_state)(void *ssl);
-	int (*err_is_ok)(int err);
+	int (*handshake_is_ok)(int err);
 	int (*err_is_want_read)(int err);
 	int (*err_is_want_write)(int err);
 	evutil_socket_t (*get_fd)(void *ssl);

--- a/ssl-compat.h
+++ b/ssl-compat.h
@@ -23,6 +23,7 @@ struct le_ssl_ops {
 	int (*handshake_is_ok)(int err);
 	int (*err_is_want_read)(int err);
 	int (*err_is_want_write)(int err);
+	int (*err_is_ok)(int err);
 	evutil_socket_t (*get_fd)(void *ssl);
 	int (*bio_set_fd)(struct bufferevent_ssl *ssl, evutil_socket_t fd);
 	void (*init_bio_counts)(struct bufferevent_ssl *bev);


### PR DESCRIPTION
Previously in case when evbuffer_reserve_space() returns > 1, but
it was able to read only 1 IO vector, it will try to read the next one,
got 0 (EOF for mbedTLS or SSL_ERROR_ZERO_RETURN for OpenSSL) and will
trigger EOF, while instead, it should trigger EV_READ w/o EOF and only
after EOF.