### PR TITLE
More SSL_read() to fill big buffer

### DIFF
--- a/bufferevent_mbedtls.c
+++ b/bufferevent_mbedtls.c
@@ -136,11 +136,6 @@ mbedtls_is_want_write(int err)
 {
 	return err == MBEDTLS_ERR_SSL_WANT_WRITE;
 }
-static int mbedtls_err_is_ok(int err)
-{
-	/* What mbedtls_ssl_read() returns when the we can proceed existing data */
-	return err == 0;
-}
 
 static evutil_socket_t
 be_mbedtls_get_fd(void *ssl)
@@ -329,7 +324,6 @@ static struct le_ssl_ops le_mbedtls_ops = {
 	mbedtls_handshake_is_ok,
 	mbedtls_is_want_read,
 	mbedtls_is_want_write,
-	mbedtls_err_is_ok,
 	be_mbedtls_get_fd,
 	be_mbedtls_bio_set_fd,
 	(void (*)(struct bufferevent_ssl *))mbedtls_set_ssl_noops,

--- a/bufferevent_openssl.c
+++ b/bufferevent_openssl.c
@@ -346,13 +346,6 @@ SSL_handshake_is_ok(int err)
 }
 
 static int
-SSL_err_is_ok(int err)
-{
-	/* What SSL_read() returns when the we can proceed existing data */
-	return err == SSL_ERROR_ZERO_RETURN;
-}
-
-static int
 SSL_is_want_read(int err)
 {
 	return err == SSL_ERROR_WANT_READ;
@@ -424,7 +417,6 @@ static struct le_ssl_ops le_openssl_ops = {
 	SSL_handshake_is_ok,
 	SSL_is_want_read,
 	SSL_is_want_write,
-	SSL_err_is_ok,
 	(int (*)(void *))be_openssl_get_fd,
 	be_openssl_bio_set_fd,
 	init_bio_counts,

--- a/bufferevent_ssl.c
+++ b/bufferevent_ssl.c
@@ -407,8 +407,6 @@ do_write(struct bufferevent_ssl *bev_ssl, int atmost)
 
 #define WRITE_FRAME 15000
 
-#define READ_DEFAULT 4096
-
 /* Try to figure out how many bytes to read; return 0 if we shouldn't be
  * reading. */
 static int
@@ -416,7 +414,7 @@ bytes_to_read(struct bufferevent_ssl *bev)
 {
 	struct evbuffer *input = bev->bev.bev.input;
 	struct event_watermark *wm = &bev->bev.bev.wm_read;
-	int result = READ_DEFAULT;
+	int result = 0;
 	ev_ssize_t limit;
 	/* XXX 99% of this is generic code that nearly all bufferevents will
 	 * want. */
@@ -439,13 +437,11 @@ bytes_to_read(struct bufferevent_ssl *bev)
 		}
 
 		result = wm->high - evbuffer_get_length(input);
-	} else {
-		result = READ_DEFAULT;
 	}
 
 	/* Respect the rate limit */
 	limit = bufferevent_get_read_max_(&bev->bev);
-	if (result > limit) {
+	if (result == 0 || result > limit) {
 		result = limit;
 	}
 

--- a/ssl-compat.h
+++ b/ssl-compat.h
@@ -23,7 +23,6 @@ struct le_ssl_ops {
 	int (*handshake_is_ok)(int err);
 	int (*err_is_want_read)(int err);
 	int (*err_is_want_write)(int err);
-	int (*err_is_ok)(int err);
 	evutil_socket_t (*get_fd)(void *ssl);
 	int (*bio_set_fd)(struct bufferevent_ssl *ssl, evutil_socket_t fd);
 	void (*init_bio_counts)(struct bufferevent_ssl *bev);


### PR DESCRIPTION
Once SSL_read() only get max 16K bytes (one TLS record).
In case of big buffer, should more SSL_read() to fill the buffer.

Fixes: #1446