### PR TITLE
Fix cache keys on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,16 +59,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Repository info
+        id: repository-info
+        run: echo "tag=$(git describe --abbrev=0)" >> $GITHUB_OUTPUT
+        shell: bash
       - name: Cache Build
         uses: actions/cache@v3
         with:
           path: build
-          key: ${{ matrix.os }}-cmake-${{ matrix.EVENT_MATRIX }}-v3
+          key: ${{ matrix.os }}-cmake-${{ matrix.EVENT_MATRIX }}-${{ steps.repository-info.outputs.tag }}
       - name: Cache Dist Build
         uses: actions/cache@v3
         with:
           path: dist
-          key: ${{ matrix.os }}-cmake-dist-${{ matrix.EVENT_MATRIX }}-v3
+          key: ${{ matrix.os }}-cmake-dist-${{ matrix.EVENT_MATRIX }}-${{ steps.repository-info.outputs.tag }}
 
       - name: Install Depends
         run: |
@@ -178,11 +182,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Repository info
+        id: repository-info
+        run: echo "tag=$(git describe --abbrev=0)" >> $GITHUB_OUTPUT
+        shell: bash
       - name: Cache Build
         uses: actions/cache@v3
         with:
           path: dist
-          key: ${{ matrix.os }}-autotools-${{ matrix.EVENT_MATRIX }}-v3
+          key: ${{ matrix.os }}-autotools-${{ steps.repository-info.outputs.tag }}
 
       - name: Install Depends
         run: |
@@ -229,7 +237,7 @@ jobs:
       - uses: actions/upload-artifact@v1
         if: failure()
         with:
-          name: ${{ matrix.os }}-autotools-${{ matrix.EVENT_MATRIX }}-dist
+          name: ${{ matrix.os }}-autotools-dist
           path: dist
 
   windows-vs2019-job:
@@ -254,12 +262,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
+      - name: Repository info
+        id: repository-info
+        run: echo "tag=$(git describe --abbrev=0)" >> $GITHUB_OUTPUT
+        shell: bash
       - name: Cache Build
         uses: actions/cache@v3
         with:
           path: build
-          key: ${{ matrix.os }}-${{ matrix.EVENT_MATRIX }}-v4
+          key: ${{ matrix.os }}-${{ matrix.EVENT_MATRIX }}-${{ steps.repository-info.outputs.tag }}
 
       - name: Prepare vcpkg
         uses: lukka/run-vcpkg@v7
@@ -383,11 +394,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Repository info
+        id: repository-info
+        run: echo "tag=$(git describe --abbrev=0)" >> $GITHUB_OUTPUT
+        shell: bash
       - name: Cache Build
         uses: actions/cache@v3
         with:
           path: build
-          key: mingw-autotools-v5
+          key: mingw-autotools-${{ steps.repository-info.outputs.tag }}
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         with:
@@ -454,11 +469,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Repository info
+        id: repository-info
+        run: echo "tag=$(git describe --abbrev=0)" >> $GITHUB_OUTPUT
+        shell: bash
       - name: Cache Build
         uses: actions/cache@v3
         with:
           path: build
-          key: mingw-cmake-${{ matrix.EVENT_MATRIX }}-v4
+          key: mingw-cmake-${{ matrix.EVENT_MATRIX }}-${{ steps.repository-info.outputs.tag }}
 
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
@@ -540,12 +559,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
+      - name: Repository info
+        id: repository-info
+        run: echo "tag=$(git describe --abbrev=0)" >> $GITHUB_OUTPUT
+        shell: bash
       - name: Cache Build
         uses: actions/cache@v3
         with:
           path: build
-          key: ${{ matrix.os }}-cmake-${{ matrix.EVENT_MATRIX }}-v3
+          key: ${{ matrix.os }}-cmake-${{ matrix.EVENT_MATRIX }}-${{ steps.repository-info.outputs.tag }}
 
       - name: Install Depends
         run: brew install mbedtls@2
@@ -625,12 +647,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
+      - name: Repository info
+        id: repository-info
+        run: echo "tag=$(git describe --abbrev=0)" >> $GITHUB_OUTPUT
+        shell: bash
       - name: Cache Build
         uses: actions/cache@v3
         with:
           path: build
-          key: ${{ matrix.os }}-autotools-v3
+          key: ${{ matrix.os }}-autotools-${{ steps.repository-info.outputs.tag }}
 
       - name: Install Depends
         run: brew install autoconf automake libtool pkg-config mbedtls@2
@@ -686,12 +711,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
+      - name: Repository info
+        id: repository-info
+        run: echo "tag=$(git describe --abbrev=0)" >> $GITHUB_OUTPUT
+        shell: bash
       - name: Cache Build
         uses: actions/cache@v3
         with:
           path: build
-          key: freebsd-${{ matrix.release }}-cmake-${{ matrix.EVENT_MATRIX }}-v1
+          key: freebsd-${{ matrix.release }}-cmake-${{ matrix.EVENT_MATRIX }}-${{ steps.repository-info.outputs.tag }}
 
       - name: Build
         uses: vmactions/freebsd-vm@v0
@@ -771,14 +799,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
+      - name: Repository info
+        id: repository-info
+        run: echo "tag=$(git describe --abbrev=0)" >> $GITHUB_OUTPUT
+        shell: bash
       - name: Cache Build
         uses: actions/cache@v3
         with:
           path: build
-          key: freebsd-${{ matrix.release }}-autotools-v1
-
-
+          key: freebsd-${{ matrix.release }}-autotools-${{ steps.repository-info.outputs.tag }}
       - name: Build
         uses: vmactions/freebsd-vm@v0
         with:
@@ -841,12 +870,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
+      - name: Repository info
+        id: repository-info
+        run: echo "tag=$(git describe --abbrev=0)" >> $GITHUB_OUTPUT
+        shell: bash
       - name: Cache Build
         uses: actions/cache@v3
         with:
           path: build
-          key: openbsd-${{ matrix.release }}-cmake-${{ matrix.EVENT_MATRIX }}-v1
+          key: openbsd-${{ matrix.release }}-cmake-${{ matrix.EVENT_MATRIX }}-${{ steps.repository-info.outputs.tag }}
 
       - name: Build
         uses: vmactions/openbsd-vm@v0
@@ -926,13 +958,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
+      - name: Repository info
+        id: repository-info
+        run: echo "tag=$(git describe --abbrev=0)" >> $GITHUB_OUTPUT
+        shell: bash
       - name: Cache Build
         uses: actions/cache@v3
         with:
           path: build
-          key: openbsd-${{ matrix.release }}-autotools-v1
-
+          key: openbsd-${{ matrix.release }}-autotools-${{ steps.repository-info.outputs.tag }}
 
       - name: Build
         uses: vmactions/openbsd-vm@v0

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,11 +16,15 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+      - name: Repository info
+        id: repository-info
+        run: echo "tag=$(git describe --abbrev=0)" >> $GITHUB_OUTPUT
+        shell: bash
       - name: Cache
         uses: actions/cache@v3
         with:
           path: build
-          key: ${{ matrix.os }}-coverage-v2
+          key: ${{ matrix.os }}-coverage-${{ steps.repository-info.outputs.tag }}
 
       - name: Install Depends
         run: sudo apt install zlib1g-dev libssl-dev build-essential lcov libmbedtls-dev


### PR DESCRIPTION
We use cache to make cmake runs faster, but this can break things, since this will preserve all cmake cached variables, and it may not be updated again.

And this is indeed what happened after the release [1], and this breaks `main/version` test, first of all it reports 2.2.0, while it should be 2.2.1:

    --         ---( Libevent 2.2.0-alpha-dev )---

And then the test fails:

    FAIL /home/runner/work/libevent/libevent/dist/libevent-2.2.1-alpha-dev/test/regress.c:2632: assert((vint&0xffffff00) == ((major<<24)|(minor<<16)|(patch<<8))): 33685760 vs 33685504main/version: 1/432 TESTS FAILED. (42 skipped)

  [1]: https://github.com/libevent/libevent/actions/runs/5036614539/jobs/9032892960#step:7:503

So for now I've added the tag name that assosiated with the commit, to avoid this situation.

Also AFAIR it was significant to use cache for cmake, but next step will be to remove it completelly..