### PR TITLE
build: fix some new warnings

### DIFF
--- a/sample/ws-chat-server.c
+++ b/sample/ws-chat-server.c
@@ -250,4 +250,6 @@ main(int argc, char **argv)
 	event_free(sig_int);
 	event_base_free(base);
 	libevent_global_shutdown();
+
+	return 0;
 }


### PR DESCRIPTION
/opensource/libevent/sample/ws-chat-server.c:253:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^