### PR TITLE
Add option to auto-detect OpenSSL and MbedTLS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
           - DIST
           - NONE
           - NO_SSL
+          - REQUIRE_SSL
           - DISABLE_OPENSSL
           - DISABLE_THREAD_SUPPORT
           - DISABLE_DEBUG_MODE
@@ -94,6 +95,8 @@ jobs:
             EVENT_CMAKE_OPTIONS="-DEVENT__DISABLE_OPENSSL=ON"
           elif [ "${{ matrix.EVENT_MATRIX }}" == "NO_SSL" ]; then
             EVENT_CMAKE_OPTIONS="-DEVENT__DISABLE_OPENSSL=ON -DEVENT__DISABLE_MBEDTLS=ON"
+          elif [ "${{ matrix.EVENT_MATRIX }}" == "REQUIRE_SSL" ]; then
+            EVENT_CMAKE_OPTIONS="-DEVENT__DISABLE_OPENSSL=OFF -DEVENT__DISABLE_MBEDTLS=OFF"
           elif [ "${{ matrix.EVENT_MATRIX }}" == "DISABLE_THREAD_SUPPORT" ]; then
             EVENT_CMAKE_OPTIONS="-DEVENT__DISABLE_THREAD_SUPPORT=ON"
           elif [ "${{ matrix.EVENT_MATRIX }}" == "DISABLE_DEBUG_MODE" ]; then

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,7 +31,7 @@ jobs:
             export JOBS=20
             mkdir -p build
             cd build
-            cmake .. -DEVENT__COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug
+            cmake .. -DEVENT__COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug -DEVENT__DISABLE_OPENSSL=OFF
             make -j $JOBS
 
       - name: Test
@@ -136,7 +136,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DEVENT__DOXYGEN=ON ..
+          cmake -DEVENT__DOXYGEN=ON -DEVENT__DISABLE_OPENSSL=OFF ..
           make doxygen
 
       - name: Deploy Documentation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,11 +135,13 @@ option(EVENT__DISABLE_MM_REPLACEMENT
 option(EVENT__DISABLE_THREAD_SUPPORT
     "Define if libevent should not be compiled with thread support" OFF)
 
-option(EVENT__DISABLE_OPENSSL
-    "Define if libevent should build without support for OpenSSL encryption" OFF)
+set(EVENT__DISABLE_OPENSSL AUTO CACHE STRING
+    "OpenSSL library support: AUTO (use if present), ON (ignore), OFF (require presence)")
+set_property(CACHE EVENT__DISABLE_OPENSSL PROPERTY STRINGS AUTO ON OFF)
 
-option(EVENT__DISABLE_MBEDTLS
-    "Define if libevent should build without support for mbed TLS encryption" OFF)
+set(EVENT__DISABLE_MBEDTLS AUTO CACHE STRING
+    "Mbed TLS library support: AUTO (use if present), ON (ignore), OFF (require presence)")
+set_property(CACHE EVENT__DISABLE_MBEDTLS PROPERTY STRINGS AUTO ON OFF)
 
 option(EVENT__DISABLE_BENCHMARK
     "Defines if libevent should build without the benchmark executables" OFF)
@@ -938,7 +940,7 @@ if(EVENT__HAVE_EVENT_PORTS)
     list(APPEND SRC_CORE evport.c)
 endif()
 
-if (NOT EVENT__DISABLE_OPENSSL)
+if (EVENT__DISABLE_OPENSSL STREQUAL "OFF" OR EVENT__DISABLE_OPENSSL STREQUAL "AUTO")
     # only if OPENSSL_ROOT_DIR is not set yet
     if (BREW AND NOT OPENSSL_ROOT_DIR AND NOT "$ENV{OPENSSL_ROOT_DIR}")
         execute_process(COMMAND ${BREW} --prefix openssl
@@ -953,20 +955,28 @@ if (NOT EVENT__DISABLE_OPENSSL)
         endif()
     endif()
 
-    find_package(OpenSSL REQUIRED)
+    find_package(OpenSSL)
 
-    set(EVENT__HAVE_OPENSSL 1)
-    set(OPENSSL_TARGETS OpenSSL::SSL)
+    if (OPENSSL_FOUND)
+        set(EVENT__HAVE_OPENSSL 1)
+        set(OPENSSL_TARGETS OpenSSL::SSL)
 
-    message(STATUS "OpenSSL include: ${OPENSSL_INCLUDE_DIR}")
-    message(STATUS "OpenSSL lib: ${OPENSSL_LIBRARIES}")
+        message(STATUS "OpenSSL include: ${OPENSSL_INCLUDE_DIR}")
+        message(STATUS "OpenSSL lib: ${OPENSSL_LIBRARIES}")
 
-    list(APPEND SRC_OPENSSL bufferevent_openssl.c bufferevent_ssl.c)
-    list(APPEND HDR_PUBLIC include/event2/bufferevent_ssl.h)
-    list(APPEND LIB_APPS ${OPENSSL_TARGETS})
+        list(APPEND SRC_OPENSSL bufferevent_openssl.c bufferevent_ssl.c)
+        list(APPEND HDR_PUBLIC include/event2/bufferevent_ssl.h)
+        list(APPEND LIB_APPS ${OPENSSL_TARGETS})
+    elseif (EVENT__DISABLE_OPENSSL STREQUAL "OFF")
+        message(FATAL_ERROR "OpenSSL required, but not found.")
+    endif()
+elseif (EVENT__DISABLE_OPENSSL STREQUAL "ON")
+    message(STATUS "Disable OpenSSL support")
+else()
+    message(FATAL_ERROR "EVENT__DISABLE_OPENSSL must be set to one of: AUTO, ON or OFF")
 endif()
 
-if (NOT EVENT__DISABLE_MBEDTLS)
+if (EVENT__DISABLE_MBEDTLS STREQUAL "OFF" OR EVENT__DISABLE_MBEDTLS STREQUAL "AUTO")
     # only if MBEDTLS_ROOT_DIR is not set yet
     if (BREW AND NOT MBEDTLS_ROOT_DIR AND NOT "$ENV{MBEDTLS_ROOT_DIR}")
         execute_process(COMMAND ${BREW} --prefix mbedtls
@@ -981,17 +991,25 @@ if (NOT EVENT__DISABLE_MBEDTLS)
         endif()
     endif()
 
-    find_package(MbedTLS REQUIRED)
+    find_package(MbedTLS)
 
-    set(EVENT__HAVE_MBEDTLS 1)
-    set(MBEDTLS_TARGETS MbedTLS::mbedtls MbedTLS::mbedcrypto MbedTLS::mbedx509)
+    if (MBEDTLS_FOUND)
+        set(EVENT__HAVE_MBEDTLS 1)
+        set(MBEDTLS_TARGETS MbedTLS::mbedtls MbedTLS::mbedcrypto MbedTLS::mbedx509)
 
-    message(STATUS "mbed TLS include: ${MBEDTLS_INCLUDE_DIR}")
-    message(STATUS "mbed TLS lib: ${MBEDTLS_LIBRARIES}")
+        message(STATUS "mbed TLS include: ${MBEDTLS_INCLUDE_DIR}")
+        message(STATUS "mbed TLS lib: ${MBEDTLS_LIBRARIES}")
 
-    list(APPEND SRC_MBEDTLS bufferevent_mbedtls.c bufferevent_ssl.c)
-    list(APPEND HDR_PUBLIC include/event2/bufferevent_ssl.h)
-    list(APPEND LIB_APPS ${MBEDTLS_TARGETS})
+        list(APPEND SRC_MBEDTLS bufferevent_mbedtls.c bufferevent_ssl.c)
+        list(APPEND HDR_PUBLIC include/event2/bufferevent_ssl.h)
+        list(APPEND LIB_APPS ${MBEDTLS_TARGETS})
+    elseif (EVENT__DISABLE_MBEDTLS STREQUAL "OFF")
+        message(FATAL_ERROR "MbedTLS required, but not found.")
+    endif()
+elseif (EVENT__DISABLE_MBEDTLS STREQUAL "ON")
+    message(STATUS "Disable MbedTLS support")
+else()
+    message(FATAL_ERROR "EVENT__DISABLE_MBEDTLS must be set to one of: AUTO, ON or OFF")
 endif()
 
 if (NOT EVENT__DISABLE_TESTS)
@@ -1087,14 +1105,14 @@ add_event_library(event_extra
     INNER_LIBRARIES event_core
     SOURCES ${SRC_EXTRA})
 
-if (NOT EVENT__DISABLE_OPENSSL)
+if (EVENT__HAVE_OPENSSL)
     add_event_library(event_openssl
         INNER_LIBRARIES event_core
         LIBRARIES ${OPENSSL_TARGETS}
         SOURCES ${SRC_OPENSSL})
 endif()
 
-if (NOT EVENT__DISABLE_MBEDTLS)
+if (EVENT__HAVE_MBEDTLS)
     add_event_library(event_mbedtls
         INNER_LIBRARIES event_core
         LIBRARIES ${MBEDTLS_TARGETS}
@@ -1168,7 +1186,7 @@ if (NOT EVENT__DISABLE_SAMPLES)
         target_link_libraries(watch-timing m)
     endif()
 
-    if (NOT EVENT__DISABLE_OPENSSL)
+    if (EVENT__HAVE_OPENSSL)
         add_sample_prog(event_openssl https-client
                         sample/https-client.c
                         sample/openssl_hostname_validation.c
@@ -1178,7 +1196,7 @@ if (NOT EVENT__DISABLE_SAMPLES)
         add_sample_prog(event_openssl becat sample/becat.c ${WIN32_GETOPT})
     endif()
 
-    if (NOT EVENT__DISABLE_MBEDTLS)
+    if (EVENT__HAVE_MBEDTLS)
         add_sample_prog(event_mbedtls https-client-mbedtls
                 sample/https-client.c)
         target_compile_definitions(https-client-mbedtls PRIVATE USE_MBEDTLS)
@@ -1298,11 +1316,11 @@ if (NOT EVENT__DISABLE_TESTS)
                 list(APPEND SRC_REGRESS test/regress_zlib.c)
             endif()
 
-            if (NOT EVENT__DISABLE_OPENSSL)
+            if (EVENT__HAVE_OPENSSL)
                 list(APPEND SRC_REGRESS test/regress_openssl.c)
             endif()
 
-            if (NOT EVENT__DISABLE_MBEDTLS)
+            if (EVENT__HAVE_MBEDTLS)
                 list(APPEND SRC_REGRESS test/regress_mbedtls.c)
             endif()
 
@@ -1313,10 +1331,10 @@ if (NOT EVENT__DISABLE_TESTS)
                                   ${LIB_PLATFORM}
                                   event_core
                                   event_extra)
-            if (NOT EVENT__DISABLE_OPENSSL)
+            if (EVENT__HAVE_OPENSSL)
                 target_link_libraries(regress event_openssl)
             endif()
-            if (NOT EVENT__DISABLE_MBEDTLS)
+            if (EVENT__HAVE_MBEDTLS)
                 target_link_libraries(regress event_mbedtls)
             endif()
             if (PTHREADS_AVAILABLE)

--- a/configure.ac
+++ b/configure.ac
@@ -56,10 +56,10 @@ AC_ARG_ENABLE([malloc-replacement],
     [], [enable_malloc_replacement=yes])
 AC_ARG_ENABLE([openssl],
      AS_HELP_STRING([--disable-openssl, disable support for openssl encryption]),
-    [], [enable_openssl=yes])
+    [], [enable_openssl=auto])
 AC_ARG_ENABLE([mbedtls],
      AS_HELP_STRING([--disable-mbedtls, disable support for mbedtls encryption]),
-    [], [enable_mbedtls=yes])
+    [], [enable_mbedtls=auto])
 AC_ARG_ENABLE([debug-mode],
      AS_HELP_STRING([--disable-debug-mode, disable support for running in debug mode]),
     [], [enable_debug_mode=yes])
@@ -716,12 +716,6 @@ dnl check if we should enable verbose debugging
 if test "$enable_verbose_debug" = "yes"; then
 	CFLAGS="$CFLAGS -DUSE_DEBUG"
 fi
-
-dnl check if we have and should use OpenSSL
-AM_CONDITIONAL(OPENSSL, [test "$enable_openssl" != "no" && test "$have_openssl" = "yes"])
-
-# check if we have and should use mbedtls
-AM_CONDITIONAL(MBEDTLS, [test "$enable_mbedtls" != "no" && test "$have_mbedtls" = "yes"])
 
 dnl enable some warnings by default
 AX_CHECK_COMPILE_FLAG([-Wall], [CFLAGS="$CFLAGS -Wall"],[],[-Werror])

--- a/m4/libevent_mbedtls.m4
+++ b/m4/libevent_mbedtls.m4
@@ -18,7 +18,6 @@ case "$enable_mbedtls" in
                    [have_mbedtls=no],
                    [-lmbedtls -lmbedcrypto -lmbedx509 $EV_LIB_GDI $EV_LIB_WS32])
     LIBS="$save_LIBS"
-    test "$have_mbedtls" = "yes" && break
     esac
     CPPFLAGS_SAVE=$CPPFLAGS
     CPPFLAGS="$CPPFLAGS $MBEDTLS_INCS"

--- a/m4/libevent_mbedtls.m4
+++ b/m4/libevent_mbedtls.m4
@@ -3,7 +3,7 @@ dnl mbedtls support
 AC_DEFUN([LIBEVENT_MBEDTLS], [
 
 case "$enable_mbedtls" in
- yes)
+ auto|yes)
     case "$have_mbedtls" in
      yes) ;;
      *)
@@ -25,12 +25,16 @@ case "$enable_mbedtls" in
     CPPFLAGS=$CPPFLAGS_SAVE
     AC_SUBST(MBEDTLS_INCS)
     AC_SUBST(MBEDTLS_LIBS)
-    case "$have_mbedtls" in
-     yes)  AC_DEFINE(HAVE_MBEDTLS, 1, [Define if the system has mbedtls]) ;;
-    esac
+    if test "$have_mbedtls" = "yes" ; then
+        AC_DEFINE(HAVE_MBEDTLS, 1, [Define if the system has mbedtls])
+    elif test "$enable_mbedtls" = "yes" ; then
+        AC_MSG_ERROR([MBedTLS could not be found. You should add the directories \
+                      containing mbedtls/ssl.h and libmbedtls to the appropriate \
+                      compiler and linker search paths.])
+    fi
     ;;
 esac
 
 # check if we have and should use mbedtls
-AM_CONDITIONAL(MBEDTLS, [test "$enable_mbedtls" != "no" && test "$have_mbedtls" = "yes"])
+AM_CONDITIONAL(MBEDTLS, [test "$have_mbedtls" = "yes"])
 ])

--- a/m4/libevent_openssl.m4
+++ b/m4/libevent_openssl.m4
@@ -41,7 +41,7 @@ case "$host_os" in
 esac
 
 case "$enable_openssl" in
- yes)
+ auto|yes)
     have_openssl=no
     case "$PKG_CONFIG" in
      '')
@@ -84,17 +84,17 @@ case "$enable_openssl" in
     CPPFLAGS=$CPPFLAGS_SAVE
     AC_SUBST(OPENSSL_INCS)
     AC_SUBST(OPENSSL_LIBS)
-    case "$have_openssl" in
-     yes)  AC_DEFINE(HAVE_OPENSSL, 1, [Define if the system has openssl]) ;;
-     *) AC_MSG_ERROR([OpenSSL could not be found. You should add the directory \
-     containing 'openssl.pc' to the 'PKG_CONFIG_PATH' environment variable, set \
-     'CFLAGS' and 'LDFLAGS' directly, or use '--disable-openssl' to disable \
-     support for OpenSSL encryption])
-	;;
-    esac
+    if test "$have_openssl" = "yes" ; then
+        AC_DEFINE(HAVE_OPENSSL, 1, [Define if the system has openssl])
+    elif test "$enable_openssl" = "yes" ; then
+        AC_MSG_ERROR([OpenSSL could not be found. You should add the directory \
+            containing 'openssl.pc' to the 'PKG_CONFIG_PATH' environment variable, set \
+            'CFLAGS' and 'LDFLAGS' directly, or use '--disable-openssl' to disable \
+            support for OpenSSL encryption])
+    fi
     ;;
 esac
 
 dnl check if we have and should use OpenSSL
-AM_CONDITIONAL(OPENSSL, [test "$enable_openssl" != "no" && test "$have_openssl" = "yes"])
+AM_CONDITIONAL(OPENSSL, [test "$have_openssl" = "yes"])
 ])


### PR DESCRIPTION
Both cmake and autoconf are capable of automatically detecting the presence of OpenSSL and MbedTLS.  However, the present build time logic doesn't do this.

With cmake, my starting point is to preserve the reversed logic of `EVENT__DISABLE_OPENSSL` and `EVENT__DISABLE_MBEDTLS`, adding a third option `AUTO` as the new default.  I'm following the pattern of this [post on the cmake list](https://cmake.org/pipermail/cmake/2016-October/064342.html).  `OFF` and `ON` should continue with their present behaviors.

With autoconf, I've tried to implement what I understand to be conventional behavior.  eg. `--enable-openssl` and `--disable-openssl` should continue to have the same effect.  The default if neither is passed is equivalent to the new `--enable-openssl=auto`.

I've also added another commit removing what I think is an unnecessary `break` in `m4/libevent_mbedtls.m4`, which I suspect is leftover from some copy+paste from `m4/libevent_openssl.m4`.  Surprisingly to me, a `break` outside of any loop does not seem to be treated as an error.