### PR TITLE
Wepoll: replace default malloc/free with libevent mm_ variants

### DIFF
--- a/wepoll.c
+++ b/wepoll.c
@@ -32,6 +32,7 @@
 #define WEPOLL_EXPORT
 
 #include <stdint.h>
+#include "mm-internal.h"
 
 enum EPOLL_EVENTS {
   EPOLLIN      = (int) (1U <<  0),
@@ -961,7 +962,7 @@ static poll_group_t* poll_group__new(port_state_t* port_state) {
   HANDLE iocp_handle = port_get_iocp_handle(port_state);
   queue_t* poll_group_queue = port_get_poll_group_queue(port_state);
 
-  poll_group_t* poll_group = malloc(sizeof *poll_group);
+  poll_group_t* poll_group = mm_malloc(sizeof *poll_group);
   if (poll_group == NULL)
     return_set_error(NULL, ERROR_NOT_ENOUGH_MEMORY);
 
@@ -972,7 +973,7 @@ static poll_group_t* poll_group__new(port_state_t* port_state) {
 
   if (afd_create_helper_handle(iocp_handle, &poll_group->afd_helper_handle) <
       0) {
-    free(poll_group);
+    mm_free(poll_group);
     return NULL;
   }
 
@@ -985,7 +986,7 @@ void poll_group_delete(poll_group_t* poll_group) {
   assert(poll_group->group_size == 0);
   CloseHandle(poll_group->afd_helper_handle);
   queue_remove(&poll_group->queue_node);
-  free(poll_group);
+  mm_free(poll_group);
 }
 
 poll_group_t* poll_group_from_queue_node(queue_node_t* queue_node) {
@@ -1067,7 +1068,7 @@ typedef struct port_state {
 } port_state_t;
 
 static port_state_t* port__alloc(void) {
-  port_state_t* port_state = malloc(sizeof *port_state);
+  port_state_t* port_state = mm_malloc(sizeof *port_state);
   if (port_state == NULL)
     return_set_error(NULL, ERROR_NOT_ENOUGH_MEMORY);
 
@@ -1076,7 +1077,7 @@ static port_state_t* port__alloc(void) {
 
 static void port__free(port_state_t* port) {
   assert(port != NULL);
-  free(port);
+  mm_free(port);
 }
 
 static HANDLE port__create_iocp(void) {
@@ -1262,7 +1263,7 @@ int port_wait(port_state_t* port_state,
   if ((size_t) maxevents <= array_count(stack_iocp_events)) {
     iocp_events = stack_iocp_events;
   } else if ((iocp_events =
-                  malloc((size_t) maxevents * sizeof *iocp_events)) == NULL) {
+                  mm_malloc((size_t) maxevents * sizeof *iocp_events)) == NULL) {
     iocp_events = stack_iocp_events;
     maxevents = array_count(stack_iocp_events);
   }
@@ -1311,7 +1312,7 @@ int port_wait(port_state_t* port_state,
   LeaveCriticalSection(&port_state->lock);
 
   if (iocp_events != stack_iocp_events)
-    free(iocp_events);
+    mm_free(iocp_events);
 
   if (result >= 0)
     return result;
@@ -1614,14 +1615,14 @@ typedef struct sock_state {
 } sock_state_t;
 
 static inline sock_state_t* sock__alloc(void) {
-  sock_state_t* sock_state = malloc(sizeof *sock_state);
+  sock_state_t* sock_state = mm_malloc(sizeof *sock_state);
   if (sock_state == NULL)
     return_set_error(NULL, ERROR_NOT_ENOUGH_MEMORY);
   return sock_state;
 }
 
 static inline void sock__free(sock_state_t* sock_state) {
-  free(sock_state);
+  mm_free(sock_state);
 }
 
 static int sock__cancel_poll(sock_state_t* sock_state) {

--- a/wepoll.c
+++ b/wepoll.c
@@ -32,7 +32,7 @@
 #define WEPOLL_EXPORT
 
 #include <stdint.h>
-#include "mm-internal.h"
+#include "event-internal.h"
 
 enum EPOLL_EVENTS {
   EPOLLIN      = (int) (1U <<  0),


### PR DESCRIPTION
This replaces malloc and free in wepoll.c with mm_malloc and mm_free. I'm using event-internal.h instead of mm-internal.h. Using only mm-internal.h in wepoll.c can cause errors regarding the export symbol macros.

Fixes #1467 