### PR TITLE
Enable containing package CFLAGS etc.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -859,6 +859,11 @@ AC_SUBST([LIBEVENT_GC_SECTIONS])
 
 AM_CONDITIONAL([INSTALL_LIBEVENT], [test "$enable_libevent_install" = "yes"])
 
+dnl Allow additional flags from a containing package such as NTP
+AC_SUBST([LIBEVENT_CFLAGS])
+AC_SUBST([LIBEVENT_CPPFLAGS])
+AC_SUBST([LIBEVENT_LDFLAGS])
+
 AC_C_BIGENDIAN([CFLAGS="$CFLAGS -DBIG_ENDIAN"], [CFLAGS="$CFLAGS -DLITTLE_ENDIAN"])
 
 dnl Doxygen support


### PR DESCRIPTION
Add AC_SUBST of LIBEVENT_FLAGS, LIBEVENT_CPPFLAGS, and LIBEVENT_LDFLAGS so they are relayed from the configure command line to the Makefile.

This is used by the NTP package when the local system doesn't already have libevent to build a static version that matches the NTP build flags such as -fPIE.