### PR TITLE
Add __cplusplus in ws.h to fix compilation errors when using c++ compiler

### DIFF
--- a/include/event2/ws.h
+++ b/include/event2/ws.h
@@ -1,6 +1,10 @@
 #ifndef EVENT2_WS_H_INCLUDED_
 #define EVENT2_WS_H_INCLUDED_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct evws_connection;
 
 #define WS_CR_NONE 0
@@ -54,5 +58,9 @@ void evws_connection_free(struct evws_connection *evws);
 EVENT2_EXPORT_SYMBOL
 struct bufferevent *evws_connection_get_bufferevent(
 	struct evws_connection *evws);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Because there is no` __cplusplus` in `ws.h`, when I use  c++ compiler to compile a program that calls the interface in the file, an "undefined reference" error occurs.

```
undefined reference to `evws_send(evws_connection*, char const*, unsigned long)'
collect2: error: ld returned 1 exit status
```


Refer to `http.h` and add `__cplusplus` in `ws.h`, then the compilation error is solved.