### PR TITLE
Run all tests in CI in parallel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
           timeout_minutes: 60
           shell: bash
           command: |
-            JOBS=20
+            JOBS=50
             export CTEST_PARALLEL_LEVEL=$JOBS
             export CTEST_OUTPUT_ON_FAILURE=1
 
@@ -226,7 +226,7 @@ jobs:
           timeout_minutes: 60
           shell: bash
           command: |
-            JOBS=20
+            JOBS=50
 
             cd dist
             archive=$(echo *.tar.gz)
@@ -363,7 +363,7 @@ jobs:
           timeout_minutes: 60
           shell: powershell
           command: |
-            $EVENT_TESTS_PARALLEL=20
+            $EVENT_TESTS_PARALLEL=50
 
             cd build
 
@@ -435,7 +435,7 @@ jobs:
           timeout_minutes: 60
           shell: powershell
           command: |
-            $env:EVENT_TESTS_PARALLEL=20
+            $env:EVENT_TESTS_PARALLEL=50
 
             $script='
             export PATH="/mingw64/bin:/usr/bin:/bin:/usr/local/bin:/opt/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:$PATH"
@@ -608,7 +608,7 @@ jobs:
           timeout_minutes: 60
           shell: bash
           command: |
-            JOBS=20
+            JOBS=50
             export CTEST_PARALLEL_LEVEL=$JOBS
             export CTEST_OUTPUT_ON_FAILURE=1
 
@@ -669,7 +669,7 @@ jobs:
           timeout_minutes: 60
           shell: bash
           command: |
-            JOBS=20
+            JOBS=50
             cd build
             make -j $JOBS verify
 
@@ -754,7 +754,7 @@ jobs:
           command: |
             ssh freebsd sh <<EOF
             cd $GITHUB_WORKSPACE
-            JOBS=20
+            JOBS=50
             export CTEST_PARALLEL_LEVEL=$JOBS
             export CTEST_OUTPUT_ON_FAILURE=1
             cd build
@@ -816,7 +816,7 @@ jobs:
           command: |
             ssh freebsd sh <<EOF
             cd $GITHUB_WORKSPACE
-            JOBS=20
+            JOBS=50
             cd build
             make verify
             EOF
@@ -911,7 +911,7 @@ jobs:
             ssh openbsd sh <<EOF
             ulimit -n 102400
             cd $GITHUB_WORKSPACE
-            JOBS=20
+            JOBS=50
             export CTEST_PARALLEL_LEVEL=$JOBS
             export CTEST_OUTPUT_ON_FAILURE=1
             cd build
@@ -977,7 +977,7 @@ jobs:
             ssh openbsd sh <<EOF
             ulimit -n 102400
             cd $GITHUB_WORKSPACE
-            JOBS=20
+            JOBS=50
             cd build
             make verify
             EOF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,6 +158,7 @@ jobs:
               sudo python3 ../test-export/test-export.py shared
             else
               cmake --build . --target verify
+              ctest --output-on-failure -j $JOBS
             fi
 
       - uses: actions/upload-artifact@v4
@@ -362,7 +363,7 @@ jobs:
           timeout_minutes: 60
           shell: powershell
           command: |
-            $EVENT_TESTS_PARALLEL=1
+            $EVENT_TESTS_PARALLEL=20
 
             cd build
 
@@ -434,7 +435,7 @@ jobs:
           timeout_minutes: 60
           shell: powershell
           command: |
-            $env:EVENT_TESTS_PARALLEL=1
+            $env:EVENT_TESTS_PARALLEL=20
 
             $script='
             export PATH="/mingw64/bin:/usr/bin:/bin:/usr/local/bin:/opt/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:$PATH"
@@ -607,7 +608,7 @@ jobs:
           timeout_minutes: 60
           shell: bash
           command: |
-            JOBS=1
+            JOBS=20
             export CTEST_PARALLEL_LEVEL=$JOBS
             export CTEST_OUTPUT_ON_FAILURE=1
 
@@ -668,7 +669,7 @@ jobs:
           timeout_minutes: 60
           shell: bash
           command: |
-            JOBS=1
+            JOBS=20
             cd build
             make -j $JOBS verify
 
@@ -753,7 +754,7 @@ jobs:
           command: |
             ssh freebsd sh <<EOF
             cd $GITHUB_WORKSPACE
-            JOBS=1
+            JOBS=20
             export CTEST_PARALLEL_LEVEL=$JOBS
             export CTEST_OUTPUT_ON_FAILURE=1
             cd build
@@ -815,7 +816,7 @@ jobs:
           command: |
             ssh freebsd sh <<EOF
             cd $GITHUB_WORKSPACE
-            JOBS=1
+            JOBS=20
             cd build
             make verify
             EOF
@@ -910,7 +911,7 @@ jobs:
             ssh openbsd sh <<EOF
             ulimit -n 102400
             cd $GITHUB_WORKSPACE
-            JOBS=1
+            JOBS=20
             export CTEST_PARALLEL_LEVEL=$JOBS
             export CTEST_OUTPUT_ON_FAILURE=1
             cd build
@@ -976,7 +977,7 @@ jobs:
             ssh openbsd sh <<EOF
             ulimit -n 102400
             cd $GITHUB_WORKSPACE
-            JOBS=1
+            JOBS=20
             cd build
             make verify
             EOF


### PR DESCRIPTION
Previously we had some issues with this because some workers was not capable to handle such load, but after adding one more element to build matrix some builds exceeds the time (i.e. freebsd, for which tests tooks 17m before, and it is kind of obvious that they exceeds now).

So let's try, maybe github actions workers are better (though I'm really doubt...)

Fixes: https://github.com/libevent/libevent/issues/1452