### PR TITLE
Setup 'EVDNS_BASE_DISABLE_WHEN_INACTIVE' before nameservers resolve.

### DIFF
--- a/evdns.c
+++ b/evdns.c
@@ -4880,6 +4880,10 @@ evdns_base_new(struct event_base *event_base, int flags)
 	}
 #undef EVDNS_BASE_ALL_FLAGS
 
+	if (flags & EVDNS_BASE_DISABLE_WHEN_INACTIVE) {
+		base->disable_when_inactive = 1;
+	}
+
 	if (flags & EVDNS_BASE_INITIALIZE_NAMESERVERS) {
 		int r;
 		int opts = DNS_OPTIONS_ALL;
@@ -4890,15 +4894,12 @@ evdns_base_new(struct event_base *event_base, int flags)
 #ifdef _WIN32
 		r = evdns_base_config_windows_nameservers(base);
 #else
-		r = evdns_base_resolv_conf_parse(base, opts, "/etc/resolv.conf");
+		r = evdns_base_resolv_conf_parse(base, opts, evutil_resolvconf_filename_());
 #endif
 		if (r && (EVDNS_ERROR_NO_NAMESERVERS_CONFIGURED != r)) {
 			evdns_base_free_and_unlock(base, 0);
 			return NULL;
 		}
-	}
-	if (flags & EVDNS_BASE_DISABLE_WHEN_INACTIVE) {
-		base->disable_when_inactive = 1;
 	}
 
 	EVDNS_UNLOCK(base);

--- a/evutil.c
+++ b/evutil.c
@@ -1849,6 +1849,23 @@ evutil_set_evdns_getaddrinfo_cancel_fn_(evdns_getaddrinfo_cancel_fn fn)
 		evdns_getaddrinfo_cancel_impl = fn;
 }
 
+static const char *evutil_custom_resolvconf_filename = NULL;
+
+void
+evutil_set_resolvconf_filename_(const char *filename)
+{
+	evutil_custom_resolvconf_filename = filename;
+}
+
+const char *
+evutil_resolvconf_filename_(void)
+{
+	if (evutil_custom_resolvconf_filename)
+		return evutil_custom_resolvconf_filename;
+
+	return "/etc/resolv.conf";
+}
+
 /* Internal helper function: act like evdns_getaddrinfo if dns_base is set;
  * otherwise do a blocking resolve and pass the result to the callback in the
  * way that evdns_getaddrinfo would.

--- a/util-internal.h
+++ b/util-internal.h
@@ -417,6 +417,12 @@ typedef void (*evdns_getaddrinfo_cancel_fn)(
 EVENT2_EXPORT_SYMBOL
 void evutil_set_evdns_getaddrinfo_cancel_fn_(evdns_getaddrinfo_cancel_fn fn);
 
+/* Customization point to override "/etc/resolv.conf" */
+EVENT2_EXPORT_SYMBOL
+void evutil_set_resolvconf_filename_(const char *filename);
+EVENT2_EXPORT_SYMBOL
+const char *evutil_resolvconf_filename_(void);
+
 EVENT2_EXPORT_SYMBOL
 struct evutil_addrinfo *evutil_new_addrinfo_(struct sockaddr *sa,
     ev_socklen_t socklen, const struct evutil_addrinfo *hints);


### PR DESCRIPTION
Also includes some additionals for test purposes:
  * added `evutil_set_resolvconf_filename_` and `evutil_resolvconf_filename_` for `resolv.conf` overriding
  * `regress_make_tmpfile` does not unlink if `filename_out` parameter passed