### PR TITLE
Cleanup  win32 winnt

### DIFF
--- a/event_iocp.c
+++ b/event_iocp.c
@@ -23,12 +23,14 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include "evconfig-private.h"
 
 #ifndef _WIN32_WINNT
 /* Minimum required for InitializeCriticalSectionAndSpinCount */
 #define _WIN32_WINNT 0x0403
 #endif
+
+#include "evconfig-private.h"
+
 #include <winsock2.h>
 #include <windows.h>
 #include <process.h>

--- a/evthread_win32.c
+++ b/evthread_win32.c
@@ -23,18 +23,21 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include "event2/event-config.h"
-#include "evconfig-private.h"
 
 #ifdef _WIN32
 #ifndef _WIN32_WINNT
 /* Minimum required for InitializeCriticalSectionAndSpinCount */
 #define _WIN32_WINNT 0x0403
 #endif
-#include <winsock2.h>
 #define WIN32_LEAN_AND_MEAN
+#endif
+
+#include "event2/event-config.h"
+#include "evconfig-private.h"
+
+#ifdef _WIN32
+#include <winsock2.h>
 #include <windows.h>
-#undef WIN32_LEAN_AND_MEAN
 #include <sys/locking.h>
 #endif
 

--- a/evutil.c
+++ b/evutil.c
@@ -26,8 +26,8 @@
 
 #ifdef _WIN32
 #ifndef _WIN32_WINNT
-/* For structs needed by GetAdaptersAddresses */
-#define _WIN32_WINNT 0x0501
+/* For structs needed by GetAdaptersAddresses and AI_NUMERICSERV */
+#define _WIN32_WINNT 0x0600
 #endif
 #define WIN32_LEAN_AND_MEAN
 #endif

--- a/evutil.c
+++ b/evutil.c
@@ -24,6 +24,14 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef _WIN32
+#ifndef _WIN32_WINNT
+/* For structs needed by GetAdaptersAddresses */
+#define _WIN32_WINNT 0x0501
+#endif
+#define WIN32_LEAN_AND_MEAN
+#endif
+
 #include "event2/event-config.h"
 #include "evconfig-private.h"
 
@@ -34,15 +42,10 @@
 #ifdef EVENT__HAVE_AFUNIX_H
 #include <afunix.h>
 #endif
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#undef WIN32_LEAN_AND_MEAN
 #include <io.h>
 #include <tchar.h>
 #include <process.h>
-#undef _WIN32_WINNT
-/* For structs needed by GetAdaptersAddresses */
-#define _WIN32_WINNT 0x0501
 #include <iphlpapi.h>
 #include <netioapi.h>
 #endif

--- a/listener.c
+++ b/listener.c
@@ -24,16 +24,19 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef _WIN32
+#ifndef _WIN32_WINNT
+/* Minimum required for InitializeCriticalSectionAndSpinCount */
+#define _WIN32_WINNT 0x0403
+#endif
+#endif
+
 #include "event2/event-config.h"
 #include "evconfig-private.h"
 
 #include <sys/types.h>
 
 #ifdef _WIN32
-#ifndef _WIN32_WINNT
-/* Minimum required for InitializeCriticalSectionAndSpinCount */
-#define _WIN32_WINNT 0x0403
-#endif
 #include <winsock2.h>
 #include <winerror.h>
 #include <ws2tcpip.h>

--- a/util-internal.h
+++ b/util-internal.h
@@ -305,7 +305,7 @@ int evutil_socket_finished_connecting_(evutil_socket_t fd);
 
 #ifdef EVENT__HAVE_AFUNIX_H
 EVENT2_EXPORT_SYMBOL
-int evutil_check_working_afunix_();
+int evutil_check_working_afunix_(void);
 #endif
 
 EVENT2_EXPORT_SYMBOL

--- a/wepoll.c
+++ b/wepoll.c
@@ -31,6 +31,12 @@
 
 #define WEPOLL_EXPORT
 
+#ifndef _WIN32_WINNT
+/* Minimum required for SetFileCompletionNotificationModes() */
+#define _WIN32_WINNT 0x0600
+#endif
+#define WIN32_LEAN_AND_MEAN
+
 #include <stdint.h>
 #include "event-internal.h"
 
@@ -113,20 +119,10 @@ WEPOLL_EXPORT int epoll_wait(HANDLE ephnd,
 #define WEPOLL_INTERNAL static
 #define WEPOLL_INTERNAL_VAR static
 
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
 #endif
-
-#ifdef _WIN32_WINNT
-#undef _WIN32_WINNT
-#endif
-
-#define _WIN32_WINNT 0x0600
 
 #ifdef __clang__
 #pragma clang diagnostic pop


### PR DESCRIPTION
`_WIN32_WINNT` and `WIN32_LEAN_AND_MEAN` need to be defined before `windows.h` is included for the first time.     This PR avoids the confusion of indirect `#include` by defining before any headers are included.

Also fix the K&R style prototype of `evutil_check_working_afunix_()`.  GCC 12 now complains by default (cf. `-Wstrict-prototype`).

Fixes: #1497