### PR TITLE
Update cmake policy wrt. RPATH on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,14 @@
 
 cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
 
+if (POLICY CMP0042)
+    cmake_policy(SET CMP0042 NEW) # MACOSX_RPATH is enabled by default.
+endif()
 if (POLICY CMP0054)
     cmake_policy(SET CMP0054 NEW)
+endif()
+if (POLICY CMP0068)
+    cmake_policy(SET CMP0068 NEW) # RPATH settings on macOS do not affect install_name.
 endif()
 if (POLICY CMP0074)
     cmake_policy(SET CMP0074 NEW)

--- a/cmake/AddEventLibrary.cmake
+++ b/cmake/AddEventLibrary.cmake
@@ -140,7 +140,6 @@ macro(add_event_library LIB_NAME)
             set_target_properties(
                 "${LIB_NAME}_shared" PROPERTIES
                 OUTPUT_NAME "${LIB_NAME}-${EVENT_PACKAGE_RELEASE}.${CURRENT_MINUS_AGE}"
-                INSTALL_NAME_DIR "${CMAKE_INSTALL_LIBDIR}"
                 LINK_FLAGS "-compatibility_version ${COMPATIBILITY_VERSION} -current_version ${COMPATIBILITY_VERSION}.${EVENT_ABI_LIBVERSION_REVISION}")
         else()
             math(EXPR CURRENT_MINUS_AGE "${EVENT_ABI_LIBVERSION_CURRENT}-${EVENT_ABI_LIBVERSION_AGE}")


### PR DESCRIPTION
wrt. https://github.com/libevent/libevent/pull/1501#issuecomment-1657284641 I found a way to fix my problem of incorrect install_name on OSX.  The mysterious `lib/libevent_core-2.2.1.dylib` relative name comes directly from setting `INSTALL_NAME_DIR` to `lib` in `AddEventLibrary.cmake`.

I am marking this PR as a draft as I don't think I have explored all possible combinations of cmake settings relating to install_name, or even enumerated them.  Also, I can only test with OSX via github actions.

I hope someone with more experience with OSX can see/say if this change would break things in other situations.

Links to some relevant cmake docs. [CMP0042](https://cmake.org/cmake/help/latest/policy/CMP0042.html#policy:CMP0042) [CMP0068](https://cmake.org/cmake/help/latest/policy/CMP0068.html#policy:CMP0068) [INSTALL_NAME_DIR](https://cmake.org/cmake/help/latest/prop_tgt/INSTALL_NAME_DIR.html) [CMAKE_INSTALL_NAME_DIR](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_NAME_DIR.html#variable:CMAKE_INSTALL_NAME_DIR)

As a note, I tried setting the `INSTALL_RPATH` property to `CMAKE_INSTALL_FULL_LIBDIR` while leaving `INSTALL_DIR` unchanged.  This did not seem to have any effect.