### PR TITLE
Fixed misaligned address access

### DIFF
--- a/ws.c
+++ b/ws.c
@@ -238,7 +238,7 @@ get_ws_frame(unsigned char *in_buffer, int buf_len, unsigned char **payload_ptr,
 		unsigned char *c;
 		int i;
 
-		mask = *((unsigned int *)(in_buffer + pos));
+		memcpy(&mask, in_buffer + pos, sizeof(mask));
 		pos += 4;
 
 		/* unmask data */


### PR DESCRIPTION
Hello,
I have an issue with GCC 13 and GCC 12 when run unit-tests of libevent:
_regress: ws.c:241:10: runtime error: load of misaligned address 0x561200c627c2 for type 'unsigned int', which requires 4 byte alignment_
So this patch is fixing misaligned access to pointers.