### PR TITLE
Fixes #include of winsock.h before winsock2.h

### DIFF
--- a/bufferevent_openssl.c
+++ b/bufferevent_openssl.c
@@ -24,6 +24,13 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "event2/event-config.h"
+#include "evconfig-private.h"
+
+#ifdef _WIN32
+#  include <winsock2.h>
+#endif
+
 #include <string.h>
 
 #include <openssl/ssl.h>


### PR DESCRIPTION
Fixes #1508 Although I am not certain where `winsock.h` is being included from.