### PR TITLE
Add function evbuffer_add_reference_with_offset()

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -2942,6 +2942,14 @@ evbuffer_add_reference(struct evbuffer *outbuf,
     const void *data, size_t datlen,
     evbuffer_ref_cleanup_cb cleanupfn, void *extra)
 {
+	return evbuffer_add_reference_with_offset(outbuf, data, /* offset= */ 0, datlen, cleanupfn, extra);
+}
+
+int
+evbuffer_add_reference_with_offset(struct evbuffer *outbuf, const void *data,
+	size_t offset, size_t datlen, evbuffer_ref_cleanup_cb cleanupfn,
+	void *extra)
+{
 	struct evbuffer_chain *chain;
 	struct evbuffer_chain_reference *info;
 	int result = -1;
@@ -2951,7 +2959,8 @@ evbuffer_add_reference(struct evbuffer *outbuf,
 		return (-1);
 	chain->flags |= EVBUFFER_REFERENCE | EVBUFFER_IMMUTABLE;
 	chain->buffer = (unsigned char *)data;
-	chain->buffer_len = datlen;
+	chain->misalign = offset;
+	chain->buffer_len = offset + datlen;
 	chain->off = datlen;
 
 	info = EVBUFFER_CHAIN_EXTRA(struct evbuffer_chain_reference, chain);

--- a/include/event2/buffer.h
+++ b/include/event2/buffer.h
@@ -521,6 +521,28 @@ int evbuffer_add_reference(struct evbuffer *outbuf,
     const void *data, size_t datlen,
     evbuffer_ref_cleanup_cb cleanupfn, void *cleanupfn_arg);
 
+
+/**
+  Reference memory into an evbuffer without copying.
+
+  The memory needs to remain valid until all the added data has been
+  read.  This function keeps just a reference to the memory without
+  actually incurring the overhead of a copy.
+
+  @param outbuf the output buffer
+  @param data the memory to reference
+  @param offset offset inside @data
+  @param datlen how memory to reference (excluding @offset)
+  @param cleanupfn callback to be invoked when the memory is no longer
+	referenced by this evbuffer.
+  @param cleanupfn_arg optional argument to the cleanup callback
+  @return 0 if successful, or -1 if an error occurred
+ */
+EVENT2_EXPORT_SYMBOL
+int evbuffer_add_reference_with_offset(struct evbuffer *outbuf, const void *data,
+	size_t offset, size_t datlen, evbuffer_ref_cleanup_cb cleanupfn,
+	void *cleanupfn_arg);
+
 /**
   Copy data from a file into the evbuffer for writing to a socket.
 

--- a/test/regress_buffer.c
+++ b/test/regress_buffer.c
@@ -2123,6 +2123,119 @@ end:
 		evbuffer_free(buf2);
 }
 
+struct t_MyData {
+	int nMyType;
+	char szMyContent[1];
+};
+
+static void
+ref_done_cb_with_offset(const void *data, size_t len, void *info)
+{
+	struct t_MyData *pstMyData = (struct t_MyData *)data;
+
+	if (pstMyData->nMyType == 1)
+	{
+		size_t nLen = (size_t)info;
+		if (len != nLen)
+		{
+			printf("evbuffer_add_reference_with_offset Test Failed");
+		}
+		free((void *)data);
+	}
+	else if (pstMyData->nMyType == 2)
+	{
+		size_t nLen = (size_t)info;
+		if (len != nLen)
+		{
+			printf("evbuffer_add_reference_with_offset Test Failed");
+		}
+		free((void *)data);
+	}
+	else
+	{
+		printf("evbuffer_add_reference_with_offset Test Failed");
+	}
+}
+static void
+test_evbuffer_add_reference_with_offset(void* ptr)
+{
+	const char* pContent1 = "If you have found the answer to such a problem";
+	const char *pContent2 = "you ought to write it up for publication";
+
+	struct evbuffer *buf1 = NULL, *buf2 = NULL;
+	/* -- Knuth's "Notes on the Exercises" from TAOCP */
+	char tmp[16];
+
+	char* pData1 = malloc(sizeof(struct t_MyData) + strlen(pContent1) - 1);
+	struct t_MyData* pstMyData1 = (struct t_MyData*)pData1;
+
+	struct t_MyData* pData2 = malloc(sizeof(struct t_MyData) + strlen(pContent2) - 1);
+	struct t_MyData* pstMyData2 = (struct t_MyData *)pData2;
+
+	size_t len1 = strlen(pContent1), len2 = strlen(pContent2);
+
+	pstMyData1->nMyType = 1;
+	memcpy(&pstMyData1->szMyContent, pContent1, strlen(pContent1));
+
+	pstMyData2->nMyType = 2;
+	memcpy(&pstMyData2->szMyContent, pContent2, strlen(pContent2));
+
+	buf1 = evbuffer_new();
+	tt_assert(buf1);
+
+	evbuffer_add_reference_with_offset(buf1, (const void *)pstMyData1, sizeof(int),
+		len1, ref_done_cb_with_offset, (void *)(sizeof(int) + len1));
+	evbuffer_add(buf1, ", ", 2);
+	evbuffer_add_reference_with_offset(buf1, (const void *)pstMyData2, sizeof(int),
+		len2, ref_done_cb_with_offset, (void *)(sizeof(int) + len2));
+	tt_int_op(evbuffer_get_length(buf1), ==, len1 + len2 + 2);
+
+	/* Make sure we can drain a little from a reference. */
+	tt_int_op(evbuffer_remove(buf1, tmp, 6), ==, 6);
+	tt_int_op(memcmp(tmp, "If you", 6), ==, 0);
+	tt_int_op(evbuffer_remove(buf1, tmp, 5), ==, 5);
+	tt_int_op(memcmp(tmp, " have", 5), ==, 0);
+
+	/* Make sure that prepending does not meddle with immutable data */
+	tt_int_op(evbuffer_prepend(buf1, "I have ", 7), ==, 0);
+	tt_int_op(memcmp(pContent1, "If you", 6), ==, 0);
+	evbuffer_validate(buf1);
+
+	/* Make sure that when the chunk is over, the callback is invoked. */
+	evbuffer_drain(buf1, 7);			 /* Remove prepended stuff. */
+	evbuffer_drain(buf1, len1 - 11 - 1); /* remove all but one byte of chunk1 */
+	evbuffer_remove(buf1, tmp, 1);
+	tt_int_op(tmp[0], ==, 'm');
+	evbuffer_validate(buf1);
+
+	/* Drain some of the remaining chunk, then add it to another buffer */
+	evbuffer_drain(buf1, 6); /* Remove the ", you ". */
+	buf2 = evbuffer_new();
+	tt_assert(buf2);
+	evbuffer_add(buf2, "I ", 2);
+
+	evbuffer_add_buffer(buf2, buf1);
+	evbuffer_remove(buf2, tmp, 16);
+	tt_int_op(memcmp("I ought to write", tmp, 16), ==, 0);
+	evbuffer_drain(buf2, evbuffer_get_length(buf2));
+	evbuffer_validate(buf2);
+
+	/* Now add more stuff to buf1 and make sure that it gets removed on
+	 * free. */
+	evbuffer_add(buf1, "You shake and shake the ", 24);
+	evbuffer_add_reference(
+		buf1, "ketchup bottle", 14, ref_done_cb, (void *)3333);
+	evbuffer_add(buf1, ". Nothing comes and then a lot'll.", 35);
+	evbuffer_free(buf1);
+	buf1 = NULL;
+
+end:
+	if (buf1)
+		evbuffer_free(buf1);
+	if (buf2)
+		evbuffer_free(buf2);
+}
+
 static void
 test_evbuffer_multicast(void *ptr)
 {
@@ -2834,6 +2947,7 @@ struct testcase_t evbuffer_testcases[] = {
 	{ "search", test_evbuffer_search, 0, NULL, NULL },
 	{ "callbacks", test_evbuffer_callbacks, 0, NULL, NULL },
 	{ "add_reference", test_evbuffer_add_reference, 0, NULL, NULL },
+	{ "add_reference_with_offset", test_evbuffer_add_reference_with_offset, 0, NULL, NULL},
 	{ "multicast", test_evbuffer_multicast, 0, NULL, NULL },
 	{ "multicast_drain", test_evbuffer_multicast_drain, 0, NULL, NULL },
 	{ "prepend", test_evbuffer_prepend, TT_FORK, NULL, NULL },


### PR DESCRIPTION
This is the same as evbuffer_add_reference(), but allows to specify
offset in the `@data`

v2: rename evbuffer_add_reference_misalign() to evbuffer_add_reference_with_offset()

Fixes: #1511 (patch from @MBeanwenshengming)