### PR TITLE
wepoll api: fix definition of EPOLLONESHOT to match Linux

### DIFF
--- a/wepoll.h
+++ b/wepoll.h
@@ -48,7 +48,7 @@ enum EPOLL_EVENTS {
   EPOLLWRBAND  = (int) (1U <<  9),
   EPOLLMSG     = (int) (1U << 10), /* Never reported. */
   EPOLLRDHUP   = (int) (1U << 13),
-  EPOLLONESHOT = (int) (1U << 31)
+  EPOLLONESHOT = (int) (1U << 30)
 };
 
 #define EPOLLIN      (1U <<  0)
@@ -62,7 +62,7 @@ enum EPOLL_EVENTS {
 #define EPOLLWRBAND  (1U <<  9)
 #define EPOLLMSG     (1U << 10)
 #define EPOLLRDHUP   (1U << 13)
-#define EPOLLONESHOT (1U << 31)
+#define EPOLLONESHOT (1U << 30)
 
 #define EPOLL_CTL_ADD 1
 #define EPOLL_CTL_MOD 2


### PR DESCRIPTION
the pr add upstream fix for EPOLLONESHOT definition: https://github.com/piscisaureus/wepoll/commit/7958b3048fa1e85ab5a71f18a07c24e1b1e64f1e