### PR TITLE
Fix two compiler errors for unused variable and undefined function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,6 +514,7 @@ list(APPEND SYMBOLS_TO_CHECK
     inet_pton
     gettimeofday
     signal
+    socketpair
     strtoll
     strlcpy
     strsep

--- a/buffer.c
+++ b/buffer.c
@@ -3068,7 +3068,9 @@ get_page_size(void)
 static int
 evbuffer_file_segment_materialize(struct evbuffer_file_segment *seg)
 {
+#if defined(EVENT__HAVE_MMAP) || defined(_WIN32)
 	const unsigned flags = seg->flags;
+#endif
 	const int fd = seg->fd;
 	const ev_off_t length = seg->length;
 	const ev_off_t offset = seg->file_offset;
@@ -3186,8 +3188,9 @@ evbuffer_file_segment_materialize(struct evbuffer_file_segment *seg)
 
 		seg->contents = mem;
 	}
-
+#if defined(EVENT__HAVE_MMAP) || defined(_WIN32)
 done:
+#endif
 	return 0;
 err:
 	return -1;

--- a/event-config.h.cmake
+++ b/event-config.h.cmake
@@ -274,6 +274,9 @@
 /* Define to 1 if you have the `signal' function. */
 #cmakedefine EVENT__HAVE_SIGNAL 1
 
+/* Define to 1 if you have the `socketpair` function. */
+#cmakedefine EVENT__HAVE_SOCKETPAIR 1
+
 /* Define to 1 if you have the `strsignal' function. */
 #cmakedefine EVENT__HAVE_STRSIGNAL 1
 

--- a/evutil.c
+++ b/evutil.c
@@ -405,10 +405,12 @@ evutil_win_socketpair(int family, int type, int protocol,
 int
 evutil_socketpair(int family, int type, int protocol, evutil_socket_t fd[2])
 {
-#ifndef _WIN32
+#if defined(_WIN32)
+	return evutil_win_socketpair(family, type, protocol, fd);
+#elif defined(EVENT__HAVE_SOCKETPAIR)
 	return socketpair(family, type, protocol, fd);
 #else
-	return evutil_win_socketpair(family, type, protocol, fd);
+	return evutil_ersatz_socketpair_(family, type, protocol, fd);
 #endif
 }
 

--- a/test/regress_util.c
+++ b/test/regress_util.c
@@ -1701,7 +1701,7 @@ test_evutil_socketpair_create(void *arg)
 	tt_int_op(evutil_socketpair(AF_INET, SOCK_RAW, 0, fd), == , -1);
 	tt_int_op(evutil_socketpair(AF_INET, SOCK_STREAM, 1, fd), == , -1);
 
-#ifndef _WIN32
+#if !defined(_WIN32) && defined(EVENT__HAVE_SOCKETPAIR)
 	tt_int_op(evutil_socketpair(AF_INET, SOCK_STREAM, 0, fd), == , -1);
 	tt_int_op(evutil_socketpair(AF_INET, SOCK_DGRAM, 0, fd), == , -1);
 	socketpair_init(fd);


### PR DESCRIPTION
In buffer.c a variable "flags" and a label "done" are defined but never used if "EVENT__HAVEMMAP" is not defined.

In evutil.c the function socketpair() is used,
even though "EVENT__HAVE_SOCKETPAIR" is not defined. In this case, call evutil_ersatz_socketpair_() instead.