### PR TITLE
Fix -Walloc-size

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -2994,7 +2994,7 @@ evbuffer_file_segment_new(
 	int fd, ev_off_t offset, ev_off_t length, unsigned flags)
 {
 	struct evbuffer_file_segment *seg =
-	    mm_calloc(sizeof(struct evbuffer_file_segment), 1);
+	    mm_calloc(1, sizeof(struct evbuffer_file_segment));
 	if (!seg)
 		return NULL;
 	seg->refcnt = 1;

--- a/http.c
+++ b/http.c
@@ -4884,7 +4884,7 @@ struct evhttp_uri {
 struct evhttp_uri *
 evhttp_uri_new(void)
 {
-	struct evhttp_uri *uri = mm_calloc(sizeof(struct evhttp_uri), 1);
+	struct evhttp_uri *uri = mm_calloc(1, sizeof(struct evhttp_uri));
 	if (uri)
 		uri->port = -1;
 	return uri;

--- a/sample/ws-chat-server.c
+++ b/sample/ws-chat-server.c
@@ -151,7 +151,7 @@ on_ws(struct evhttp_request *req, void *arg)
 	struct sockaddr_storage addr;
 	socklen_t len;
 
-	client = calloc(sizeof(*client), 1);
+	client = calloc(1, sizeof(*client));
 
 	client->evws = evws_new_session(req, on_msg_cb, client, 0);
 	if (!client->evws) {

--- a/test/regress_zlib.c
+++ b/test/regress_zlib.c
@@ -296,10 +296,10 @@ test_bufferevent_zlib(void *arg)
 	bev1 = bufferevent_socket_new(NULL, pair[0], 0);
 	bev2 = bufferevent_socket_new(NULL, pair[1], 0);
 
-	z_output = mm_calloc(sizeof(*z_output), 1);
+	z_output = mm_calloc(1, sizeof(*z_output));
 	r = deflateInit(z_output, Z_DEFAULT_COMPRESSION);
 	tt_int_op(r, ==, Z_OK);
-	z_input = mm_calloc(sizeof(*z_input), 1);
+	z_input = mm_calloc(1, sizeof(*z_input));
 	r = inflateInit(z_input);
 	tt_int_op(r, ==, Z_OK);
 


### PR DESCRIPTION
GCC 14 introduces a new -Walloc-size included in -Wextra which gives:
```
In file included from buffer.c:93:
buffer.c: In function ‘evbuffer_file_segment_new’:
mm-internal.h:82:26: warning: allocation of insufficient size ‘1’ for type ‘struct evbuffer_file_segment’ with size ‘60’ [-Walloc-size]
   82 | #define mm_calloc(n, sz) calloc((n), (sz))
      |                          ^~~~~~
buffer.c:2968:13: note: in expansion of macro ‘mm_calloc’
 2968 |             mm_calloc(sizeof(struct evbuffer_file_segment), 1);
      |             ^~~~~~~~~
In file included from http.c:112:
http.c: In function ‘evhttp_uri_new’:
mm-internal.h:82:26: warning: allocation of insufficient size ‘1’ for type ‘struct evhttp_uri’ with size ‘32’ [-Walloc-size]
   82 | #define mm_calloc(n, sz) calloc((n), (sz))
      |                          ^~~~~~
http.c:4494:34: note: in expansion of macro ‘mm_calloc’
 4494 |         struct evhttp_uri *uri = mm_calloc(sizeof(struct evhttp_uri), 1);
      |                                  ^~~~~~~~~
[...]
```

The calloc prototype is:
```
void *calloc(size_t nmemb, size_t size);
```

So, just swap the number of members and size arguments to match the prototype, as we're initialising 1 struct of size `sizeof(struct ...)`. GCC then sees we're not doing anything wrong.