### PR TITLE
Fix documentation inconsistency in evhttp callbacks

### DIFF
--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -332,7 +332,7 @@ int evhttp_del_cb(struct evhttp *, const char *);
 
     @param http the evhttp server object for which to set the callback
     @param cb the callback to invoke for any unmatched requests
-    @param arg an context argument for the callback
+    @param arg an additional context argument for the callback
 */
 EVENT2_EXPORT_SYMBOL
 void evhttp_set_gencb(struct evhttp *http,
@@ -352,7 +352,7 @@ void evhttp_set_gencb(struct evhttp *http,
 
    @param http the evhttp server object for which to set the callback
    @param cb the callback to invoke for incoming connections
-   @param arg an context argument for the callback
+   @param arg an additional context argument for the callback
  */
 EVENT2_EXPORT_SYMBOL
 void evhttp_set_bevcb(struct evhttp *http,
@@ -370,7 +370,7 @@ void evhttp_set_bevcb(struct evhttp *http,
 
    @param http the evhttp server object for which to set the callback
    @param cb the callback to invoke for incoming connections
-   @param arg an context argument for the callback
+   @param arg an additional context argument for the callback
  */
 EVENT2_EXPORT_SYMBOL
 void evhttp_set_newreqcb(struct evhttp *http,
@@ -396,7 +396,7 @@ void evhttp_set_newreqcb(struct evhttp *http,
 
    @param http the evhttp server object for which to set the callback
    @param cb the callback to invoke to format error pages
-   @param arg an context argument for the callback
+   @param arg an additional context argument for the callback
  */
 EVENT2_EXPORT_SYMBOL
 void evhttp_set_errorcb(struct evhttp *http,


### PR DESCRIPTION
This commit addresses a minor inconsistency identified in the documentation of multiple `evhttp` callback functions within the `event2/http.h` header file. It was observed that the word "additional" was presumably missing in the description of the `arg` parameter for several functions. This oversight led to an incorrect phrasing: "an context argument for the callback."

The documentation for the following functions has been updated to rectify this issue:

  - `evhttp_set_gencb`
  - `evhttp_set_bevcb`
  - `evhttp_set_newreqcb`
  - `evhttp_set_errorcb`

This commit solely improves the readability of the function descriptions without altering any functional aspects of the code.