### PR TITLE
Ignore the project files from IDE or editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,11 @@ rules.ninja
 
 # clangd
 .cache
+
+# Project files from IDE or editors
+
+# VS/VSCode
+.vs/
+.vscode/
+# IntelliJ/Clion
+.idea/


### PR DESCRIPTION
I sometimes browse and edit C/C++ code with VSCode, and it would generate some project files in .vscode which could easily be added and even pushed to a git repo by accident.

It's sort of annoying for programmers who work with VS/VSCode, IntelliJ/Clion, or other widely-used IDE or editors to prevent themself from using git command like `git add .` in lib event project.

Therefore, I propose leaving the project files generated by VS/VSCode and IntelliJ/Clion untracked for libevent project. Hopefully, this can be accepted.