### PR TITLE
Fix integer overflow in HTTP version

### DIFF
--- a/http.c
+++ b/http.c
@@ -1739,16 +1739,16 @@ evhttp_valid_response_code(int code)
 static int
 evhttp_parse_http_version(const char *version, struct evhttp_request *req)
 {
-	int major, minor;
+	char major, minor;
 	char ch;
-	int n = sscanf(version, "HTTP/%d.%d%c", &major, &minor, &ch);
-	if (n != 2 || major > 1) {
+	int n = sscanf(version, "HTTP/%c.%c%c", &major, &minor, &ch);
+	if (n != 2 || major > '1' || major < '0' || minor > '9' || minor < '0') {
 		event_debug(("%s: bad version %s on message %p from %s",
 			__func__, version, (void *)req, req->remote_host));
 		return (-1);
 	}
-	req->major = major;
-	req->minor = minor;
+	req->major = major - '0';
+	req->minor = minor - '0';
 	return (0);
 }
 


### PR DESCRIPTION
Currently, when libevent parses requests with version `HTTP/4294967295.255`, you end up with `req->major == req->minor == (char)-1`. (At least on linux-gnu-x86_64, where `char` is signed.)

This is sort of weird.

This patch changes the version parser to match the grammar in RFCs 7230 and 9112. (i.e. `HTTP/[0-9].[0-9]`)

EDIT: Technically, a little stronger than the RFC requires, since this patch continues to block major versions greater than 1, which was already what libevent was doing.