### PR TITLE
Make MbedTLS and OpenSSL dependencies configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1120,6 +1120,9 @@ if (EVENT__HAVE_OPENSSL)
         INNER_LIBRARIES event_core
         LIBRARIES ${OPENSSL_TARGETS}
         SOURCES ${SRC_OPENSSL})
+    set(LIBEVENT_OPENSSL_DEPENDENCY "find_dependency(OpenSSL)")
+else ()
+    set(LIBEVENT_OPENSSL_DEPENDENCY "")
 endif()
 
 if (EVENT__HAVE_MBEDTLS)
@@ -1127,6 +1130,9 @@ if (EVENT__HAVE_MBEDTLS)
         INNER_LIBRARIES event_core
         LIBRARIES ${MBEDTLS_TARGETS}
         SOURCES ${SRC_MBEDTLS})
+    set(LIBEVENT_MBEDTLS_DEPENDENCY "find_dependency(MbedTLS)")
+else ()
+    set(LIBEVENT_MBEDTLS_DEPENDENCY "")
 endif()
 
 if (EVENT__HAVE_PTHREADS)

--- a/cmake/LibeventConfig.cmake.in
+++ b/cmake/LibeventConfig.cmake.in
@@ -40,8 +40,8 @@ set(LIBEVENT_VERSION @EVENT_PACKAGE_VERSION@)
 # by component.
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
-find_dependency(MbedTLS)
-find_dependency(OpenSSL)
+@LIBEVENT_MBEDTLS_DEPENDENCY@
+@LIBEVENT_OPENSSL_DEPENDENCY@
 
 # IMPORTED targets from LibeventTargets.cmake
 set(LIBEVENT_STATIC_LIBRARIES "@LIBEVENT_STATIC_LIBRARIES@")


### PR DESCRIPTION
As https://github.com/libevent/libevent/commit/acfac7ae4a3edbbb7ce4ceee7208b4245a6e203e#r124469888 mentioned, LibeventConfig.cmake is looking for MBedTLS package, even if libevent is not configured to use MBedTLS.

This PR makes MbedTLS and OpenSSL dependencies configurable.

Fix #1543 