### PR TITLE
ci: use prebuilt image for ABI check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -974,3 +974,29 @@ jobs:
         with:
           name: openbsd-${{ matrix.release }}-autotools-${{ matrix.EVENT_MATRIX }}-build
           path: .
+
+  abi-job:
+    runs-on: ubuntu-20.04
+    container: docker.pkg.github.com/azat/docker-images/lvc-debian
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Generate
+        shell: bash
+        run: |
+          ./extra/abi-check/abi_check.sh
+        env:
+          ABI_CHECK_ROOT: /tmp/le-abi-root
+      # XXX: requires container-id for docker
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: build
+          path: /tmp/le-abi-root
+      - uses: actions/upload-artifact@v1
+        with:
+          name: build
+          path: /tmp/le-abi-root/work/abi-check

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -55,30 +55,14 @@ jobs:
           path: build
   abi-job:
     permissions:
-      contents: write # for Git to git push
-    # ABI check is broken [1].
-    #   [1]: https://github.com/libevent/libevent/issues/1463
-    if: "false"
+      contents: write  # for Git to git push
     runs-on: ubuntu-20.04
-    ## TODO: use docker image, but for now this is not possible without hacks
-    ## due to even public registry require some authentication:
-    ## - https://github.community/t5/GitHub-Actions/docker-pull-from-public-GitHub-Package-Registry-fail-with-quot/td-p/32782/page/5
-    #container: docker.pkg.github.com/azat/docker-images/lvc-debian
+    container: docker.pkg.github.com/azat/docker-images/lvc-debian
     strategy:
       fail-fast: false
 
     steps:
       - uses: actions/checkout@v3
-
-      - name: Install Dependencies
-        run:
-          sudo apt install
-            abi-tracker
-            abi-monitor
-            abi-dumper
-            abi-compliance-checker
-            pkgdiff
-            vtable-dumper
 
       - name: Generate
         shell: bash


### PR DESCRIPTION
Refs: https://github.com/libevent/libevent/commit/cffb7c03f1965b4706435315dd3456061d53a102#commitcomment-138374733