### PR TITLE
Make Infer static analyzer happy

### DIFF
--- a/bufferevent_filter.c
+++ b/bufferevent_filter.c
@@ -118,8 +118,7 @@ static inline struct bufferevent_filtered *
 upcast(struct bufferevent *bev)
 {
 	struct bufferevent_filtered *bev_f;
-	if (!BEV_IS_FILTER(bev))
-		return NULL;
+	EVUTIL_ASSERT(BEV_IS_FILTER(bev));
 	bev_f = (void*)( ((char*)bev) -
 			 evutil_offsetof(struct bufferevent_filtered, bev.bev));
 	EVUTIL_ASSERT(BEV_IS_FILTER(&bev_f->bev.bev));
@@ -229,8 +228,6 @@ static void
 be_filter_unlink(struct bufferevent *bev)
 {
 	struct bufferevent_filtered *bevf = upcast(bev);
-	EVUTIL_ASSERT(bevf);
-
 	if (bevf->bev.options & BEV_OPT_CLOSE_ON_FREE) {
 		/* Yes, there is also a decref in bufferevent_decref_.
 		 * That decref corresponds to the incref when we set
@@ -258,7 +255,6 @@ static void
 be_filter_destruct(struct bufferevent *bev)
 {
 	struct bufferevent_filtered *bevf = upcast(bev);
-	EVUTIL_ASSERT(bevf);
 	if (bevf->free_context)
 		bevf->free_context(bevf->context);
 
@@ -575,7 +571,6 @@ be_filter_flush(struct bufferevent *bufev,
 {
 	struct bufferevent_filtered *bevf = upcast(bufev);
 	int processed_any = 0;
-	EVUTIL_ASSERT(bevf);
 
 	bufferevent_incref_and_lock_(bufev);
 

--- a/bufferevent_mbedtls.c
+++ b/bufferevent_mbedtls.c
@@ -292,9 +292,6 @@ bufferevent_mbedtls_get_ssl(struct bufferevent *bufev)
 int
 bufferevent_mbedtls_renegotiate(struct bufferevent *bufev)
 {
-	struct bufferevent_ssl *bev_ssl = bufferevent_ssl_upcast(bufev);
-	if (!bev_ssl)
-		return -1;
 	return bufferevent_ssl_renegotiate_impl(bufev);
 }
 

--- a/bufferevent_pair.c
+++ b/bufferevent_pair.c
@@ -56,8 +56,6 @@ static inline struct bufferevent_pair *
 upcast(struct bufferevent *bev)
 {
 	struct bufferevent_pair *bev_p;
-	if (!BEV_IS_PAIR(bev))
-		return NULL;
 	bev_p = EVUTIL_UPCAST(bev, struct bufferevent_pair, bev.bev);
 	EVUTIL_ASSERT(BEV_IS_PAIR(&bev_p->bev.bev));
 	return bev_p;
@@ -341,10 +339,9 @@ bufferevent_pair_get_partner(struct bufferevent *bev)
 {
 	struct bufferevent_pair *bev_p;
 	struct bufferevent *partner = NULL;
-	bev_p = upcast(bev);
-	if (! bev_p)
+	if (!BEV_IS_PAIR(bev))
 		return NULL;
-
+	bev_p = upcast(bev);
 	incref_and_lock(bev);
 	if (bev_p->partner)
 		partner = downcast(bev_p->partner);

--- a/bufferevent_ssl.c
+++ b/bufferevent_ssl.c
@@ -1088,8 +1088,8 @@ err:
 		bev_ssl->ssl = NULL;
 		bufferevent_free(&bev_ssl->bev.bev);
 	} else {
-		if (ssl && (options & BEV_OPT_CLOSE_ON_FREE))
-			bev_ssl->ssl_ops->free_raw(bev_ssl->ssl);
+		if (ssl && options & BEV_OPT_CLOSE_ON_FREE)
+			ssl_ops->free_raw(ssl);
 	}
 	return NULL;
 }

--- a/bufferevent_ssl.c
+++ b/bufferevent_ssl.c
@@ -105,8 +105,7 @@ struct bufferevent_ssl *
 bufferevent_ssl_upcast(struct bufferevent *bev)
 {
 	struct bufferevent_ssl *bev_o;
-	if (!BEV_IS_SSL(bev))
-		return NULL;
+	EVUTIL_ASSERT(BEV_IS_SSL(bev));
 	bev_o = (void*)( ((char*)bev) -
 			 evutil_offsetof(struct bufferevent_ssl, bev.bev));
 	EVUTIL_ASSERT(BEV_IS_SSL(&bev_o->bev.bev));
@@ -815,9 +814,11 @@ set_handshake_callbacks(struct bufferevent_ssl *bev_ssl, evutil_socket_t fd)
 int
 bufferevent_ssl_renegotiate_impl(struct bufferevent *bev)
 {
-	struct bufferevent_ssl *bev_ssl = bufferevent_ssl_upcast(bev);
-	if (!bev_ssl)
+	struct bufferevent_ssl *bev_ssl;
+	if (!BEV_IS_SSL(bev))
 		return -1;
+
+	bev_ssl = bufferevent_ssl_upcast(bev);
 	if (bev_ssl->ssl_ops->renegotiate(bev_ssl->ssl) < 0)
 		return -1;
 	bev_ssl->state = BUFFEREVENT_SSL_CONNECTING;
@@ -1098,9 +1099,13 @@ bufferevent_get_ssl_error(struct bufferevent *bev)
 {
 	unsigned long err = 0;
 	struct bufferevent_ssl *bev_ssl;
+
+	if (BEV_IS_SSL(bev))
+		return err;
+
 	BEV_LOCK(bev);
 	bev_ssl = bufferevent_ssl_upcast(bev);
-	if (bev_ssl && bev_ssl->n_errors) {
+	if (bev_ssl->n_errors) {
 		err = bev_ssl->errors[--bev_ssl->n_errors];
 	}
 	BEV_UNLOCK(bev);
@@ -1112,10 +1117,12 @@ ev_uint64_t bufferevent_ssl_get_flags(struct bufferevent *bev)
 	ev_uint64_t flags = EV_UINT64_MAX;
 	struct bufferevent_ssl *bev_ssl;
 
+	if (!BEV_IS_SSL(bev))
+		return flags;
+
 	BEV_LOCK(bev);
 	bev_ssl = bufferevent_ssl_upcast(bev);
-	if (bev_ssl)
-		flags = bev_ssl->flags;
+	flags = bev_ssl->flags;
 	BEV_UNLOCK(bev);
 
 	return flags;
@@ -1126,15 +1133,13 @@ ev_uint64_t bufferevent_ssl_set_flags(struct bufferevent *bev, ev_uint64_t flags
 	struct bufferevent_ssl *bev_ssl;
 
 	flags &= (BUFFEREVENT_SSL_DIRTY_SHUTDOWN|BUFFEREVENT_SSL_BATCH_WRITE);
-	if (!flags)
+	if (!flags || !BEV_IS_SSL(bev))
 		return old_flags;
 
 	BEV_LOCK(bev);
 	bev_ssl = bufferevent_ssl_upcast(bev);
-	if (bev_ssl) {
-		old_flags = bev_ssl->flags;
-		bev_ssl->flags |= flags;
-	}
+	old_flags = bev_ssl->flags;
+	bev_ssl->flags |= flags;
 	BEV_UNLOCK(bev);
 
 	return old_flags;
@@ -1145,15 +1150,13 @@ ev_uint64_t bufferevent_ssl_clear_flags(struct bufferevent *bev, ev_uint64_t fla
 	struct bufferevent_ssl *bev_ssl;
 
 	flags &= (BUFFEREVENT_SSL_DIRTY_SHUTDOWN|BUFFEREVENT_SSL_BATCH_WRITE);
-	if (!flags)
+	if (!flags || !BEV_IS_SSL(bev))
 		return old_flags;
 
 	BEV_LOCK(bev);
 	bev_ssl = bufferevent_ssl_upcast(bev);
-	if (bev_ssl) {
-		old_flags = bev_ssl->flags;
-		bev_ssl->flags &= ~flags;
-	}
+	old_flags = bev_ssl->flags;
+	bev_ssl->flags &= ~flags;
 	BEV_UNLOCK(bev);
 
 	return old_flags;

--- a/bufferevent_ssl.c
+++ b/bufferevent_ssl.c
@@ -1083,7 +1083,7 @@ bufferevent_ssl_new_impl(struct event_base *base,
 	return &bev_ssl->bev.bev;
 err:
 	if (bev_ssl) {
-		if (bev_ssl->ssl && (options & BEV_OPT_CLOSE_ON_FREE))
+		if (bev_ssl->ssl && bev_ssl->ssl_ops && options & BEV_OPT_CLOSE_ON_FREE)
 			bev_ssl->ssl_ops->free(bev_ssl->ssl, options);
 		bev_ssl->ssl = NULL;
 		bufferevent_free(&bev_ssl->bev.bev);

--- a/evrpc-internal.h
+++ b/evrpc-internal.h
@@ -118,7 +118,7 @@ struct evrpc_hook_meta {
 };
 
 /* allows association of meta data with a request */
-static void evrpc_hook_associate_meta_(struct evrpc_hook_meta **pctx,
+static int evrpc_hook_associate_meta_(struct evrpc_hook_meta **pctx,
     struct evhttp_connection *evcon);
 
 /* creates a new meta data store */

--- a/evthread.c
+++ b/evthread.c
@@ -402,8 +402,9 @@ evthread_setup_global_lock_(void *lock_, unsigned locktype, int enable_locks)
 	} else {
 		/* Case 4: Fill in a debug lock with a real lock */
 		struct debug_lock *lock = lock_ ? lock_ : debug_lock_alloc(locktype);
-		EVUTIL_ASSERT(enable_locks &&
-		              evthread_lock_debugging_enabled_);
+		if (!lock)
+			return NULL;
+		EVUTIL_ASSERT(enable_locks && evthread_lock_debugging_enabled_);
 		EVUTIL_ASSERT(lock->locktype == locktype);
 		if (!lock->lock) {
 			lock->lock = original_lock_fns_.alloc(

--- a/evutil.c
+++ b/evutil.c
@@ -2284,6 +2284,7 @@ evutil_inet_pton_scope(int af, const char *src, void *dst, unsigned *indexp)
 		return -1;
 	}
 	cp = strchr(tmp_src, '%');
+	// The check had been already done above against original src
 	*cp = '\0';
 	r = evutil_inet_pton(af, tmp_src, dst);
 	mm_free(tmp_src);

--- a/include/event2/rpc.h
+++ b/include/event2/rpc.h
@@ -546,9 +546,10 @@ int evrpc_resume_request(void *vbase, void *ctx, enum EVRPC_HOOK_RESULT res);
  * @param key a NUL-terminated c-string
  * @param data the data to be associated with the key
  * @param data_size the size of the data
+ * @return 0 on success or -1 on failure (in case of memory allocation failures)
  */
 EVENT2_EXPORT_SYMBOL
-void evrpc_hook_add_meta(void *ctx, const char *key,
+int evrpc_hook_add_meta(void *ctx, const char *key,
     const void *data, size_t data_size);
 
 /** retrieves meta data previously associated


### PR DESCRIPTION
Actually this PR will not make it completely happy, since it has few false-positive reports, but at least something, and it found one minor issue - https://github.com/libevent/libevent/commit/5412b2c30d7ee228db1da4cfe2f5176ce4e29706

Also note that in order to do this for evrpc, `evrpc_hook_add_meta()` should have return value, so this is a minor ABI change, which should not affect C ABI, but still worth to mention.

Fixes: https://github.com/libevent/libevent/issues/1516