### PR TITLE
Fix util/monotonic_prc_fallback under FreeBSD

### DIFF
--- a/evutil_time.c
+++ b/evutil_time.c
@@ -316,6 +316,8 @@ evutil_configure_monotonic_time_(struct evutil_monotonic_timer *base,
 	const int fallback = flags & EV_MONOT_FALLBACK;
 	struct timespec	ts;
 
+	memset(base, 0, sizeof(*base));
+
 #ifdef CLOCK_MONOTONIC_COARSE
 	if (CLOCK_MONOTONIC_COARSE < 0) {
 		/* Technically speaking, nothing keeps CLOCK_* from being


### PR DESCRIPTION
Looks like there was garbage, since evutil_configure_monotonic_time_() does not reset evutil_monotonic_timer structure, while in case of fallback it uses two fields from it:
- last_time
- adjust_monotonic_clock

Fixes: https://github.com/libevent/libevent/issues/1495
Fixes: https://github.com/libevent/libevent/issues/776
Fixes: https://github.com/libevent/libevent/issues/1193