### PR TITLE
Set SOCK_NONBLOCK and SOCK_CLOEXEC in the type argument of socketpair

### DIFF
--- a/evutil.c
+++ b/evutil.c
@@ -2777,6 +2777,7 @@ evutil_socketpair(int family, int type, int protocol, evutil_socket_t fd[2])
 {
 	int ret = 0;
 	int sock_type = type;
+	(void) sock_type;
 #ifndef SOCK_NONBLOCK
 	type &= ~EVUTIL_SOCK_NONBLOCK;
 #endif

--- a/evutil.c
+++ b/evutil.c
@@ -2778,6 +2778,11 @@ evutil_socketpair(int family, int type, int protocol, evutil_socket_t fd[2])
 	int ret = 0;
 	int sock_type = type;
 	(void) sock_type;
+	/* SOCK_NONBLOCK and SOCK_CLOEXEC are UNIX-specific. Therefore, the predefined and
+	 * platform-independent macros EVUTIL_SOCK_NONBLOCK and EVUTIL_SOCK_CLOEXEC are used
+	 * in type argument as combination while SOCK_NONBLOCK and SOCK_CLOEXEC are used for
+	 * distinguishing platforms.
+	 */
 #ifndef SOCK_NONBLOCK
 	type &= ~EVUTIL_SOCK_NONBLOCK;
 #endif

--- a/include/event2/util.h
+++ b/include/event2/util.h
@@ -377,9 +377,11 @@ int evutil_gettime_monotonic(struct evutil_monotonic_timer *timer,
 
 /** Create two new sockets that are connected to each other.
 
-    On Unix, this simply calls socketpair().
-    On Windows, it uses the loopback network interface on 127.0.0.1, and only
-    AF_INET,SOCK_STREAM are supported.
+    On Unix, this simply calls socketpair() and creates an unnamed pair of connected sockets
+    in the specified domain, of the specified type, and using the optionally specified protocol.
+
+    On Windows, it will try to use the AF_UNIX to create unix socket pair if available, otherwise
+    it instead uses AF_INET to create socket pair, binding the loopback network interface 127.0.0.1.
 
     Including the bitwise OR of the EVUTIL_SOCK_NONBLOCK and/or EVUTIL_SOCK_CLOEXEC
     in the type argument will apply to both file descriptors.
@@ -390,7 +392,7 @@ int evutil_gettime_monotonic(struct evutil_monotonic_timer *timer,
     Parameters and return values are as for socketpair()
 */
 EVENT2_EXPORT_SYMBOL
-int evutil_socketpair(int d, int type, int protocol, evutil_socket_t sv[2]);
+int evutil_socketpair(int domain, int type, int protocol, evutil_socket_t sv[2]);
 /** Do platform-specific operations as needed to make a socket nonblocking.
 
     @param sock The socket to make nonblocking

--- a/include/event2/util.h
+++ b/include/event2/util.h
@@ -377,9 +377,12 @@ int evutil_gettime_monotonic(struct evutil_monotonic_timer *timer,
 
 /** Create two new sockets that are connected to each other.
 
-    On Unix, this simply calls socketpair().  On Windows, it uses the
-    loopback network interface on 127.0.0.1, and only
+    On Unix, this simply calls socketpair().
+    On Windows, it uses the loopback network interface on 127.0.0.1, and only
     AF_INET,SOCK_STREAM are supported.
+
+    Including the bitwise OR of the EVUTIL_SOCK_NONBLOCK and/or EVUTIL_SOCK_CLOEXEC
+    in the type argument will apply to both file descriptors.
 
     (This may fail on some Windows hosts where firewall software has cleverly
     decided to keep 127.0.0.1 from talking to itself.)

--- a/test/regress_buffer.c
+++ b/test/regress_buffer.c
@@ -1237,14 +1237,12 @@ test_evbuffer_add_file(void *ptr)
 #if defined(EVENT__HAVE_SENDFILE) && defined(__sun__) && defined(__svr4__)
 	/* We need to use a pair of AF_INET sockets, since Solaris
 	   doesn't support sendfile() over AF_UNIX. */
-	if (evutil_ersatz_socketpair_(AF_INET, SOCK_STREAM, 0, pair) == -1)
+	if (evutil_ersatz_socketpair_(AF_INET, SOCK_STREAM|EVUTIL_SOCK_NONBLOCK, 0, pair) == -1)
 		tt_abort_msg("ersatz_socketpair failed");
 #else
-	if (evutil_socketpair(AF_UNIX, SOCK_STREAM, 0, pair) == -1)
+	if (evutil_socketpair(AF_UNIX, SOCK_STREAM|EVUTIL_SOCK_NONBLOCK, 0, pair) == -1)
 		tt_abort_msg("socketpair failed");
 #endif
-	evutil_make_socket_nonblocking(pair[0]);
-	evutil_make_socket_nonblocking(pair[1]);
 
 	tt_assert(fd != -1);
 
@@ -2665,7 +2663,7 @@ test_evbuffer_freeze(void *ptr)
 	FREEZE_EQ(r, 0, -1);
 	len = strlen(tmpfilecontent);
 	fd = regress_make_tmpfile(tmpfilecontent, len, &tmpfilename);
-	/* On Windows, if TMP environment variable is corrupted, we may not be 
+	/* On Windows, if TMP environment variable is corrupted, we may not be
 	 * able create temporary file, just skip it */
 	if (fd < 0)
 		tt_skip();

--- a/test/regress_main.c
+++ b/test/regress_main.c
@@ -286,18 +286,8 @@ basic_test_setup(const struct testcase_t *testcase)
 	}
 
 	if (testcase->flags & TT_NEED_SOCKETPAIR) {
-		if (evutil_socketpair(AF_UNIX, SOCK_STREAM, 0, spair) == -1) {
+		if (evutil_socketpair(AF_UNIX, SOCK_STREAM|EVUTIL_SOCK_NONBLOCK, 0, spair) == -1) {
 			fprintf(stderr, "%s: socketpair\n", __func__);
-			exit(1);
-		}
-
-		if (evutil_make_socket_nonblocking(spair[0]) == -1) {
-			fprintf(stderr, "fcntl(O_NONBLOCK)");
-			exit(1);
-		}
-
-		if (evutil_make_socket_nonblocking(spair[1]) == -1) {
-			fprintf(stderr, "fcntl(O_NONBLOCK)");
 			exit(1);
 		}
 	}

--- a/test/regress_zlib.c
+++ b/test/regress_zlib.c
@@ -49,6 +49,8 @@
 #include <assert.h>
 #include <errno.h>
 
+#include "util-internal.h"
+
 #include "event2/util.h"
 #include "event2/event.h"
 #include "event2/event_compat.h"
@@ -286,12 +288,9 @@ test_bufferevent_zlib(void *arg)
 	infilter_calls = outfilter_calls = readcb_finished = writecb_finished
 	    = errorcb_invoked = 0;
 
-	if (evutil_socketpair(AF_UNIX, SOCK_STREAM, 0, pair) == -1) {
+	if (evutil_socketpair(AF_UNIX, SOCK_STREAM|EVUTIL_SOCK_NONBLOCK, 0, pair) == -1) {
 		tt_abort_perror("socketpair");
 	}
-
-	evutil_make_socket_nonblocking(pair[0]);
-	evutil_make_socket_nonblocking(pair[1]);
 
 	bev1 = bufferevent_socket_new(NULL, pair[0], 0);
 	bev2 = bufferevent_socket_new(NULL, pair[1], 0);


### PR DESCRIPTION
Setting `SOCK_NONBLOCK` and `SOCK_CLOEXEC` in the `type` argument of `socketpair()` is widely supported across UNIX-like OS: Linux, *BSD, Solaris, etc., as is the `socket()`. This will conserve several extra system calls, we should use it where available.

### References

- [socketpair(2) on Linux](https://man7.org/linux/man-pages/man2/socketpair.2.html#HISTORY)
- [socketpair(2) on FreeBSD](https://man.freebsd.org/cgi/man.cgi?query=socketpair&sektion=2#DESCRIPTION)
- [socketpair(2) on DragonFly](https://man.dragonflybsd.org/?command=socketpair&section=2)
- [socketpair(2) on NetBSD](https://man.netbsd.org/socketpair.2#DESCRIPTION)
- [socketpair(2) on OpenBSD](https://man.openbsd.org/socketpair.2)
- [socketpair(3C) on Solaris](https://docs.oracle.com/cd/E88353_01/html/E37843/socketpair-3c.html)