### PR TITLE
evutil: don't memset more memory then memcpy

### DIFF
--- a/evutil.c
+++ b/evutil.c
@@ -2379,7 +2379,7 @@ evutil_parse_sockaddr_port(const char *ip_as_string, struct sockaddr *out, int *
 		if ((int)sizeof(sin6) > *outlen)
 			return -1;
 		sin6.sin6_scope_id = if_index;
-		memset(out, 0, *outlen);
+		memset(out, 0, sizeof(sin6));
 		memcpy(out, &sin6, sizeof(sin6));
 		*outlen = sizeof(sin6);
 		return 0;
@@ -2398,7 +2398,7 @@ evutil_parse_sockaddr_port(const char *ip_as_string, struct sockaddr *out, int *
 			return -1;
 		if ((int)sizeof(sin) > *outlen)
 			return -1;
-		memset(out, 0, *outlen);
+		memset(out, 0, sizeof(sin));
 		memcpy(out, &sin, sizeof(sin));
 		*outlen = sizeof(sin);
 		return 0;


### PR DESCRIPTION
In `evutil_parse_sockaddr_port`, it whould memset the out to zero, however, if `outlen` is invalid, it would be an undefined behavior.

This should close #1573.