### PR TITLE
Drop 4096 bytes of the early keystream

### DIFF
--- a/arc4random.c
+++ b/arc4random.c
@@ -374,9 +374,9 @@ arc4_stir(void)
 	 * belief that "words" in the Fluhrer/Mantin/Shamir paper refers
 	 * to processor words.
 	 *
-	 * We add another sect to the cargo cult, and choose 12*256.
+	 * We add another sect to the cargo cult, and choose 16*256.
 	 */
-	for (i = 0; i < 12*256; i++)
+	for (i = 0; i < 16*256; i++)
 		(void)arc4_getbyte();
 
 	rekey_fuzz = arc4_getword();


### PR DESCRIPTION
It might be safer to drop 4096 bytes to be on the safe side.

See: https://twitter.com/nugxperience/status/1773906926503591970

