### PR TITLE
fix WSOptions enum value and extended payload length bug

### DIFF
--- a/test/regress_ws.c
+++ b/test/regress_ws.c
@@ -205,15 +205,17 @@ receive_ws_msg(struct evbuffer *buf, size_t *out_len, bool *is_text_type)
 
 enum WSOptions {
 	WS_FIN = 1 << 7,
-	WS_TEXT = 1 << 1,
-	WS_BINARY = 0 << 1,
+	WS_TEXT = 1 << 0,
+	WS_BINARY = 1 << 1,
 };
 
 static void
 send_ws_msg(
 	struct evbuffer *buf, const char *msg, size_t len, enum WSOptions options)
 {
-	uint8_t a = 0, b = 0, c = 0, d = 0;
+	uint8_t a = 0, b = 0;
+	uint16_t c = 0;
+       	uint64_t d = 0;
 	uint8_t mask_key[4] = {1, 2, 3, 4}; /* should be random */
 	uint8_t m;
 	size_t i;


### PR DESCRIPTION
RFC6455:

Opcode:  4 bits
> *  %x1 denotes a text frame
> *  %x2 denotes a binary frame

Payload length:  7 bits, 7+16 bits, or 7+64 bits
> The length of the "Payload data", in bytes: if 0-125, that is the payload length.  
> If 126, the following 2 bytes interpreted as a 16-bit unsigned integer are the payload length.  
> If 127, the following 8 bytes interpreted as a 64-bit unsigned integer (the most significant bit MUST be 0) are the payload length.

Fixes: https://github.com/libevent/libevent/issues/1587