### PR TITLE
Feat/hashpin sensitive workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,9 +15,9 @@ jobs:
       contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
         with:
           path: build
           key: ${{ matrix.os }}-coverage-v2
@@ -43,12 +43,12 @@ jobs:
             make verify_coverage
 
       - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@v1
+        uses: coverallsapp/github-action@09b709cf6a16e30b0808ba050c7a6e8a5ef13f8d # v1.2.5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./build/coverage.info.cleaned
 
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@3446296876d12d4e3a0f3145a3c87e67bf0a16b5 # v1.0.0
         if: failure()
         with:
           name: coverage-build
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Install Dependencies
         run:
@@ -115,12 +115,12 @@ jobs:
           git push -f git@github.com:$owner_name/abi master
 
       # XXX: requires container-id for docker
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@3446296876d12d4e3a0f3145a3c87e67bf0a16b5 # v1.0.0
         if: failure()
         with:
           name: build
           path: /tmp/le-abi-root
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@3446296876d12d4e3a0f3145a3c87e67bf0a16b5 # v1.0.0
         with:
           name: build
           path: /tmp/le-abi-root/work/abi-check
@@ -133,7 +133,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Install Depends
         run: |
           sudo apt install doxygen libmbedtls-dev
@@ -169,7 +169,7 @@ jobs:
           git commit -m "Update documentation (libevent/libevent@$short_commit_id)"
           git push -f git@github.com:$owner_name/doc master
 
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@3446296876d12d4e3a0f3145a3c87e67bf0a16b5 # v1.0.0
         if: failure()
         with:
           name: doxygen-build


### PR DESCRIPTION
Fixes #1523

Hi @azat! I'm implementing the changes as discussed on the issue. More specifically:
1. I'm hashpinning the GitHub workflows that are run on privileged permissions. You could also hashpin all the other workflows, but the security benefit is debatable and could enhance maintenance effort.
2. I'm enabling dependabot to automatically create a single monthly PR updating the versions of all your GitHub Actions.

Thanks very much for your attention and support. Count on me if you find any problems or have any doubt =)

Cheers,
