### PR TITLE
build: Add `Iphlpapi` to `Libs.private` in `*.pc` files on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1070,7 +1070,7 @@ if(WIN32)
     list(APPEND HDR_PRIVATE WIN32-Code/getopt.h)
 
     set(EVENT__DNS_USE_FTIME_FOR_ID 1)
-    set(LIB_PLATFORM ws2_32 shell32 advapi32 bcrypt)
+    set(LIB_PLATFORM ws2_32 shell32 advapi32 bcrypt iphlpapi)
     add_definitions(
             -D_CRT_SECURE_NO_WARNINGS
             -D_CRT_NONSTDC_NO_DEPRECATE)

--- a/configure.ac
+++ b/configure.ac
@@ -267,6 +267,7 @@ AM_CONDITIONAL(BUILD_WITH_NO_UNDEFINED, test x$bwin32 = xtrue || test x$cygwin =
 
 if test "$bwin32" = "true"; then
   AC_CHECK_LIB([ws2_32], [main])
+  AC_CHECK_LIB([iphlpapi], [GetAdaptersAddresses])
 fi
 
 dnl Checks for typedefs, structures, and compiler characteristics.


### PR DESCRIPTION
The Iphlpapi library has been required since https://github.com/libevent/libevent/pull/923 at least for the `if_nametoindex` call when cross-compiling for Windows with static linking.

Refs: https://github.com/libevent/libevent/issues/1110.