### PR TITLE
Support SO_REUSEPORT on FreeBSD, DragonFly and Solaris

### DIFF
--- a/evutil.c
+++ b/evutil.c
@@ -480,14 +480,14 @@ evutil_make_listen_socket_reuseable(evutil_socket_t sock)
 int
 evutil_make_listen_socket_reuseable_port(evutil_socket_t sock)
 {
-#if __FreeBSD__ >= 12 && defined(SO_REUSEPORT_LB)
+#if defined(__FreeBSD__) && __FreeBSD__ >= 12 && defined(SO_REUSEPORT_LB)
 	/* FreeBSD 12 introduced a new socket option named SO_REUSEPORT_LB
 	 * with the capability of load balancing, it's the equivalent of
 	 * the SO_REUSEPORTs on Linux and DragonFlyBSD. */
 	int enabled = 1;
 	return setsockopt(sock, SOL_SOCKET, SO_REUSEPORT_LB, (void*)&enabled,
 	    (ev_socklen_t)sizeof(enabled));
-#elif (defined __linux__ || defined __DragonFly__ || __sun) && defined(SO_REUSEPORT)
+#elif (defined __linux__ || defined __DragonFly__ || defined __sun) && defined(SO_REUSEPORT)
 	int enabled = 1;
 	/* SO_REUSEPORT on Linux 3.9+ means, "Multiple servers (processes or
 	 * threads) can bind to the same port if they each set the option".

--- a/evutil.c
+++ b/evutil.c
@@ -506,6 +506,12 @@ evutil_make_listen_socket_reuseable_port(evutil_socket_t sock)
 	 * Solaris 11 supported SO_REUSEPORT, but it's implemented only for
 	 * binding to the same address and port, without load balancing.
 	 * Solaris 11.4 extended SO_REUSEPORT with the capability of load balancing.
+	 *
+	 * TODO(panjf2000): Since it's impossible to detect the Solaris 11.4 version
+	 * via OS macros, so we check the presence of the socket option SO_FLOW_NAME
+	 * that was first introduced to Solaris 11.4. But try to find some other ways
+	 * to detect the Solaris version at runtime instead of compile time cuz this
+	 * code could be compiled on one machine and run on another.
 	 */
 	return setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (void*)&enabled,
 	    (ev_socklen_t)sizeof(enabled));

--- a/evutil.c
+++ b/evutil.c
@@ -53,6 +53,9 @@
 #include <netioapi.h>
 #endif
 
+#ifdef EVENT__HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
 #include <sys/types.h>
 #ifdef EVENT__HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
@@ -487,7 +490,10 @@ evutil_make_listen_socket_reuseable_port(evutil_socket_t sock)
 	int enabled = 1;
 	return setsockopt(sock, SOL_SOCKET, SO_REUSEPORT_LB, (void*)&enabled,
 	    (ev_socklen_t)sizeof(enabled));
-#elif (defined(__linux__) || defined(__DragonFly__) || defined(__sun)) && defined(SO_REUSEPORT)
+#elif (defined(__linux__) || \
+      (defined(__DragonFly__) && __DragonFly_version >= 300600) || \
+      (defined(__sun) && defined(SO_FLOW_NAME))) && \
+      defined(SO_REUSEPORT)
 	int enabled = 1;
 	/* SO_REUSEPORT on Linux 3.9+ means, "Multiple servers (processes or
 	 * threads) can bind to the same port if they each set the option".

--- a/evutil.c
+++ b/evutil.c
@@ -507,11 +507,9 @@ evutil_make_listen_socket_reuseable_port(evutil_socket_t sock)
 	 * binding to the same address and port, without load balancing.
 	 * Solaris 11.4 extended SO_REUSEPORT with the capability of load balancing.
 	 *
-	 * TODO(panjf2000): Since it's impossible to detect the Solaris 11.4 version
-	 * via OS macros, so we check the presence of the socket option SO_FLOW_NAME
-	 * that was first introduced to Solaris 11.4. But try to find some other ways
-	 * to detect the Solaris version at runtime instead of compile time cuz this
-	 * code could be compiled on one machine and run on another.
+	 * Since it's impossible to detect the Solaris 11.4 version via OS macros,
+	 * so we check the presence of the socket option SO_FLOW_NAME that was first
+	 * introduced to Solaris 11.4.
 	 */
 	return setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (void*)&enabled,
 	    (ev_socklen_t)sizeof(enabled));

--- a/evutil.c
+++ b/evutil.c
@@ -487,7 +487,7 @@ evutil_make_listen_socket_reuseable_port(evutil_socket_t sock)
 	int enabled = 1;
 	return setsockopt(sock, SOL_SOCKET, SO_REUSEPORT_LB, (void*)&enabled,
 	    (ev_socklen_t)sizeof(enabled));
-#elif (defined __linux__ || defined __DragonFly__ || defined __sun) && defined(SO_REUSEPORT)
+#elif (defined(__linux__) || defined(__DragonFly__) || defined(__sun)) && defined(SO_REUSEPORT)
 	int enabled = 1;
 	/* SO_REUSEPORT on Linux 3.9+ means, "Multiple servers (processes or
 	 * threads) can bind to the same port if they each set the option".

--- a/include/event2/listener.h
+++ b/include/event2/listener.h
@@ -90,12 +90,16 @@ typedef void (*evconnlistener_errorcb)(struct evconnlistener *, void *);
  */
 #define LEV_OPT_DEFERRED_ACCEPT		(1u<<6)
 /** Flag: Indicates that we ask to allow multiple servers (processes or
- * threads) to bind to the same port if they each set the option. 
- * 
+ * threads) to bind to the same port if they each set the option for
+ * incoming connections/datagrams to be distributed evenly across all of
+ * the threads (or processes).
+ *
  * SO_REUSEPORT is what most people would expect SO_REUSEADDR to be, however
  * SO_REUSEPORT does not imply SO_REUSEADDR.
  *
- * This is only available on Linux and kernel 3.9+
+ * This feature is available only on Linux 3.9+, DragonFlyBSD 3.6+,
+ * FreeBSD 12.0+, Solaris 11.4 for now.
+ *
  */
 #define LEV_OPT_REUSEABLE_PORT		(1u<<7)
 /** Flag: Indicates that the listener wants to work only in IPv6 socket.
@@ -110,7 +114,7 @@ typedef void (*evconnlistener_errorcb)(struct evconnlistener *, void *);
  * This socket option on Windows is instead enabled by default.
  */
 #define LEV_OPT_BIND_IPV6ONLY		(1u<<8)
-/** Flag: Indicates that the listener wants to work only in both IPv4 and 
+/** Flag: Indicates that the listener wants to work only in both IPv4 and
  * IPv6 socket.
  *
  * This flag exists as copmlement to LEV_OPT_BIND_IPV6ONLY to account for

--- a/include/event2/util.h
+++ b/include/event2/util.h
@@ -417,10 +417,13 @@ int evutil_make_listen_socket_reuseable(evutil_socket_t sock);
 
 /** Do platform-specific operations to make a listener port reusable.
 
-    Specifically, we want to make sure that multiple programs which also
-    set the same socket option will be able to bind, listen at the same time.
+    Specifically, we want to make sure that multiple programs that also
+    set the same socket option will be able to bind, and listen at the
+    same time, for incoming connections/datagrams to be distributed evenly
+    across all of the threads (or processes).
 
-    This is a feature available only to Linux 3.9+
+    This feature is available only on Linux 3.9+, DragonFlyBSD 3.6+,
+    FreeBSD 12.0+, Solaris 11.4 for now.
 
     @param sock The socket to make reusable
     @return 0 on success, -1 on failure

--- a/test/regress_dns.c
+++ b/test/regress_dns.c
@@ -1307,7 +1307,7 @@ dns_nameservers_no_nameservers_configured_test(void *arg)
 	const char filecontents[] = "# tmp empty resolv.conf\n";
 	const size_t filecontentssize = sizeof(filecontents);
 	int ok;
-
+	
 	fd = regress_make_tmpfile(filecontents, filecontentssize, &tmpfilename);
 	if (fd < 0)
 		tt_skip();

--- a/test/regress_dns.c
+++ b/test/regress_dns.c
@@ -1307,7 +1307,7 @@ dns_nameservers_no_nameservers_configured_test(void *arg)
 	const char filecontents[] = "# tmp empty resolv.conf\n";
 	const size_t filecontentssize = sizeof(filecontents);
 	int ok;
-	
+
 	fd = regress_make_tmpfile(filecontents, filecontentssize, &tmpfilename);
 	if (fd < 0)
 		tt_skip();


### PR DESCRIPTION
## References

- [The SO_REUSEPORT socket option on Linux](https://lwn.net/Articles/542629/)
- [DragonFly Release 3.6](https://www.dragonflybsd.org/release36/)
- [FreeBSD 12.0-RELEASE Release Notes](https://www.freebsd.org/releases/12.0R/relnotes/)
- [SO_REUSEPORT on Solaris 11.4](https://docs.oracle.com/cd/E88353_01/html/E37843/setsockopt-3c.html)
