### PR TITLE
Add Privacy Manifest for App Store

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -101,8 +101,9 @@ LIBEVENT_PKGCONFIG=libevent.pc libevent_core.pc libevent_extra.pc
 # included from other files.
 PLATFORM_DEPENDENT_SRC = \
 	arc4random.c \
-	epoll_sub.c \
 	bufferevent_ssl.c \
+	epoll_sub.c \
+	PrivacyInfo.xcprivacy \
 	test/regress_ssl.c
 
 CMAKE_FILES = \

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>0A2A.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Fix #1583

As we don't distribute the libevent SDK as an iOS package (SwiftPM , CocoaPods, Carthage), we don't have to reference this PrivacyInfo.xcprivacy file by ourselves for now. Having the file in the repo makes it easy to reference for those using libevent for an app on iOS App Store.

Official doc: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files

Adopted reason: 0A2A.1 (explained why in #1583)

Alternative solution: instead of this PrivacyInfo.xcprivacy file, we could change the code of libevent to replace calls to `fstat` to something else, like `lseek` (suggested [here](https://forums.developer.apple.com/forums/thread/734750), but with the caveat that we would need to call it thrice: SEEK_CUR to save pos, SEEK_END to get filesize, SEEK_POS to restore pos) or `[[[NSURL fileURLWithPath:filePath] resourceValuesForKeys:@[NSURLFileSizeKey] error:nil][NSURLFileSizeKey] unsignedLongLongValue]` (by adding an ObjC file for Darwin file access). But considering that Apple will block all apps submissions from 1st of May 2024 if they don't comply, the PrivacyInfo.xcprivacy solution is the only easy one for now.