### PR TITLE
Fix evbuffer_file_segment_new 64-bit support on Win32

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -2373,7 +2373,7 @@ evbuffer_read(struct evbuffer *buf, evutil_socket_t fd, int howmuch)
 #endif
 	}
 
-#else /*!USE_IOVEC_IMPL*/
+#else /* !USE_IOVEC_IMPL */
 	/* If we don't have FIONREAD, we might waste some space here */
 	/* XXX we _will_ waste some space here if there is any space left
 	 * over on buf->last. */
@@ -3011,27 +3011,15 @@ evbuffer_file_segment_new(
 	seg->file_offset = offset;
 	seg->cleanup_cb = NULL;
 	seg->cleanup_cb_arg = NULL;
-#ifdef _WIN32
-#ifndef lseek
-#define lseek _lseeki64
-#endif
-#ifndef fstat
-#define fstat _fstat
-#endif
-#ifndef stat
-#define stat _stat
-#endif
-#endif
 	if (length == -1) {
-		struct stat st;
-		if (fstat(fd, &st) < 0)
+		length = evutil_fd_filesize(fd);
+		if (length == -1)
 			goto err;
-		length = st.st_size;
 	}
 	seg->length = length;
 
 	if (offset < 0 || length < 0 ||
-	    ((ev_uint64_t)length > EVBUFFER_CHAIN_MAX) ||
+	    (length > EVBUFFER_CHAIN_MAX) ||
 	    (ev_uint64_t)offset > (ev_uint64_t)(EVBUFFER_CHAIN_MAX - length))
 		goto err;
 
@@ -3148,6 +3136,11 @@ evbuffer_file_segment_materialize(struct evbuffer_file_segment *seg)
 		ev_ssize_t n = 0;
 		char *mem;
 #ifndef EVENT__HAVE_PREAD
+#ifdef _WIN32
+#ifndef lseek
+#define lseek _lseeki64
+#endif
+#endif
 		ev_off_t start_pos = lseek(fd, 0, SEEK_CUR);
 		ev_off_t pos;
 		int e;

--- a/buffer.c
+++ b/buffer.c
@@ -3019,7 +3019,7 @@ evbuffer_file_segment_new(
 	seg->length = length;
 
 	if (offset < 0 || length < 0 ||
-	    (length > EVBUFFER_CHAIN_MAX) ||
+	    ((ev_uint64_t)length > EVBUFFER_CHAIN_MAX) ||
 	    (ev_uint64_t)offset > (ev_uint64_t)(EVBUFFER_CHAIN_MAX - length))
 		goto err;
 

--- a/evutil.c
+++ b/evutil.c
@@ -163,10 +163,10 @@ evutil_open_closeonexec_(const char *pathname, int flags, unsigned mode)
 
 ev_off_t evutil_fd_filesize(evutil_socket_t fd)
 {
-    struct stat st;
-    if (fstat(fd, &st) < 0)
-        return -1;
-    return st.st_size;
+	struct stat st;
+	if (fstat(fd, &st) < 0)
+		return -1;
+	return st.st_size;
 }
 
 /**

--- a/evutil.c
+++ b/evutil.c
@@ -183,7 +183,8 @@ int
 evutil_read_file_(const char *filename, char **content_out, size_t *len_out,
     int is_binary)
 {
-	int fd, r;
+	int fd;
+	ev_ssize_t r;
 	ev_off_t length;
 	char *mem;
 	size_t read_so_far = 0;
@@ -203,8 +204,7 @@ evutil_read_file_(const char *filename, char **content_out, size_t *len_out,
 	if (fd < 0)
 		return -1;
 	length = evutil_fd_filesize(fd);
-	if (length < 0 ||
-        length > EV_SSIZE_MAX-1 ) {
+	if (length < 0 || length > EV_SSIZE_MAX-1) {
 		close(fd);
 		return -2;
 	}
@@ -221,9 +221,8 @@ evutil_read_file_(const char *filename, char **content_out, size_t *len_out,
 #endif
 	while ((r = read(fd, mem+read_so_far, N_TO_READ(length - read_so_far))) > 0) {
 		read_so_far += r;
-		if (read_so_far >= length)
+		if (read_so_far >= (size_t)length)
 			break;
-		EVUTIL_ASSERT(read_so_far < length);
 	}
 	close(fd);
 	if (r < 0) {

--- a/evutil.c
+++ b/evutil.c
@@ -110,6 +110,7 @@
 #define read _read
 #define close _close
 #ifndef fstat
+// i64 suffix is for 64-bit filesize support
 #define fstat _fstati64
 #endif
 #ifndef stat
@@ -160,6 +161,14 @@ evutil_open_closeonexec_(const char *pathname, int flags, unsigned mode)
 	return fd;
 }
 
+ev_off_t evutil_fd_filesize(evutil_socket_t fd)
+{
+    struct stat st;
+    if (fstat(fd, &st) < 0)
+        return -1;
+    return st.st_size;
+}
+
 /**
    Read the contents of 'filename' into a newly allocated NUL-terminated
    string.  Set *content_out to hold this string, and *len_out to hold its
@@ -175,9 +184,9 @@ evutil_read_file_(const char *filename, char **content_out, size_t *len_out,
     int is_binary)
 {
 	int fd, r;
-	struct stat st;
+	ev_off_t length;
 	char *mem;
-	size_t read_so_far=0;
+	size_t read_so_far = 0;
 	int mode = O_RDONLY;
 
 	EVUTIL_ASSERT(content_out);
@@ -193,12 +202,13 @@ evutil_read_file_(const char *filename, char **content_out, size_t *len_out,
 	fd = evutil_open_closeonexec_(filename, mode, 0);
 	if (fd < 0)
 		return -1;
-	if (fstat(fd, &st) || st.st_size < 0 ||
-	    st.st_size > EV_SSIZE_MAX-1 ) {
+	length = evutil_fd_filesize(fd);
+	if (length < 0 ||
+        length > EV_SSIZE_MAX-1 ) {
 		close(fd);
 		return -2;
 	}
-	mem = mm_malloc((size_t)st.st_size + 1);
+	mem = mm_malloc(length + 1);
 	if (!mem) {
 		close(fd);
 		return -2;
@@ -209,11 +219,11 @@ evutil_read_file_(const char *filename, char **content_out, size_t *len_out,
 #else
 #define N_TO_READ(x) (x)
 #endif
-	while ((r = read(fd, mem+read_so_far, N_TO_READ(st.st_size - read_so_far))) > 0) {
+	while ((r = read(fd, mem+read_so_far, N_TO_READ(length - read_so_far))) > 0) {
 		read_so_far += r;
-		if (read_so_far >= (size_t)st.st_size)
+		if (read_so_far >= length)
 			break;
-		EVUTIL_ASSERT(read_so_far < (size_t)st.st_size);
+		EVUTIL_ASSERT(read_so_far < length);
 	}
 	close(fd);
 	if (r < 0) {

--- a/util-internal.h
+++ b/util-internal.h
@@ -293,6 +293,8 @@ void evutil_rtrim_lws_(char *);
  */
 int evutil_open_closeonexec_(const char *pathname, int flags, unsigned mode);
 
+ev_off_t evutil_fd_filesize(evutil_socket_t fd);
+
 EVENT2_EXPORT_SYMBOL
 int evutil_read_file_(const char *filename, char **content_out, size_t *len_out,
     int is_binary);


### PR DESCRIPTION
This fixes the problematic `#define fstat _fstat` which would only support files up to 2 GB.

Also refactored it as `evutil_fd_filesize` to avoid exposing `stat` when not necessary.