### PR TITLE
Asserting we're not freeing active event

### DIFF
--- a/event.c
+++ b/event.c
@@ -1677,7 +1677,7 @@ event_process_active_single_queue(struct event_base *base,
 	EVUTIL_ASSERT(activeq != NULL);
 
 	for (evcb = TAILQ_FIRST(activeq); evcb; evcb = TAILQ_FIRST(activeq)) {
-		struct event *ev=NULL;
+		struct event *ev = NULL;
 		if (evcb->evcb_flags & EVLIST_INIT) {
 			ev = event_callback_to_event(evcb);
 
@@ -1698,6 +1698,9 @@ event_process_active_single_queue(struct event_base *base,
 				"closure %d, call %p",
 				(void *)evcb, evcb->evcb_closure, (void *)evcb->evcb_cb_union.evcb_callback));
 		}
+		// We don't want an infinite loop or use of memory after it is freed.
+		// Hence, for next loop iteration, it is expected that `event_queue_remove_active` or `event_del_nolock_` have removed current event from the queue at this point.
+		EVUTIL_ASSERT(evcb != TAILQ_FIRST(activeq));
 
 		if (!(evcb->evcb_flags & EVLIST_INTERNAL))
 			++count;

--- a/event.c
+++ b/event.c
@@ -2575,7 +2575,7 @@ static int
 evthread_notify_base_default(struct event_base *base)
 {
 	char buf[1];
-	int r;
+	ev_ssize_t r;
 	buf[0] = (char) 0;
 #ifdef _WIN32
 	r = send(base->th_notify_fd[1], buf, 1, 0);


### PR DESCRIPTION
Fix #1638.

Although, could be done differently if you have suggestions.

Conditions:
- `evcb_flags & EVLIST_INIT` to set `ev`
- `! (ev->ev_events & EV_PERSIST)` to skip `event_queue_remove_active`
- `! (ev->ev_flags & EVLIST_FINALIZING)` to skip `event_queue_remove_active`
- eventually `ev->ev_base == NULL` to skip `event_queue_remove_active` in `event_del_nolock_`
- or `! (ev->ev_flags & EVLIST_ACTIVE)` to skip `event_queue_remove_active` in `event_del_nolock_`
- `evcb->evcb_closure == EV_CLOSURE_EVENT_FINALIZE_FREE` for the free to occur
- `! base->event_break` to continue the loop
- `! base->event_continue` to continue the loop

When those conditions are met, we free an event without removing it from the queue.
If you know that one of those conditions is strictly impossible, then we could add a specific assert instead my current proposal.
Another alternative to "not free" when it's in the queue, is to remove that event from the queue when above conditions arise, but I wouldn't know the side effects of such change.