### PR TITLE
Improve hashsocket() (for win32) to avoid collisions

### DIFF
--- a/evmap.c
+++ b/evmap.c
@@ -95,7 +95,7 @@ hashsocket(struct event_map_entry *e)
 	 * matter.  Our hashtable implementation really likes low-order bits,
 	 * though, so let's do the rotate-and-add trick. */
 	unsigned h = (unsigned) e->fd;
-	h += (h >> 2) | (h << 30);
+	h = (h >> 2) | (h << 30);
 	return h;
 }
 


### PR DESCRIPTION
In 91e3ead, @nmathewson "improved" the hashsocket function with a "rotate-and-add trick".

Well, while rotating the bits is fine, performing an addition on the other hand will divide by two the number of possible different hashes. With twice less possible hashes, there will be collisions. Example:
```
unsigned h = 0x33333333;
h += (h >> 2) | (h << 30);
// result is 0xFFFFFFFF
```
```
unsigned h = 0xCCCCCCCC;
h += (h >> 2) | (h << 30);
// result is 0xFFFFFFFF
```
So we can keep the rotation, but we need to remove the addition for proper hashing.