### PR TITLE
Fix incorrect handling of ECONNREFUSED on BSD

### DIFF
--- a/bufferevent_sock.c
+++ b/bufferevent_sock.c
@@ -194,6 +194,8 @@ bufferevent_readcb(evutil_socket_t fd, short event, void *arg)
 		int err = evutil_socket_geterror(fd);
 		if (EVUTIL_ERR_RW_RETRIABLE(err))
 			goto reschedule;
+		/* NOTE: sometimes on FreeBSD 9.2 the connect() does not returns an
+		 * error, and instead, first readv() will */
 		if (EVUTIL_ERR_CONNECT_REFUSED(err)) {
 			bufev_p->connection_refused = 1;
 			goto done;

--- a/bufferevent_sock.c
+++ b/bufferevent_sock.c
@@ -411,11 +411,14 @@ bufferevent_socket_connect(struct bufferevent *bev,
 			bufev_p->connecting = 1;
 			result = 0;
 			goto done;
-		} else
+		} else {
 #endif
 		r = evutil_socket_connect_(&fd, sa, socklen);
 		if (r < 0)
 			goto freesock;
+#ifdef _WIN32
+		}
+#endif
 	}
 #ifdef _WIN32
 	/* ConnectEx() isn't always around, even when IOCP is enabled.

--- a/bufferevent_sock.c
+++ b/bufferevent_sock.c
@@ -433,11 +433,16 @@ bufferevent_socket_connect(struct bufferevent *bev,
 			result = 0;
 			goto done;
 		}
-	} else {
+	} else if (r == 1) {
 		/* The connect succeeded already. How very BSD of it. */
 		result = 0;
 		bufev_p->connecting = 1;
 		bufferevent_trigger_nolock_(bev, EV_WRITE, BEV_OPT_DEFER_CALLBACKS);
+	} else {
+		/* The connect failed already (only ECONNREFUSED case). How very BSD of it. */
+		result = 0;
+		bufferevent_run_eventcb_(bev, BEV_EVENT_ERROR, BEV_OPT_DEFER_CALLBACKS);
+		bufferevent_disable(bev, EV_WRITE|EV_READ);
 	}
 
 	goto done;


### PR DESCRIPTION
#1100 wasn't the dead code, since the `r` could be `2` in case of
`ECONNREFUSED`, and it should trigger errorcb not the writecb.

This is actually questionable should be call errorcb at all in case of
connect() returns an error immediately, but I guess the reason was to
make it compatible with others, ECONNREFUSED can be returned only for
specific cases and only on BSD (AFAIK). While for instance EHOSTUNREACH
is not.

And after this change now all tests are passed on FreeBSD. Well,
sometimes few tests fails due to timing issues, but in general looks
good. Since even all tests in parallel passed:

    $ rm -f /tmp/libevent*log; bin/regress --list-tests | awk '/^    / { print $1 }' | xargs -I{} -P100 bash -c 'n={}; bin/regress --no-fork --verbose $n |& tee /tmp/libevent-test-${n//\//_}.log' |& grep -F '  [FAILED' |& tee /tmp/libevent-tests.log

And having green CI is crucial for libevent, not only because it is
a rule of thumb for all projects, but also because in case of failures
it will retry on and on, which will cause CI stuck.

Fixes: bufferevent/bufferevent_connect_fail
Fixes: bufferevent/bufferevent_connect_fail_eventcb
Fixes: bufferevent/bufferevent_connect_fail_eventcb_defer

This reverts commit 56e121310954cbee2310c5eb2a3000115186563d.
Refs: https://github.com/libevent/libevent/pull/1100