### PR TITLE
aix: enable SO_REUSEPORT on AIX

### DIFF
--- a/evutil.c
+++ b/evutil.c
@@ -500,6 +500,7 @@ evutil_make_listen_socket_reuseable_port(evutil_socket_t sock)
 	return setsockopt(sock, SOL_SOCKET, SO_REUSEPORT_LB, (void*)&enabled,
 	    (ev_socklen_t)sizeof(enabled));
 #elif (defined(__linux__) || \
+      defined(_AIX73) || \
       (defined(__DragonFly__) && __DragonFly_version >= 300600) || \
       (defined(__sun) && defined(SO_FLOW_NAME))) && \
       defined(SO_REUSEPORT)
@@ -511,6 +512,9 @@ evutil_make_listen_socket_reuseable_port(evutil_socket_t sock)
 	 *
 	 * DragonFlyBSD 3.6.0 extended SO_REUSEPORT to distribute workload to
 	 * available sockets, which make it the same as Linux's SO_REUSEPORT.
+	 *
+	 * AIX 7.2.5 added the feature that would add the capability to distribute
+	 * incoming connections across all listening ports for SO_REUSEPORT.
 	 *
 	 * Solaris 11 supported SO_REUSEPORT, but it's implemented only for
 	 * binding to the same address and port, without load balancing.

--- a/include/event2/listener.h
+++ b/include/event2/listener.h
@@ -98,7 +98,7 @@ typedef void (*evconnlistener_errorcb)(struct evconnlistener *, void *);
  * SO_REUSEPORT does not imply SO_REUSEADDR.
  *
  * This feature is available only on Linux 3.9+, DragonFlyBSD 3.6+,
- * FreeBSD 12.0+, Solaris 11.4 for now.
+ * FreeBSD 12.0+, Solaris 11.4, AIX 7.2.5 for now.
  *
  */
 #define LEV_OPT_REUSEABLE_PORT		(1u<<7)

--- a/include/event2/util.h
+++ b/include/event2/util.h
@@ -423,7 +423,7 @@ int evutil_make_listen_socket_reuseable(evutil_socket_t sock);
     across all of the threads (or processes).
 
     This feature is available only on Linux 3.9+, DragonFlyBSD 3.6+,
-    FreeBSD 12.0+, Solaris 11.4 for now.
+    FreeBSD 12.0+, Solaris 11.4, AIX 7.2.5 for now.
 
     @param sock The socket to make reusable
     @return 0 on success, -1 on failure


### PR DESCRIPTION
AIX 7.2.5 added the feature that would add the capability to distribute incoming connections across all listening ports.

https://www.ibm.com/support/pages/how-get-better-listening-performance-multiple-listening-sockets-using-same-port-number-soreuseport
