### PR TITLE
Revert "Update vcpkg to fix windows CI"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,7 +265,7 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.EVENT_MATRIX }}-v4
 
       - name: Prepare vcpkg
-        uses: lukka/run-vcpkg@v11
+        uses: lukka/run-vcpkg@v7
         id: runvcpkg
         with:
           vcpkgArguments: zlib:x64-windows openssl:x64-windows mbedtls:x64-windows


### PR DESCRIPTION
windows-vs-job shows this warning:

    >(https://github.com/libevent/libevent/actions/runs/8949929874/job/24584751215#step:4:1)
    Unexpected input(s) 'vcpkgArguments', 'vcpkgTriplet', valid inputs are ['vcpkgDirectory', 'runVcpkgInstall', 'vcpkgGitCommitId', 'vcpkgGitURL', 'doNotUpdateVcpkg', 'doNotCache', 'vcpkgJsonGlob', 'vcpkgJsonIgnores', 'vcpkgConfigurationJsonGlob', 'binaryCachePath', 'runVcpkgFormatString', 'useShell', 'logCollectionRegExps']

Let's simply revert to the last working version, thanks to @hebasto, @Coeur

Fixes: https://github.com/libevent/libevent/issues/1648
This reverts commit 3e01178b1b9d88026278e1442053e0452b1879b8.