### PR TITLE
gcc: fix some compiler errors from the new GCC

### DIFF
--- a/bufferevent_openssl.c
+++ b/bufferevent_openssl.c
@@ -424,7 +424,7 @@ static struct le_ssl_ops le_openssl_ops = {
 	SSL_handshake_is_ok,
 	SSL_is_want_read,
 	SSL_is_want_write,
-	(int (*)(void *))be_openssl_get_fd,
+	(evutil_socket_t (*)(void *))be_openssl_get_fd,
 	be_openssl_bio_set_fd,
 	init_bio_counts,
 	decrement_buckets,

--- a/evutil.c
+++ b/evutil.c
@@ -3150,7 +3150,11 @@ evutil_set_tcp_keepalive(evutil_socket_t fd, int on, int timeout)
 	if (timeout <= 0)
 		return 0;
 
+#ifdef _WIN32
+	if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, (const char*)&on, sizeof(on)))
+#else
 	if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &on, sizeof(on)))
+#endif
 		return -1;
 	if (!on)
 		return 0;
@@ -3164,14 +3168,14 @@ evutil_set_tcp_keepalive(evutil_socket_t fd, int on, int timeout)
 	 * Windows 10 version 1709, but let's gamble here.
 	 */
 #if defined(TCP_KEEPIDLE) && defined(TCP_KEEPINTVL) && defined(TCP_KEEPCNT)
-	if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle)))
+	if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, (const char*)&idle, sizeof(idle)))
 		return -1;
 
-	if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl)))
+	if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, (const char*)&intvl, sizeof(intvl)))
 		return -1;
 
 	cnt = 3;
-	if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &cnt, sizeof(cnt)))
+	if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, (const char*)&cnt, sizeof(cnt)))
 		return -1;
 
 	/* For those versions prior to Windows 10 version 1709, we fall back to SIO_KEEPALIVE_VALS.

--- a/sample/http-server.c
+++ b/sample/http-server.c
@@ -392,7 +392,7 @@ parse_opts(int argc, char **argv)
 }
 
 static void
-do_term(int sig, short events, void *arg)
+do_term(evutil_socket_t sig, short events, void *arg)
 {
 	struct event_base *base = arg;
 	event_base_loopbreak(base);

--- a/test/regress.c
+++ b/test/regress.c
@@ -1369,7 +1369,9 @@ test_signal_while_processing(void)
 #endif // \_WIN32
 
 #ifndef EVENT__DISABLE_THREAD_SUPPORT
-static void* del_wait_thread(void *arg)
+
+static THREAD_FN
+del_wait_thread(void *arg)
 {
 	struct timeval tv_start, tv_end;
 
@@ -1380,7 +1382,7 @@ static void* del_wait_thread(void *arg)
 	test_timeval_diff_eq(&tv_start, &tv_end, 300);
 
 	end:
-	return NULL;
+	THREAD_RETURN();
 }
 
 static void
@@ -1431,11 +1433,14 @@ test_del_wait(void)
 }
 
 static void null_cb(evutil_socket_t fd, short what, void *arg) {}
-static void* test_del_notify_thread(void *arg)
+
+static THREAD_FN
+test_del_notify_thread(void *arg)
 {
 	event_dispatch();
-	return NULL;
+	THREAD_RETURN();
 }
+
 static void
 test_del_notify(void)
 {

--- a/test/regress_dns.c
+++ b/test/regress_dns.c
@@ -1307,7 +1307,7 @@ dns_nameservers_no_nameservers_configured_test(void *arg)
 	const char filecontents[] = "# tmp empty resolv.conf\n";
 	const size_t filecontentssize = sizeof(filecontents);
 	int ok;
-	
+
 	fd = regress_make_tmpfile(filecontents, filecontentssize, &tmpfilename);
 	if (fd < 0)
 		tt_skip();
@@ -2542,14 +2542,14 @@ struct race_param
 
 	int locked;
 };
-static void *
+static THREAD_FN
 race_base_run(void *arg)
 {
 	struct race_param *rp = (struct race_param *)arg;
 	event_base_loop(rp->base, EVLOOP_NO_EXIT_ON_EMPTY);
 	THREAD_RETURN();
 }
-static void *
+static THREAD_FN
 race_busywait_run(void *arg)
 {
 	struct race_param *rp = (struct race_param *)arg;

--- a/test/regress_http.c
+++ b/test/regress_http.c
@@ -1811,7 +1811,7 @@ http_cancel_test(void *arg)
 	tt_assert(evcon);
 	if (type & INACTIVE_SERVER)
 		evhttp_connection_set_timeout(evcon, 5);
-	
+
 
 	bufev = evhttp_connection_get_bufferevent(evcon);
 	/* Guarantee that we stack in connect() not after waiting EV_READ after
@@ -3545,7 +3545,7 @@ http_base_test(void *ptr)
 	const char *http_request;
 	ev_uint16_t port = 0;
 	struct evhttp *http;
-	
+
 	test_ok = 0;
 	base = event_base_new();
 	tt_assert(base);
@@ -5802,7 +5802,7 @@ end:
 		evhttp_free(http);
 }
 
-static void http_add_output_buffer(int fd, short events, void *arg)
+static void http_add_output_buffer(evutil_socket_t fd, short events, void *arg)
 {
 	evbuffer_add(arg, POST_DATA, strlen(POST_DATA));
 }

--- a/test/regress_listener.c
+++ b/test/regress_listener.c
@@ -331,7 +331,7 @@ disable_thread(void * arg)
 {
 	struct evconnlistener *lev = (struct evconnlistener *)arg;
 	evconnlistener_disable(lev);
-	return NULL;
+	THREAD_RETURN();
 }
 
 static void

--- a/test/regress_main.c
+++ b/test/regress_main.c
@@ -258,7 +258,15 @@ basic_test_setup(const struct testcase_t *testcase)
 		evthread_flags |= EVTHREAD_PTHREAD_PRIO_INHERIT;
 #endif
 
+#ifdef _WIN32
+	DWORD tid;
+	THREAD_T p;
+	tid = THREAD_SELF();
+	p = (THREAD_T)&tid;
+	thread_setup(p);
+#else
 	thread_setup(THREAD_SELF());
+#endif
 
 #ifndef _WIN32
 	if (testcase->flags & TT_ENABLE_IOCP_FLAG)


### PR DESCRIPTION
New compiler errors to be fixed: `[-Wincompatible-pointer-types]`, `[-Wint-conversion]`, and `[-Wcast-function-type]`

---

The [CI failure for -Wincompatible-pointer-types](https://github.com/libevent/libevent/pull/1652#issuecomment-2118836052) may have something to do with this [GCC patch](https://gcc.gnu.org/pipermail/gcc-cvs/2023-December/394351.html). See also this https://github.com/llvm/llvm-project/issues/74605.

Thus, I think we should explicitly cast the `int` pointer to the expected type to avoid these compiler errors.

@azat 