### PR TITLE
event_warn mmap format

### DIFF
--- a/test/regress_buffer.c
+++ b/test/regress_buffer.c
@@ -1373,12 +1373,16 @@ test_evbuffer_file_segment_add_cleanup_cb(void* ptr)
 	struct evbuffer *evb = NULL;
 	struct evbuffer_file_segment *seg = NULL, *segptr;
 	char const* arg = "token";
+	struct stat st;
 
 	fd = regress_make_tmpfile("file_segment_test_file", 22, &tmpfilename);
 	/* On Windows, if TMP environment variable is corrupted, we may not be
 	 * able create temporary file, just skip it */
 	if (fd < 0)
 		tt_skip();
+
+	fstat(fd, &st);
+	tt_assert(st.st_size == 22);
 
 	evb = evbuffer_new();
 	tt_assert(evb);


### PR DESCRIPTION
We have various test failures with either:
>mmap(4, 0, 0) failed: Invalid argument

or:
>mmap(5, 0, 0) failed: Bad file descriptor

This change the format of this failure, for somewhat more comprehensive debugging, since mmap takes 6 arguments, not 3.

[edit]

So with that change, the failures are now instead showing:
>mmap(NULL, 0, 1, 1026, 4, 0) failed: Invalid argument
