### PR TITLE
Fix Windows format warning in newer Visual Studio

### DIFF
--- a/util-internal.h
+++ b/util-internal.h
@@ -476,7 +476,7 @@ HMODULE evutil_load_windows_system_library_(const TCHAR *library_name);
 #endif
 
 #ifndef EV_SIZE_FMT
-#if EV_WINDOWS
+#if defined(_MSC_VER) && _MSC_VER < 1400
 #define EV_U64_FMT "%I64u"
 #define EV_I64_FMT "%I64d"
 #define EV_I64_ARG(x) ((__int64)(x))


### PR DESCRIPTION
Fix warnings like those:
```
../test/bench.c:133:41: warning: format '%d' expects argument of type 'int', but argument 4 has type 'ssize_t' {aka 'long long int'} [-Wformat=]
  133 |                         fprintf(stderr, "Xcount: %d, Rcount: " EV_SSIZE_FMT "\n",
      |                                         ^~~~~~~~~~~~~~~~~~~~~~
  134 |                                 xcount, count);
      |                                         ~~~~~
      |                                         |
      |                                         ssize_t {aka long long int}
In file included from ../test/bench.c:37:
../test/../util-internal.h:481:25: note: format string is defined here
  481 | #define EV_I64_FMT "%I64d"
      |                     ~~~~^
      |                         |
      |                         int
      |                     %I64lld
  CC       test/test-eof.o
  CC       test/test-dumpevents.o
  CC       test/test-closed.o
  CC       test/test-fdleak.o
../test/bench_httpclient.c: In function 'main':
../test/bench_httpclient.c:226:16: warning: format '%d' expects argument of type 'int', but argument 7 has type 'long long int' [-Wformat=]
  226 |         printf("\n%d requests in %d.%06d sec. (%.2f throughput)\n"
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
......
  233 |             (I64_TYP)total_n_bytes, n_errors);
      |             ~~~~~~~~~~~~~~~~~~~~~~
      |             |
      |             long long int
../test/bench_httpclient.c:219:22: note: format string is defined here
  219 | #define I64_FMT "%I64d"
      |                  ~~~~^
      |                      |
      |                      int
      |                  %I64lld
```
As seen in https://github.com/libevent/libevent/actions/runs/9207390269/job/25327329725?pr=1661