### PR TITLE
Reducing the number of mingw warnings

### DIFF
--- a/sample/ssl-client-mbedtls.c
+++ b/sample/ssl-client-mbedtls.c
@@ -158,14 +158,16 @@ main(void)
 #ifdef WIN32
 	WORD wVersionRequested;
 	WSADATA wsaData;
-	int err;
 
 	/* Use the MAKEWORD(lowbyte, highbyte) macro declared in Windef.h */
 	wVersionRequested = MAKEWORD(2, 2);
 
-	err = WSAStartup(wVersionRequested, &wsaData);
+	ret = WSAStartup(wVersionRequested, &wsaData);
+	if (ret != 0) {
+		mbedtls_printf(
+			" warning\n  !  WSAStartup returned 0x%x\n\n", ret);
+	}
 #endif
-
 
 #if defined(MBEDTLS_DEBUG_C)
 	mbedtls_debug_set_threshold(DEBUG_LEVEL);

--- a/test/regress_bufferevent.c
+++ b/test/regress_bufferevent.c
@@ -854,7 +854,7 @@ static void
 test_bufferevent_connect_fail_eventcb(void *arg)
 {
 	struct basic_test_data *data = arg;
-	int flags = BEV_OPT_CLOSE_ON_FREE | (long)data->setup_data;
+	int flags = BEV_OPT_CLOSE_ON_FREE | (intptr_t)data->setup_data;
 	struct event close_listener_event;
 	struct bufferevent *bev = NULL;
 	struct evconnlistener *lev = NULL;


### PR DESCRIPTION
This addresses:
```
../sample/ssl-client-mbedtls.c:161:13: warning: variable 'err' set but not used [-Wunused-but-set-variable]
  161 |         int err;
      |             ^~~

../test/regress_bufferevent.c:857:45: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  857 |         int flags = BEV_OPT_CLOSE_ON_FREE | (long)data->setup_data;
      |                                             ^
```