### PR TITLE
Fix potential Null pointer dereference in bench_httpclient.c

### DIFF
--- a/test/bench_httpclient.c
+++ b/test/bench_httpclient.c
@@ -164,8 +164,8 @@ launch_request(void)
 
 	b = bufferevent_socket_new(base, sock, BEV_OPT_CLOSE_ON_FREE);
 	if (b == NULL) {
+		perror("bufferevent_socket_new");
 		evutil_closesocket(sock);
-		fprintf(stderr, "Couldn't create bufferevent\n");
 		return -1;
 	}
 	bufferevent_setcb(b, readcb, NULL, errorcb, ri);
@@ -199,7 +199,7 @@ main(int argc, char **argv)
 
 	for (i=0; i < PARALLELISM; ++i) {
 		if (launch_request() < 0)
-			perror("launch");
+			fprintf(stderr, "Cannot launch %i request\n", i);
 	}
 
 	evutil_gettimeofday(&start, NULL);

--- a/test/bench_httpclient.c
+++ b/test/bench_httpclient.c
@@ -164,6 +164,8 @@ launch_request(void)
 
 	b = bufferevent_socket_new(base, sock, BEV_OPT_CLOSE_ON_FREE);
 	if (b == NULL) {
+		evutil_closesocket(sock);
+		fprintf(stderr, "Couldn't create bufferevent\n");
 		return -1;
 	}
 	bufferevent_setcb(b, readcb, NULL, errorcb, ri);

--- a/test/bench_httpclient.c
+++ b/test/bench_httpclient.c
@@ -163,7 +163,9 @@ launch_request(void)
 	evutil_gettimeofday(&ri->started, NULL);
 
 	b = bufferevent_socket_new(base, sock, BEV_OPT_CLOSE_ON_FREE);
-
+	if (b == NULL) {
+		return -1;
+	}
 	bufferevent_setcb(b, readcb, NULL, errorcb, ri);
 	bufferevent_enable(b, EV_READ|EV_WRITE);
 


### PR DESCRIPTION
Supersedes #1609.
Although I didn't do the "_add an error path into main_" part. I'm not sure what that is, but likely could be done in a separate PR, as the scope of this one is to silence a warning.