### PR TITLE
ci: ignore lukka/run-vcpkg for updates by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    ignore:
+      # Newer versions expect a vcpkg manifest, so stick to v7, that could handle vcpkgArguments
+      - dependency-name: "lukka/run-vcpkg"
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,6 +265,7 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.EVENT_MATRIX }}-v4
 
       - name: Prepare vcpkg
+        # Newer versions expect a vcpkg manifest, so stick to v7, that could handle vcpkgArguments
         uses: lukka/run-vcpkg@v7
         id: runvcpkg
         with:


### PR DESCRIPTION
Follow-up for: https://github.com/libevent/libevent/pull/1657