### PR TITLE
samples: use evutil_socket_t instead  and handle 64 bit Windows

### DIFF
--- a/evutil.c
+++ b/evutil.c
@@ -3313,3 +3313,14 @@ evutil_set_tcp_keepalive(evutil_socket_t fd, int on, int timeout)
 
 	return 0;
 }
+
+const char * evutil_strsignal(int sig)
+{
+#if !defined(EVENT__HAVE_STRSIGNAL)
+	static char buf[10];
+	evutil_snprintf(buf, 10, "%d", sig);
+	return buf;
+#else
+	return strsignal(sig);
+#endif
+}

--- a/sample/becat.c
+++ b/sample/becat.c
@@ -348,9 +348,6 @@ static struct options parse_opts(int argc, char **argv)
 	return o;
 }
 
-#ifndef EVENT__HAVE_STRSIGNAL
-static inline const char* strsignal(evutil_socket_t sig) { return "Signal"; }
-#endif
 static void do_term(evutil_socket_t sig, short events, void *arg)
 {
 	struct event_base *base = arg;

--- a/sample/becat.c
+++ b/sample/becat.c
@@ -352,8 +352,8 @@ static void do_term(evutil_socket_t sig, short events, void *arg)
 {
 	struct event_base *base = arg;
 	event_base_loopexit(base, NULL);
-	fprintf(stderr, "%s(" EV_SOCK_FMT "), Terminating\n",
-		strsignal(sig), EV_SOCK_ARG(sig));
+	fprintf(stderr, "%s signal received. Terminating\n",
+		evutil_strsignal(EV_SOCK_ARG(sig)));
 }
 
 static ev_socklen_t

--- a/sample/http-server.c
+++ b/sample/http-server.c
@@ -396,8 +396,8 @@ do_term(evutil_socket_t sig, short events, void *arg)
 {
 	struct event_base *base = arg;
 	event_base_loopbreak(base);
-	fprintf(stderr, "%s(" EV_SOCK_FMT "), Terminating\n",
-		strsignal(sig), EV_SOCK_ARG(sig));
+	fprintf(stderr, "%s signal received. Terminating\n",
+		evutil_strsignal(EV_SOCK_ARG(sig)));
 }
 
 static int

--- a/sample/http-server.c
+++ b/sample/http-server.c
@@ -396,11 +396,8 @@ do_term(evutil_socket_t sig, short events, void *arg)
 {
 	struct event_base *base = arg;
 	event_base_loopbreak(base);
-#ifdef _WIN64
-	fprintf(stderr, "Got %lld, Terminating\n", sig);
-#else
-	fprintf(stderr, "Got %i, Terminating\n", sig);
-#endif
+	fprintf(stderr, "%s(" EV_SOCK_FMT "), Terminating\n",
+		strsignal(sig), EV_SOCK_ARG(sig));
 }
 
 static int

--- a/sample/http-server.c
+++ b/sample/http-server.c
@@ -395,9 +395,9 @@ static void
 do_term(evutil_socket_t sig, short events, void *arg)
 {
 	struct event_base *base = arg;
-	event_be_loopbreak(base);
+	event_base_loopbreak(base);
 #ifdef _WIN64
-    fprintf(stderr, "Got %lld, Terminating\n", sig);
+	fprintf(stderr, "Got %lld, Terminating\n", sig);
 #else
 	fprintf(stderr, "Got %i, Terminating\n", sig);
 #endif

--- a/sample/http-server.c
+++ b/sample/http-server.c
@@ -395,8 +395,12 @@ static void
 do_term(evutil_socket_t sig, short events, void *arg)
 {
 	struct event_base *base = arg;
-	event_base_loopbreak(base);
+	event_be_loopbreak(base);
+#ifdef _WIN64
+    fprintf(stderr, "Got %lld, Terminating\n", sig);
+#else
 	fprintf(stderr, "Got %i, Terminating\n", sig);
+#endif
 }
 
 static int

--- a/sample/ws-chat-server.c
+++ b/sample/ws-chat-server.c
@@ -3,6 +3,7 @@
 #include <event2/event.h>
 #include <event2/http.h>
 #include <event2/ws.h>
+#include "../util-internal.h"
 
 #include <fcntl.h>
 #include <signal.h>
@@ -206,18 +207,10 @@ err:
 		close(fd);
 }
 
-#ifndef EVENT__HAVE_STRSIGNAL
-static inline const char *
-strsignal(evutil_socket_t sig)
-{
-	return "Signal";
-}
-#endif
-
 static void
 signal_cb(evutil_socket_t fd, short event, void *arg)
 {
-	printf("%s signal received\n", strsignal(fd));
+	printf("%s(" EV_SOCK_FMT ") signal received\n", strsignal(fd), EV_SOCK_ARG(fd));
 	event_base_loopbreak(arg);
 }
 

--- a/sample/ws-chat-server.c
+++ b/sample/ws-chat-server.c
@@ -210,7 +210,7 @@ err:
 static void
 signal_cb(evutil_socket_t fd, short event, void *arg)
 {
-	printf("%s(" EV_SOCK_FMT ") signal received\n", strsignal(fd), EV_SOCK_ARG(fd));
+	printf("%s signal received. Terminating\n", evutil_strsignal(EV_SOCK_ARG(fd)));
 	event_base_loopbreak(arg);
 }
 

--- a/util-internal.h
+++ b/util-internal.h
@@ -520,9 +520,10 @@ HMODULE evutil_load_windows_system_library_(const TCHAR *library_name);
 #endif
 #endif
 
-#if !defined(EVENT__HAVE_STRSIGNAL) && !defined(strsignal)
-#define strsignal(sig) "Signal"
-#endif
+/* Either a mapping for strsignal() or snprintf("%d", sig)
+ * NOTE: MT-Unsafe*/
+EVENT2_EXPORT_SYMBOL
+const char * evutil_strsignal(int sig);
 
 EVENT2_EXPORT_SYMBOL
 evutil_socket_t evutil_socket_(int domain, int type, int protocol);

--- a/util-internal.h
+++ b/util-internal.h
@@ -520,6 +520,10 @@ HMODULE evutil_load_windows_system_library_(const TCHAR *library_name);
 #endif
 #endif
 
+#if !defined(EVENT__HAVE_STRSIGNAL) && !defined(strsignal)
+#define strsignal(sig) "Signal"
+#endif
+
 EVENT2_EXPORT_SYMBOL
 evutil_socket_t evutil_socket_(int domain, int type, int protocol);
 evutil_socket_t evutil_accept4_(evutil_socket_t sockfd, struct sockaddr *addr,


### PR DESCRIPTION
Fixes #1574.
Supersedes #1575.
The solution used is identical to the one in becat.c.