### PR TITLE
expose evhttp_get_request to user

### DIFF
--- a/http.c
+++ b/http.c
@@ -199,7 +199,7 @@ static void evhttp_read_header(struct evhttp_connection *evcon,
 static int evhttp_add_header_internal(struct evkeyvalq *headers,
     const char *key, const char *value);
 static const char *evhttp_response_phrase_internal(int code);
-static void evhttp_get_request(struct evhttp *, evutil_socket_t, struct sockaddr *, ev_socklen_t, struct bufferevent *bev);
+static void evhttp_get_request_internal(struct evhttp *, evutil_socket_t, struct sockaddr *, ev_socklen_t, struct bufferevent *bev);
 static void evhttp_write_buffer(struct evhttp_connection *,
     void (*)(struct evhttp_connection *, void *), void *);
 static void evhttp_make_header(struct evhttp_connection *, struct evhttp_request *);
@@ -3843,7 +3843,7 @@ accept_socket_cb(struct evconnlistener *listener, evutil_socket_t nfd, struct so
 	if (bound->bevcb)
 		bev = bound->bevcb(http->base, bound->bevcbarg);
 
-	evhttp_get_request(http, nfd, peer_sa, peer_socklen, bev);
+	evhttp_get_request_internal(http, nfd, peer_sa, peer_socklen, bev);
 }
 
 int
@@ -4696,8 +4696,15 @@ evhttp_associate_new_request_with_connection(struct evhttp_connection *evcon)
 	return (0);
 }
 
+void
+evhttp_get_request(struct evhttp *http, evutil_socket_t fd, struct sockaddr *sa,
+	ev_socklen_t salen, struct bufferevent *bev)
+{
+	evhttp_get_request_internal(http, fd, sa, salen, bev);
+}
+
 static void
-evhttp_get_request(struct evhttp *http, evutil_socket_t fd,
+evhttp_get_request_internal(struct evhttp *http, evutil_socket_t fd,
     struct sockaddr *sa, ev_socklen_t salen,
     struct bufferevent *bev)
 {

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -515,6 +515,19 @@ void evhttp_set_write_timeout_tv(struct evhttp *http, const struct timeval* tv);
 EVENT2_EXPORT_SYMBOL
 int evhttp_set_flags(struct evhttp *http, int flags);
 
+/**
+ * Accept request for bufferevent
+ * @param http an evhttp object
+ * @param fd a socket fd that is ready for accepting connections
+ * @param sa A location to receive the server's address.
+ * @param salen The number of bytes available at sa.
+ * @param bev a bufferevent to use for connecting to the server; if NULL, a
+ *     socket-based bufferevent will be created.
+ */
+EVENT2_EXPORT_SYMBOL
+void evhttp_get_request(struct evhttp *http, evutil_socket_t fd,
+	struct sockaddr *sa, ev_socklen_t salen, struct bufferevent *bev);
+
 /* Request/Response functionality */
 
 /**


### PR DESCRIPTION
Fixes #1471.
ALTERNATIVE SOLUTION OF https://github.com/libevent/libevent/pull/1684 and #1689.

This PR is aimed at moving forward with the remaining tasks for the 2.2 milestone: https://github.com/libevent/libevent/milestone/4.

This PR is based on @MBeanwenshengming code idea and exposes `evhttp_get_request`.

I did not write a test for it and do not plan to write one myself: I'd like instead those interested in that feature to share a snippet of code that would demonstrate its usage (@MBeanwenshengming, @mllw, @ghazel, ...), and then we could adapt it as a test.