### PR TITLE
expose evhttp_get_request_bufferevent to user

### DIFF
--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -515,6 +515,18 @@ void evhttp_set_write_timeout_tv(struct evhttp *http, const struct timeval* tv);
 EVENT2_EXPORT_SYMBOL
 int evhttp_set_flags(struct evhttp *http, int flags);
 
+/**
+ * Accept request for bufferevent
+ * @param http an evhttp object
+ * @param bev a bufferevent to use for connecting to the server; if NULL, a
+ *     socket-based bufferevent will be created.
+ * @param sa A location to receive the server's address.
+ * @param salen The number of bytes available at sa.
+ */
+EVENT2_EXPORT_SYMBOL
+void evhttp_get_request_bufferevent(struct evhttp *http,
+	struct bufferevent *bev, struct sockaddr *sa, ev_socklen_t salen);
+
 /* Request/Response functionality */
 
 /**


### PR DESCRIPTION
Fixes #1471.
ALTERNATIVE SOLUTION OF #1683 and #1689.

This PR is aimed at moving forward with the remaining tasks for the 2.2 milestone: https://github.com/libevent/libevent/milestone/4.

This PR is based on @mllw patch idea and exposes `evhttp_get_request_bufferevent` instead of `evhttp_get_request`.

I did not write a test for it and do not plan to write one myself: I'd like instead those interested in that feature to share a snippet of code that would demonstrate its usage (@MBeanwenshengming, @mllw, @ghazel, ...), and then we could adapt it as a test.