### PR TITLE
Add evhttp_serve function

### DIFF
--- a/event.c
+++ b/event.c
@@ -2596,14 +2596,6 @@ static int
 evthread_notify_base_eventfd(struct event_base *base)
 {
 	#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
-		ev_uint64_t msg = 1;
-	int r;
-	do {
-		r = write(base->th_notify_fd[0], (void*) &msg, sizeof(msg));
-	} while (r < 0 && errno == EAGAIN);
-
-	return (r < 0) ? -1 : 0;
-	#else
 	int efd = base->th_notify_fd[0];
 	eventfd_t val;
 	int ret;
@@ -2627,6 +2619,14 @@ evthread_notify_base_eventfd(struct event_base *base)
 	}
 
 	return ret;
+	#else
+		ev_uint64_t msg = 1;
+		int r;
+		do {
+			r = write(base->th_notify_fd[0], (void*) &msg, sizeof(msg));
+		} while (r < 0 && errno == EAGAIN);
+
+		return (r < 0) ? -1 : 0;
 	#endif
 }
 #endif

--- a/event.c
+++ b/event.c
@@ -1377,11 +1377,13 @@ event_signal_closure(struct event_base *base, struct event *ev)
 {
 #if defined(__clang__)
 #elif defined(__GNUC__)
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic push
 /* NOTE: it is better to avoid such code all together, by using separate
  * variable to break the loop in the event structure, but now this code is safe
  * */
 #pragma GCC diagnostic ignored "-Wdangling-pointer"
+#endif
 #endif
 
 	short ncalls;
@@ -1412,7 +1414,9 @@ event_signal_closure(struct event_base *base, struct event *ev)
 
 #if defined(__clang__)
 #elif defined(__GNUC__)
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic pop
+#endif
 #endif
 }
 

--- a/event.c
+++ b/event.c
@@ -2595,6 +2595,15 @@ evthread_notify_base_default(struct event_base *base)
 static int
 evthread_notify_base_eventfd(struct event_base *base)
 {
+	#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+		ev_uint64_t msg = 1;
+	int r;
+	do {
+		r = write(base->th_notify_fd[0], (void*) &msg, sizeof(msg));
+	} while (r < 0 && errno == EAGAIN);
+
+	return (r < 0) ? -1 : 0;
+	#else
 	int efd = base->th_notify_fd[0];
 	eventfd_t val;
 	int ret;
@@ -2618,6 +2627,7 @@ evthread_notify_base_eventfd(struct event_base *base)
 	}
 
 	return ret;
+	#endif
 }
 #endif
 

--- a/http.c
+++ b/http.c
@@ -3846,6 +3846,15 @@ accept_socket_cb(struct evconnlistener *listener, evutil_socket_t nfd, struct so
 	evhttp_get_request(http, nfd, peer_sa, peer_socklen, bev);
 }
 
+void
+evhttp_serve(struct evhttp *http, 
+    evutil_socket_t fd, 
+    struct sockaddr *sa, ev_socklen_t salen, 
+    struct bufferevent *bev)
+{
+	evhttp_get_request(http, nfd, peer_sa, peer_socklen, bev);
+}
+
 int
 evhttp_bind_socket(struct evhttp *http, const char *address, ev_uint16_t port)
 {

--- a/http.c
+++ b/http.c
@@ -3852,7 +3852,7 @@ evhttp_serve(struct evhttp *http,
     struct sockaddr *sa, ev_socklen_t salen, 
     struct bufferevent *bev)
 {
-	evhttp_get_request(http, nfd, peer_sa, peer_socklen, bev);
+	evhttp_get_request(http, fd, sa, salen, bev);
 }
 
 int

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -112,6 +112,10 @@ void evhttp_serve(struct evhttp *http,
     struct sockaddr *sa, ev_socklen_t salen, 
     struct bufferevent *bev);
 
+EVENT2_EXPORT_SYMBOL
+void evhttp_serve_connection(struct evhttp *http, 
+    struct evhttp_connection *evcon);
+
 /**
  * Binds an HTTP server on the specified address and port.
  *

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -98,6 +98,21 @@ EVENT2_EXPORT_SYMBOL
 struct evhttp *evhttp_new(struct event_base *base);
 
 /**
+   Submit the socket obtained by accept to the http service for processing
+
+   @param http the evhttp server object will handle the connection
+   @param fd accept gets the socket
+   @param sa remote address
+   @param salen remote address length
+   @param bev Optional associated bufferevent
+ */
+EVENT2_EXPORT_SYMBOL
+void evhttp_serve(struct evhttp *http, 
+    evutil_socket_t fd, 
+    struct sockaddr *sa, ev_socklen_t salen, 
+    struct bufferevent *bev);
+
+/**
  * Binds an HTTP server on the specified address and port.
  *
  * Can be called multiple times to bind the same http server
@@ -357,7 +372,6 @@ void evhttp_set_gencb(struct evhttp *http,
 EVENT2_EXPORT_SYMBOL
 void evhttp_set_bevcb(struct evhttp *http,
     struct bufferevent *(*cb)(struct event_base *, void *), void *arg);
-
 
 /**
    Set a callback which allows the user to note or throttle incoming requests.

--- a/sample/watch-timing.c
+++ b/sample/watch-timing.c
@@ -44,8 +44,10 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wfloat-equal"
 #elif defined(__GNUC__)
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
 #endif
 
 /** Compare two doubles for equality without the compiler warning. This is
@@ -59,7 +61,9 @@ eq(double a, double b)
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #elif defined(__GNUC__)
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic pop
+#endif
 #endif
 
 struct bin {

--- a/sha1.c
+++ b/sha1.c
@@ -19,10 +19,12 @@ A million repetitions of "a"
 
 #if defined(__clang__)
 #elif defined(__GNUC__)
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic push
 /* Ignore the case when SHA1Transform() called with 'char *', that code passed
  * buffer of 64 bytes anyway (at least now) */
 #pragma GCC diagnostic ignored "-Wstringop-overread"
+#endif
 #endif
 
 #include <stdio.h>

--- a/test/regress_util.c
+++ b/test/regress_util.c
@@ -1326,14 +1326,18 @@ test_event_calloc_enomem(void *arg)
 	errno = 0;
 #if defined(__clang__)
 #elif defined(__GNUC__)
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Walloc-size-larger-than="
+#endif
 #endif
 	/* Requires allocator_may_return_null=1 for sanitizers */
 	p = mm_calloc(EV_SIZE_MAX, EV_SIZE_MAX);
 #if defined(__clang__)
 #elif defined(__GNUC__)
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic pop
+#endif
 #endif
 	tt_ptr_op(p, ==, NULL);
 	tt_int_op(errno, ==, ENOMEM);


### PR DESCRIPTION
Sometimes there is an evutil_socket_t fd coming from a connection outside of evhttp, but I want it to be handled by the evhttp. evhttp_serve is used to complete this function. evhttp_serve simply calls the static function evhttp_get_request.

Fixes: https://github.com/libevent/libevent/issues/1471
