### PR TITLE
expose evhttp_serve to user

### DIFF
--- a/http.c
+++ b/http.c
@@ -3846,6 +3846,15 @@ accept_socket_cb(struct evconnlistener *listener, evutil_socket_t nfd, struct so
 	evhttp_get_request(http, nfd, peer_sa, peer_socklen, bev);
 }
 
+void
+evhttp_serve(struct evhttp *http, 
+    evutil_socket_t fd, 
+    struct sockaddr *sa, ev_socklen_t salen, 
+    struct bufferevent *bev)
+{
+	evhttp_get_request(http, nfd, peer_sa, peer_socklen, bev);
+}
+
 int
 evhttp_bind_socket(struct evhttp *http, const char *address, ev_uint16_t port)
 {

--- a/http.c
+++ b/http.c
@@ -3852,7 +3852,7 @@ evhttp_serve(struct evhttp *http,
     struct sockaddr *sa, ev_socklen_t salen, 
     struct bufferevent *bev)
 {
-	evhttp_get_request(http, nfd, peer_sa, peer_socklen, bev);
+	evhttp_get_request(http, fd, sa, salen, bev);
 }
 
 int

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -98,6 +98,21 @@ EVENT2_EXPORT_SYMBOL
 struct evhttp *evhttp_new(struct event_base *base);
 
 /**
+   Submit the socket obtained by accept to the http service for processing
+
+   @param http the evhttp server object will handle the connection
+   @param fd accept gets the socket
+   @param sa remote address
+   @param salen remote address length
+   @param bev Optional associated bufferevent
+ */
+EVENT2_EXPORT_SYMBOL
+void evhttp_serve(struct evhttp *http, 
+    evutil_socket_t fd, 
+    struct sockaddr *sa, ev_socklen_t salen, 
+    struct bufferevent *bev);
+
+/**
  * Binds an HTTP server on the specified address and port.
  *
  * Can be called multiple times to bind the same http server
@@ -357,7 +372,6 @@ void evhttp_set_gencb(struct evhttp *http,
 EVENT2_EXPORT_SYMBOL
 void evhttp_set_bevcb(struct evhttp *http,
     struct bufferevent *(*cb)(struct event_base *, void *), void *arg);
-
 
 /**
    Set a callback which allows the user to note or throttle incoming requests.


### PR DESCRIPTION
Fixes #1471
ALTERNATIVE SOLUTION OF #1683 and #1684.
Cherry-pick of #1685 (only the first two commits).

This PR is aimed at moving forward with the remaining tasks for the 2.2 milestone: https://github.com/libevent/libevent/milestone/4.

This PR is based on @zuiwuchang pull request and exposes evhttp_serve instead of evhttp_get_request.

I did not write a test for it and do not plan to write one myself: I'd like instead those interested in that feature to share a snippet of code that would demonstrate its usage (@zuiwuchang, @azat, ...), and then we could adapt it as a test.