### PR TITLE
disallow empty header names

### DIFF
--- a/http.c
+++ b/http.c
@@ -2147,7 +2147,8 @@ evhttp_add_header(struct evkeyvalq *headers,
 {
 	event_debug(("%s: key: %s val: %s\n", __func__, key, value));
 
-	if (strchr(key, '\r') != NULL || strchr(key, '\n') != NULL) {
+	/* RFC 9110 */
+	if (strchr(key, '\r') != NULL || strchr(key, '\n') != NULL || key[0] == '\0') {
 		/* drop illegal headers */
 		event_debug(("%s: dropping illegal header key\n", __func__));
 		return (-1);

--- a/http.c
+++ b/http.c
@@ -2147,7 +2147,11 @@ evhttp_add_header(struct evkeyvalq *headers,
 {
 	event_debug(("%s: key: %s val: %s\n", __func__, key, value));
 
-	/* RFC 9110 */
+	/* RFC 9110 defines field-names as case-sensitive non-empty strings made of the following characters */
+	// field-name     = 1*tchar
+	// tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / 0-9 / A-Z / a-z
+	/* For simplicity, we'll reject field-names containing the documented most dangerous characters */
+	// "Field values containing CR, LF, or NUL characters are invalid and dangerous, due to the varying ways that implementations might parse and interpret those characters; a recipient of CR, LF, or NUL within a field value MUST either reject the message or replace each of those characters with SP before further processing or forwarding of that message."
 	if (strchr(key, '\r') != NULL || strchr(key, '\n') != NULL || key[0] == '\0') {
 		/* drop illegal headers */
 		event_debug(("%s: dropping illegal header key\n", __func__));

--- a/test/regress_http.c
+++ b/test/regress_http.c
@@ -2820,6 +2820,7 @@ http_bad_header_test(void *ptr)
 
 	tt_want(evhttp_add_header(&headers, "One", "Two") == 0);
 	tt_want(evhttp_add_header(&headers, "One", "Two\r\n Three") == 0);
+	tt_want(evhttp_add_header(&headers, "", "Two") == -1);
 	tt_want(evhttp_add_header(&headers, "One\r", "Two") == -1);
 	tt_want(evhttp_add_header(&headers, "One\n", "Two") == -1);
 	tt_want(evhttp_add_header(&headers, "One", "Two\r") == -1);


### PR DESCRIPTION
Fix #1686

In theory, we could be more strict, since there is only a subset of allowed characters:
> ```
> tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*"
>                 / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
>                 / DIGIT / ALPHA
>                 ; any VCHAR, except delimiters
> ```

But I'd skip such verification, unless there is a legitimate interest (versus performances).