### PR TITLE
http.c: Reject NUL in header lines and strip HTAB from header values.

### DIFF
--- a/http.c
+++ b/http.c
@@ -2283,6 +2283,10 @@ evhttp_parse_headers_(struct evhttp_request *req, struct evbuffer* buffer)
 
 		req->headers_size += len;
 
+		if (memchr(line, '\x00', len) != NULL) {
+			goto error;
+		}
+
 		if (req->evcon != NULL &&
 		    req->headers_size > req->evcon->max_headers_size) {
 			errcode = DATA_TOO_LONG;
@@ -2309,7 +2313,7 @@ evhttp_parse_headers_(struct evhttp_request *req, struct evbuffer* buffer)
 		if (svalue == NULL)
 			goto error;
 
-		svalue += strspn(svalue, " ");
+		svalue += strspn(svalue, " \t");
 		evutil_rtrim_lws_(svalue);
 
 		if (evhttp_add_header(headers, skey, svalue) == -1)

--- a/test/regress_http.c
+++ b/test/regress_http.c
@@ -2824,6 +2824,12 @@ http_bad_header_test(void *ptr)
 	tt_want(evhttp_add_header(&headers, "One\n", "Two") == -1);
 	tt_want(evhttp_add_header(&headers, "One", "Two\r") == -1);
 	tt_want(evhttp_add_header(&headers, "One", "Two\n") == -1);
+	tt_want(evhttp_add_header(&headers, "\x00One", "Two") == -1);
+	tt_want(evhttp_add_header(&headers, "O\x00ne", "Two") == -1);
+	tt_want(evhttp_add_header(&headers, "One\x00", "Two") == -1);
+	tt_want(evhttp_add_header(&headers, "One", "\x00Two") == -1);
+	tt_want(evhttp_add_header(&headers, "One", "T\x00wo") == -1);
+	tt_want(evhttp_add_header(&headers, "One", "Two\x00") == -1);
 
 	evhttp_clear_headers(&headers);
 }


### PR DESCRIPTION
NUL shouldn't be permitted in header field names or values. This patch ensures that requests containing NUL within the headers are rejected.

This patch also ensures that header values get stripped of SP and HTAB on the left, instead of just SP.