### PR TITLE
Add small note to event_active() documentation

### DIFF
--- a/include/event2/event.h
+++ b/include/event2/event.h
@@ -1317,6 +1317,9 @@ int event_del_block(struct event *ev);
   One common use in multithreaded programs is to wake the thread running
   event_base_loop() from another thread.
 
+  If event_active() is called on the same event more than once before the 
+  event is run, the flags are OR'd with the flags passed in previous calls.
+
   @param ev an event to make active.
   @param res a set of flags to pass to the event's callback.
   @param ncalls an obsolete argument: this is ignored.


### PR DESCRIPTION
Adds a note to `event_active()` documentation, stating that if event_active() is called more than once before the event is actually run, the passed flags are OR'd together. This could've saved me time debugging when passing custom flags through `event_active()`.

In `event_active_nolock_()` (called from `event_active()`), from `event.c`, the following `switch` statement OR's flags if event is set to be active later:
```c
switch ((ev->ev_flags & (EVLIST_ACTIVE|EVLIST_ACTIVE_LATER))) {
	default:
	case EVLIST_ACTIVE|EVLIST_ACTIVE_LATER:
		EVUTIL_ASSERT(0);
		break;
	case EVLIST_ACTIVE:
		/* We get different kinds of events, add them together */
		ev->ev_res |= res;
		return;
	case EVLIST_ACTIVE_LATER:
		ev->ev_res |= res;
		break;
	case 0:
		ev->ev_res = res;
		break;
	}
```