### PR TITLE
fix cmake build error for android: threads not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1116,10 +1116,16 @@ endif()
 
 if (EVENT__HAVE_PTHREADS)
     set(SRC_PTHREADS evthread_pthread.c)
-    add_event_library(event_pthreads
-        INNER_LIBRARIES event_core
-        LIBRARIES Threads::Threads
-        SOURCES ${SRC_PTHREADS})
+    if(ANDROID)
+        add_event_library(event_pthreads
+            INNER_LIBRARIES event_core
+            SOURCES ${SRC_PTHREADS})
+    else()
+        add_event_library(event_pthreads
+            INNER_LIBRARIES event_core
+            LIBRARIES Threads::Threads
+            SOURCES ${SRC_PTHREADS})
+    endif()
 endif()
 
 # library exists for historical reasons; it contains the contents of


### PR DESCRIPTION
This:

https://github.com/libevent/libevent/blob/e5181b153e155b1f1d626f2bb3903cadcc1b38aa/CMakeLists.txt#L1121

is going to fail because

https://github.com/libevent/libevent/blob/e5181b153e155b1f1d626f2bb3903cadcc1b38aa/CMakeLists.txt#L584

it is supposed to. `find_package(Threads)` isn't called on android and `-pthreads` is implicitly handled by Android NDK compiler.