### PR TITLE
CI and tests fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,12 +66,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build
-          key: ${{ matrix.os }}-cmake-${{ matrix.EVENT_MATRIX }}-v3
+          key: ${{ matrix.os }}-cmake-${{ matrix.EVENT_MATRIX }}-${{ hashFiles('CMakeLists.txt', 'cmake/**', '.github/**') }}-v4
+
       - name: Cache Dist Build
         uses: actions/cache@v4
         with:
           path: dist
-          key: ${{ matrix.os }}-cmake-dist-${{ matrix.EVENT_MATRIX }}-v3
+          key: ${{ matrix.os }}-cmake-dist-${{ matrix.EVENT_MATRIX }}-${{ hashFiles('CMakeLists.txt', 'cmake/**', '.github/**') }}-v4
 
       - name: Install Depends
         run: |
@@ -267,7 +268,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build
-          key: ${{ matrix.os }}-${{ matrix.EVENT_MATRIX }}-v4
+          key: ${{ matrix.os }}-${{ matrix.EVENT_MATRIX }}-${{ hashFiles('CMakeLists.txt', 'cmake/**', '.github/**') }}-v4
 
       - name: Prepare vcpkg
         # Newer versions expect a vcpkg manifest, so stick to v7, that could handle vcpkgArguments
@@ -471,7 +472,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build
-          key: mingw-cmake-${{ matrix.EVENT_MATRIX }}-v4
+          key: mingw-cmake-${{ matrix.EVENT_MATRIX }}-${{ hashFiles('CMakeLists.txt', 'cmake/**', '.github/**') }}-v4
 
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
@@ -559,7 +560,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build
-          key: ${{ matrix.os }}-cmake-${{ matrix.EVENT_MATRIX }}-v3
+          key: ${{ matrix.os }}-cmake-${{ matrix.EVENT_MATRIX }}-${{ hashFiles('CMakeLists.txt', 'cmake/**', '.github/**') }}-v4
 
       - name: Install Depends
         run: brew install mbedtls
@@ -702,7 +703,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build
-          key: freebsd-${{ matrix.release }}-cmake-${{ matrix.EVENT_MATRIX }}-v1
+          key: freebsd-${{ matrix.release }}-cmake-${{ matrix.EVENT_MATRIX }}-${{ hashFiles('CMakeLists.txt', 'cmake/**', '.github/**') }}-v4
 
       - name: Build
         uses: vmactions/freebsd-vm@v1
@@ -858,7 +859,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build
-          key: openbsd-${{ matrix.release }}-cmake-${{ matrix.EVENT_MATRIX }}-v1
+          key: openbsd-${{ matrix.release }}-cmake-${{ matrix.EVENT_MATRIX }}-${{ hashFiles('CMakeLists.txt', 'cmake/**', '.github/**') }}-v1
 
       - name: Build
         uses: vmactions/openbsd-vm@v1
@@ -1007,7 +1008,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build
-          key: ${{ matrix.os }}-cmake-${{ matrix.EVENT_MATRIX }}-v4
+          key: ${{ matrix.os }}-cmake-${{ matrix.EVENT_MATRIX }}-${{ hashFiles('CMakeLists.txt', 'cmake/**', '.github/**') }}-v4
 
       - name: Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -562,7 +562,7 @@ jobs:
           key: ${{ matrix.os }}-cmake-${{ matrix.EVENT_MATRIX }}-v3
 
       - name: Install Depends
-        run: brew install mbedtls@2
+        run: brew install mbedtls
 
       - name: Build
         shell: bash
@@ -591,7 +591,7 @@ jobs:
           else
             EVENT_CMAKE_OPTIONS=""
           fi
-          EVENT_CMAKE_OPTIONS="$EVENT_CMAKE_OPTIONS -DMBEDTLS_ROOT_DIR=`brew --prefix mbedtls@2`"
+          EVENT_CMAKE_OPTIONS="$EVENT_CMAKE_OPTIONS -DMBEDTLS_ROOT_DIR=`brew --prefix mbedtls`"
 
           mkdir -p build
           cd build
@@ -645,13 +645,13 @@ jobs:
           key: ${{ matrix.os }}-autotools-v3
 
       - name: Install Depends
-        run: brew install autoconf automake libtool pkg-config mbedtls@2
+        run: brew install autoconf automake libtool pkg-config mbedtls
 
       - name: Build
         shell: bash
         run: |
-          export CPPFLAGS="-I`brew --prefix mbedtls@2`/include"
-          export  LDFLAGS="-L`brew --prefix mbedtls@2`/lib"
+          export CPPFLAGS="-I`brew --prefix mbedtls`/include"
+          export  LDFLAGS="-L`brew --prefix mbedtls`/lib"
 
           ./autogen.sh
           mkdir -p build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -866,7 +866,7 @@ jobs:
         with:
           release: ${{ matrix.release }}
           prepare: |
-            pkg_add  mbedtls cmake python3
+            pkg_add mbedtls cmake py3-pip
           usesh: true
           run: |
             if [ "${{ matrix.EVENT_MATRIX }}" == "DISABLE_OPENSSL" ]; then
@@ -953,7 +953,7 @@ jobs:
         with:
           release: ${{ matrix.release }}
           prepare: |
-            pkg_add  mbedtls  python3 automake-1.16.5  autoconf-2.71  libtool pkgconf
+            pkg_add mbedtls py3-pip automake-1.16.5 autoconf-2.72p0 libtool pkgconf
           usesh: true
           run: |
             export AUTOMAKE_VERSION=1.16

--- a/test/regress_dns.c
+++ b/test/regress_dns.c
@@ -1685,8 +1685,10 @@ test_bufferevent_connect_hostname(void *arg)
 	 */
 	if (!emfile) {
 		tt_int_op(be_outcome[3].dnserr, ==, 0);
+#if defined(__linux__)
 	} else {
 		tt_int_op(be_outcome[3].dnserr, !=, 0);
+#endif
 	}
 	if (expect_err) {
 		tt_int_op(be_outcome[4].what, ==, BEV_EVENT_ERROR);

--- a/test/regress_dns.c
+++ b/test/regress_dns.c
@@ -1679,6 +1679,10 @@ test_bufferevent_connect_hostname(void *arg)
 	tt_int_op(be_outcome[2].what, ==, !emfile ? BEV_EVENT_CONNECTED : BEV_EVENT_ERROR);
 	tt_int_op(be_outcome[2].dnserr, ==, 0);
 	tt_int_op(be_outcome[3].what, ==, !emfile ? BEV_EVENT_CONNECTED : BEV_EVENT_ERROR);
+	/*
+	 * Some platforms check for localhost explicitly, and therefore may succeed without opening any files *
+	 * e.g. https://github.com/openbsd/src/blob/53e0023678f73561cc0c0c07e49830be23d94673/lib/libc/asr/getaddrinfo_async.c#L234
+	 */
 	if (!emfile) {
 		tt_int_op(be_outcome[3].dnserr, ==, 0);
 	} else {

--- a/test/regress_mbedtls.c
+++ b/test/regress_mbedtls.c
@@ -47,7 +47,9 @@
 #define get_ssl_ctx get_mbedtls_config
 
 /* FIXME: clean this up, add some prefix, i.e. le_ssl_ */
+#if MBEDTLS_VERSION_MAJOR < 3
 #define SSL_renegotiate mbedtls_ssl_renegotiate
+#endif
 #undef SSL_get_peer_certificate
 #define SSL_get_peer_certificate mbedtls_ssl_get_peer_cert
 #define SSL_get1_peer_certificate mbedtls_ssl_get_peer_cert

--- a/test/regress_ssl.c
+++ b/test/regress_ssl.c
@@ -172,9 +172,10 @@ respond_to_number(struct bufferevent *bev, void *ctx)
 	struct evbuffer *b = bufferevent_get_input(bev);
 	char *line;
 	int n;
-
+#ifdef SSL_renegotiate
 	enum regress_openssl_type type;
 	type = (enum regress_openssl_type)ctx;
+#endif
 
 	line = evbuffer_readln(b, NULL, EVBUFFER_EOL_LF);
 	if (! line)

--- a/test/regress_ssl.c
+++ b/test/regress_ssl.c
@@ -114,7 +114,9 @@ enum regress_openssl_type
 {
 	REGRESS_OPENSSL_SOCKETPAIR = 1,
 	REGRESS_OPENSSL_FILTER = 2,
+#ifdef SSL_renegotiate
 	REGRESS_OPENSSL_RENEGOTIATE = 4,
+#endif
 	REGRESS_OPENSSL_OPEN = 8,
 	REGRESS_OPENSSL_DIRTY_SHUTDOWN = 16,
 	REGRESS_OPENSSL_FD = 32,
@@ -187,9 +189,11 @@ respond_to_number(struct bufferevent *bev, void *ctx)
 		bufferevent_free(bev); /* Should trigger close on other side. */
 		return;
 	}
+#ifdef SSL_renegotiate
 	if ((type & REGRESS_OPENSSL_CLIENT) && n == renegotiate_at) {
 		SSL_renegotiate(bufferevent_ssl_get_ssl(bev));
 	}
+#endif
 	++n;
 	evbuffer_add_printf(bufferevent_get_output(bev),
 	    "%d\n", n);
@@ -332,6 +336,7 @@ regress_bufferevent_openssl(void *arg)
 	enum regress_openssl_type type;
 	type = (enum regress_openssl_type)data->setup_data;
 
+#ifdef SSL_renegotiate
 	if (type & REGRESS_OPENSSL_RENEGOTIATE) {
 		/*
 		 * Disable TLS 1.3, so we negotiate something older to test
@@ -347,6 +352,7 @@ regress_bufferevent_openssl(void *arg)
 		}
 		renegotiate_at = 600;
 	}
+#endif
 
 	ssl1 = SSL_new(get_ssl_ctx(SSL_IS_CLIENT));
 	ssl2 = SSL_new(get_ssl_ctx(SSL_IS_SERVER));
@@ -767,12 +773,14 @@ struct testcase_t TESTCASES_NAME[] = {
 	{ "bufferevent_filter_write_after_connect", regress_bufferevent_openssl,
 	  TT_ISOLATED, &ssl_setup,
 	  T(REGRESS_OPENSSL_FILTER|REGRESS_OPENSSL_CLIENT_WRITE) },
+#ifdef SSL_renegotiate
 	{ "bufferevent_renegotiate_socketpair", regress_bufferevent_openssl,
 	  TT_ISOLATED, &ssl_setup,
 	  T(REGRESS_OPENSSL_SOCKETPAIR | REGRESS_OPENSSL_RENEGOTIATE) },
 	{ "bufferevent_renegotiate_filter", regress_bufferevent_openssl,
 	  TT_ISOLATED, &ssl_setup,
 	  T(REGRESS_OPENSSL_FILTER | REGRESS_OPENSSL_RENEGOTIATE) },
+#endif
 	{ "bufferevent_socketpair_startopen", regress_bufferevent_openssl,
 	  TT_ISOLATED, &ssl_setup,
 	  T(REGRESS_OPENSSL_SOCKETPAIR | REGRESS_OPENSSL_OPEN) },
@@ -786,6 +794,7 @@ struct testcase_t TESTCASES_NAME[] = {
 	{ "bufferevent_filter_dirty_shutdown", regress_bufferevent_openssl,
 	  TT_ISOLATED, &ssl_setup,
 	  T(REGRESS_OPENSSL_FILTER | REGRESS_OPENSSL_DIRTY_SHUTDOWN) },
+#ifdef SSL_renegotiate
 	{ "bufferevent_renegotiate_socketpair_dirty_shutdown",
 	  regress_bufferevent_openssl,
 	  TT_ISOLATED,
@@ -796,6 +805,7 @@ struct testcase_t TESTCASES_NAME[] = {
 	  TT_ISOLATED,
 	  &ssl_setup,
 	  T(REGRESS_OPENSSL_FILTER | REGRESS_OPENSSL_RENEGOTIATE | REGRESS_OPENSSL_DIRTY_SHUTDOWN) },
+#endif
 	{ "bufferevent_socketpair_startopen_dirty_shutdown",
 	  regress_bufferevent_openssl,
 	  TT_ISOLATED, &ssl_setup,


### PR DESCRIPTION
homebrew is going to deprecate mbedtls@2 soon:
* https://github.com/Homebrew/homebrew-core/pull/179727

and it's supported in libevent:

* https://github.com/libevent/libevent/pull/1299