### PR TITLE
Move find_dependency() directly to LibeventConfig.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1099,9 +1099,6 @@ if (EVENT__HAVE_OPENSSL)
         INNER_LIBRARIES event_core
         LIBRARIES ${OPENSSL_TARGETS}
         SOURCES ${SRC_OPENSSL})
-    set(LIBEVENT_OPENSSL_DEPENDENCY "find_dependency(OpenSSL)")
-else ()
-    set(LIBEVENT_OPENSSL_DEPENDENCY "")
 endif()
 
 if (EVENT__HAVE_MBEDTLS)
@@ -1109,9 +1106,6 @@ if (EVENT__HAVE_MBEDTLS)
         INNER_LIBRARIES event_core
         LIBRARIES ${MBEDTLS_TARGETS}
         SOURCES ${SRC_MBEDTLS})
-    set(LIBEVENT_MBEDTLS_DEPENDENCY "find_dependency(MbedTLS)")
-else ()
-    set(LIBEVENT_MBEDTLS_DEPENDENCY "")
 endif()
 
 if (EVENT__HAVE_PTHREADS)

--- a/cmake/LibeventConfig.cmake.in
+++ b/cmake/LibeventConfig.cmake.in
@@ -61,7 +61,7 @@ if(${LIBEVENT_STATIC_LINK})
     set(_AVAILABLE_LIBS "${LIBEVENT_STATIC_LIBRARIES}")
 
     # CMake before 3.15 doesn't link OpenSSL to pthread/dl, do it ourselves instead
-    if (${CMAKE_VERSION} VERSION_LESS "3.15.0" AND ${LIBEVENT_STATIC_LINK} AND ${OPENSSL_FOUND} AND ${Threads_FOUND})
+    if (${CMAKE_VERSION} VERSION_LESS "3.15.0" AND "${LIBEVENT_STATIC_LINK}" AND "${OPENSSL_FOUND}" AND "${Threads_FOUND}")
         set_property(TARGET OpenSSL::Crypto APPEND PROPERTY INTERFACE_LINK_LIBRARIES Threads::Threads)
         set_property(TARGET OpenSSL::Crypto APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS})
     endif ()

--- a/cmake/LibeventConfig.cmake.in
+++ b/cmake/LibeventConfig.cmake.in
@@ -40,8 +40,12 @@ set(LIBEVENT_VERSION @EVENT_PACKAGE_VERSION@)
 # by component.
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
-@LIBEVENT_MBEDTLS_DEPENDENCY@
-@LIBEVENT_OPENSSL_DEPENDENCY@
+if(@EVENT__HAVE_MBEDTLS@)
+    find_dependency(MbedTLS)
+endif()
+if(@EVENT__HAVE_OPENSSL@)
+    find_dependency(OpenSSL)
+endif()
 
 # IMPORTED targets from LibeventTargets.cmake
 set(LIBEVENT_STATIC_LIBRARIES "@LIBEVENT_STATIC_LIBRARIES@")


### PR DESCRIPTION
Patch-by: @ahuj9
Fixes: https://github.com/libevent/libevent/issues/1711
Follow-up for: https://github.com/libevent/libevent/pull/1544 (cc @kurtlau)