### PR TITLE
Fix notifying the base in a different thread after removing active timer event

### DIFF
--- a/event.c
+++ b/event.c
@@ -2926,13 +2926,9 @@ event_del_nolock_(struct event *ev, int blocking)
 	}
 
 	if (ev->ev_flags & EVLIST_TIMEOUT) {
-		/* NOTE: We never need to notify the main thread because of a
-		 * deleted timeout event: all that could happen if we don't is
-		 * that the dispatch loop might wake up too early.  But the
-		 * point of notifying the main thread _is_ to wake up the
-		 * dispatch loop early anyway, so we wouldn't gain anything by
-		 * doing it.
-		 */
+		/* Notify the base if this was the minimal timeout */
+		if (min_heap_top_(&base->timeheap) == ev)
+			notify = 1;
 		event_queue_remove_timeout(base, ev);
 	}
 


### PR DESCRIPTION
The base should be notified in case of timer removal if that was the minimal timer in the base.

Reported-by: @moihn (who is also provided the reproducer on which this test is based on)
Fixes: https://github.com/libevent/libevent/issues/1727