### PR TITLE
Updated documentation for bufferevent_setcb()

### DIFF
--- a/include/event2/bufferevent.h
+++ b/include/event2/bufferevent.h
@@ -280,7 +280,8 @@ int bufferevent_socket_get_dns_error(struct bufferevent *bev);
 
   NOTE that only socket bufferevents support this function.
 
-  @param base an event_base returned by event_init()
+  @param base an event_base returned by event_base_new() or the deprecated
+         event_init()
   @param bufev a bufferevent struct returned by bufferevent_new()
      or bufferevent_socket_new()
   @return 0 if successful, or -1 if an error occurred

--- a/include/event2/bufferevent.h
+++ b/include/event2/bufferevent.h
@@ -280,8 +280,7 @@ int bufferevent_socket_get_dns_error(struct bufferevent *bev);
 
   NOTE that only socket bufferevents support this function.
 
-  @param base an event_base returned by event_base_new() or the deprecated
-         event_init()
+  @param base an event_base returned by event_base_new()
   @param bufev a bufferevent struct returned by bufferevent_new()
      or bufferevent_socket_new()
   @return 0 if successful, or -1 if an error occurred


### PR DESCRIPTION
- `bufferevent_setcb()` states that it requires an event base returned from `event_init()` however that function looks to be depricated. Thus I've updated the comment to suggest the usage of `event_base_new()`