### PR TITLE
Retry tests with SIGALRM on OSX (and fix some related stuff)

### DIFF
--- a/test/regress.c
+++ b/test/regress.c
@@ -3774,7 +3774,7 @@ struct testcase_t evtag_testcases[] = {
 	END_OF_TESTCASES
 };
 
-#if defined(__darwin__)
+#if defined(__APPLE__)
 #define RETRY_ON_DARWIN TT_RETRIABLE
 #else
 #define RETRY_ON_DARWIN 0

--- a/test/regress.c
+++ b/test/regress.c
@@ -3784,6 +3784,8 @@ struct testcase_t evtag_testcases[] = {
 	END_OF_TESTCASES
 };
 
+/* Apparently there is a bug in OSX that leads to subsequent ALRM signal
+ * delievered even though it_interval is set to 0, so let's retry the tests */
 #if defined(__APPLE__)
 #define RETRY_ON_DARWIN TT_RETRIABLE
 #else
@@ -3803,7 +3805,7 @@ struct testcase_t signal_testcases[] = {
 	LEGACY(signal_restore, TT_ISOLATED),
 	LEGACY(signal_assert, TT_ISOLATED),
 	LEGACY(signal_while_processing, TT_ISOLATED),
-	BASIC(signal_free_in_callback, TT_FORK|TT_NEED_BASE|RETRY_ON_DARWIN),
+	BASIC(signal_free_in_callback, TT_FORK|TT_NEED_BASE),
 #endif
 	END_OF_TESTCASES
 };

--- a/test/regress.c
+++ b/test/regress.c
@@ -1045,10 +1045,20 @@ signal_cb(evutil_socket_t fd, short event, void *arg)
 }
 
 static void
+signal_alarm_fallback(int sig)
+{
+	TT_DIE(("ALRM received not from event loop!"));
+end:
+	;
+}
+
+static void
 test_simple_signal_impl(int find_reorder)
 {
 	struct event ev;
 	struct itimerval itv;
+
+	signal(SIGALRM, signal_alarm_fallback);
 
 	evsignal_set(&ev, SIGALRM, signal_cb, &ev);
 	evsignal_add(&ev, NULL);
@@ -1123,6 +1133,8 @@ test_multiplesignal(void)
 	struct itimerval itv;
 
 	setup_test("Multiple signal: ");
+
+	signal(SIGALRM, signal_alarm_fallback);
 
 	evsignal_set(&ev_one, SIGALRM, signal_cb, &ev_one);
 	evsignal_add(&ev_one, NULL);

--- a/test/regress.c
+++ b/test/regress.c
@@ -1061,11 +1061,10 @@ test_simple_signal_impl(int find_reorder)
 	memset(&itv, 0, sizeof(itv));
 	itv.it_value.tv_sec = 0;
 	itv.it_value.tv_usec = 100000;
-	if (setitimer(ITIMER_REAL, &itv, NULL) == -1)
-		goto skip_simplesignal;
+	tt_int_op(setitimer(ITIMER_REAL, &itv, NULL), ==, 0);
 
 	event_dispatch();
- skip_simplesignal:
+end:
 	if (evsignal_del(&ev) == -1)
 		test_ok = 0;
 
@@ -1134,12 +1133,11 @@ test_multiplesignal(void)
 	memset(&itv, 0, sizeof(itv));
 	itv.it_value.tv_sec = 0;
 	itv.it_value.tv_usec = 100000;
-	if (setitimer(ITIMER_REAL, &itv, NULL) == -1)
-		goto skip_simplesignal;
+	tt_int_op(setitimer(ITIMER_REAL, &itv, NULL), ==, 0);
 
 	event_dispatch();
 
- skip_simplesignal:
+end:
 	if (evsignal_del(&ev_one) == -1)
 		test_ok = 0;
 	if (evsignal_del(&ev_two) == -1)

--- a/test/regress.c
+++ b/test/regress.c
@@ -1045,7 +1045,7 @@ signal_cb(evutil_socket_t fd, short event, void *arg)
 }
 
 static void
-test_simplesignal_impl(int find_reorder)
+test_simple_signal_impl(int find_reorder)
 {
 	struct event ev;
 	struct itimerval itv;
@@ -1073,17 +1073,17 @@ test_simplesignal_impl(int find_reorder)
 }
 
 static void
-test_simplestsignal(void)
+test_simple_signal(void)
 {
 	setup_test("Simplest one signal: ");
-	test_simplesignal_impl(0);
+	test_simple_signal_impl(0);
 }
 
 static void
-test_simplesignal(void)
+test_simple_signal_re_order(void)
 {
 	setup_test("Simple signal: ");
-	test_simplesignal_impl(1);
+	test_simple_signal_impl(1);
 }
 
 /* signal_free_in_callback */
@@ -3782,8 +3782,8 @@ struct testcase_t evtag_testcases[] = {
 
 struct testcase_t signal_testcases[] = {
 #ifndef _WIN32
-	LEGACY(simplestsignal, TT_ISOLATED|RETRY_ON_DARWIN),
-	LEGACY(simplesignal, TT_ISOLATED|RETRY_ON_DARWIN),
+	LEGACY(simple_signal, TT_ISOLATED|RETRY_ON_DARWIN),
+	LEGACY(simple_signal_re_order, TT_ISOLATED|RETRY_ON_DARWIN),
 	LEGACY(multiplesignal, TT_ISOLATED|RETRY_ON_DARWIN),
 	LEGACY(immediatesignal, TT_ISOLATED),
 	LEGACY(signal_dealloc, TT_ISOLATED),


### PR DESCRIPTION
By some reason even after first ALRM signal received and event loop
returned it is possible to recieve an ALRM one more time (at least one):

    % yes signal/simple_signal.. | head -n 1000 | xargs -I{} -P10 sh -c 'EVENT_DEBUG_LOGGING_ALL= bin/regress --timeout 0 --verbose {} >& /tmp/test.$SECONDS.$RANDOM.log'
    % cat /tmp/test.0.18384.log
    signal/simple_signal: [forking] [debug] event_add: event: 0x16d70f368 (fd 14),     call 0x102704ae8
    [debug] evsig_ensure_saved_: evsignal (14) >= sh_old_max (0), resizing

             OK /Users/ec2-user/libevent/test/regress.c:1086: assert(setitimer(ITIMER_REAL, &itv, NULL) == 0): 0 vs 0[debug] kq_dispatch: kevent reports 1
    [debug] event_active: 0x16d70f368 (fd 14), res 8, callback 0x102704ae8
    [debug] event_process_active: event: 0x16d70f368,    call 0x102704ae8
    [debug] event_del: 0x16d70f368 (fd 14), callback 0x102704ae8
    [debug] event_base_loop: no events registered.

      FAIL /Users/ec2-user/libevent/test/regress.c:1062: ALRM received not from event loop![debug] event_del: 0x16d70f368 (fd 14), callback 0x102704ae8
    [debug] event_base_free_: 0 events freed
    signal/simple_signal: exited with 0 (0)

      [FAILED signal/simple_signal (0 retries)]
    signal/simple_signal_re_order: [forking] [debug] event_add: event: 0x16d70f368 (fd 14),     call 0x102704ae8
    [debug] evsig_ensure_saved_: evsignal (14) >= sh_old_max (0), resizing
    [debug] event_del: 0x16d70f368 (fd 14), callback 0x102704ae8
    [debug] event_add: event: 0x16d70f368 (fd 14),     call 0x102704ae8

             OK /Users/ec2-user/libevent/test/regress.c:1086: assert(setitimer(ITIMER_REAL, &itv, NULL) == 0): 0 vs 0[debug] kq_dispatch: kevent reports 1
    [debug] event_active: 0x16d70f368 (fd 14), res 8, callback 0x102704ae8
    [debug] event_process_active: event: 0x16d70f368,    call 0x102704ae8
    [debug] event_del: 0x16d70f368 (fd 14), callback 0x102704ae8
    [debug] event_base_loop: no events registered.
    [debug] event_del: 0x16d70f368 (fd 14), callback 0x102704ae8
    [debug] event_base_free_: 0 events freed
    signal/simple_signal_re_order: exited with 0 (0)

    1/2 TESTS FAILED. (0 skipped)

Also note, that the problem not only when I run two tests, but only one
as well:

    % bin/regress --timeout 0 --repeat 1000 --verbose --no-fork signal/simple_signal >/tmp/test2.log 2>&1
    signal/simple_signal:
             OK /Users/ec2-user/libevent/test/regress.c:1086: assert(setitimer(ITIMER_REAL, &itv, NULL) == 0): 0 vs 0
    signal/simple_signal:
             OK /Users/ec2-user/libevent/test/regress.c:1086: assert(setitimer(ITIMER_REAL, &itv, NULL) == 0): 0 vs 0
      FAIL /Users/ec2-user/libevent/test/regress.c:1062: ALRM received not from event loop!

I've tried to run under "ktrace trace -Ss -f C4,S0x010c -c" but of
course it does not fails under it (dtruss by some reason did not work
for me).

P.S. Also remove one TT_RETRIABLE for one test, since only setitimer()
causes this.

Fixes: https://github.com/libevent/libevent/issues/1632