### PR TITLE
cmake: Update minimum required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 #       start libevent.sln
 #
 
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 if (POLICY CMP0042)
     cmake_policy(SET CMP0042 NEW) # MACOSX_RPATH is enabled by default.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,15 +21,6 @@
 
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
-if (POLICY CMP0042)
-    cmake_policy(SET CMP0042 NEW) # MACOSX_RPATH is enabled by default.
-endif()
-if (POLICY CMP0054)
-    cmake_policy(SET CMP0054 NEW)
-endif()
-if (POLICY CMP0068)
-    cmake_policy(SET CMP0068 NEW) # RPATH settings on macOS do not affect install_name.
-endif()
 if (POLICY CMP0074)
     cmake_policy(SET CMP0074 NEW)
 endif()

--- a/test-export/CMakeLists.txt
+++ b/test-export/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 if (POLICY CMP0074)
     cmake_policy(SET CMP0074 NEW)
 endif()


### PR DESCRIPTION
From CMake 3.31 [Release Notes](https://cmake.org/cmake/help/v3.31/release/3.31.html):

> Compatibility with versions of CMake older than 3.10 is now deprecated and will be removed from a future version.

Also see https://github.com/libevent/libevent/pull/1630.

Additionally, this PR removes redundant policy settings.