### PR TITLE
ci: Test Autotools build on FreeBSD 14.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -778,7 +778,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ["13.4"]
+        release: ["13.4", "14.1"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
CMake builds are already tested on FreeBSD 13.4 and 14.1:https://github.com/libevent/libevent/blob/5bfb2ae81a055a624283b8e3b2002ea2bbe0c384/.github/workflows/build.yml#L687

This PR extends testing with Autotools to include FreeBSD 14.1.