### PR TITLE
Improve portability on NetBSD

### DIFF
--- a/kqueue.c
+++ b/kqueue.c
@@ -52,8 +52,8 @@
  * intptr_t, whereas others define it as void*.  There doesn't seem to be an
  * easy way to tell them apart via autoconf, so we need to use OS macros. */
 #if defined(__NetBSD__)
-#define PTR_TO_UDATA(x) ((typeof(((struct kevent *)0)->udata))(x))
-#define INT_TO_UDATA(x) ((typeof(((struct kevent *)0)->udata))(intptr_t)(x))
+#define PTR_TO_UDATA(x) ((__typeof__(((struct kevent *)0)->udata))(x))
+#define INT_TO_UDATA(x) ((__typeof__(((struct kevent *)0)->udata))(intptr_t)(x))
 #elif defined(EVENT__HAVE_INTTYPES_H) && !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__darwin__) && !defined(__APPLE__) && !defined(__CloudABI__)
 #define PTR_TO_UDATA(x)	((intptr_t)(x))
 #define INT_TO_UDATA(x) ((intptr_t)(x))


### PR DESCRIPTION
https://github.com/libevent/libevent/pull/909 introduced the [`typeof`](https://gcc.gnu.org/onlinedocs/gcc/Typeof.html) C language extension in NetBSD-specific code.

However, GCC [states](https://gcc.gnu.org/onlinedocs/gcc/Alternate-Keywords.html):
> the various `-std` options disable certain keywords.

This can cause issues when building libevent as part of a downstream project that uses a build environment with an `-std` compiler flag.

For instance, on NetBSD 10.0:
```
$ cmake -B build -DCMAKE_C_FLAGS="-std=c17"
$ cmake --build build
...
[ 10%] Building C object CMakeFiles/event_core_static.dir/kqueue.c.o
/home/hebasto/dev/libevent/kqueue.c: In function 'kq_setup_kevent':
/home/hebasto/dev/libevent/kqueue.c:56:27: warning: implicit declaration of function 'typeof' [-Wimplicit-function-declaration]
   56 | #define INT_TO_UDATA(x) ((typeof(((struct kevent *)0)->udata))(intptr_t)(x))
      |                           ^~~~~~
/home/hebasto/dev/libevent/kqueue.c:184:16: note: in expansion of macro 'INT_TO_UDATA'
  184 |   out->udata = INT_TO_UDATA(ADD_UDATA);
      |                ^~~~~~~~~~~~
/home/hebasto/dev/libevent/kqueue.c:56:64: error: expected expression before 'intptr_t'
   56 | #define INT_TO_UDATA(x) ((typeof(((struct kevent *)0)->udata))(intptr_t)(x))
      |                                                                ^~~~~~~~
/home/hebasto/dev/libevent/kqueue.c:184:16: note: in expansion of macro 'INT_TO_UDATA'
  184 |   out->udata = INT_TO_UDATA(ADD_UDATA);
      |                ^~~~~~~~~~~~
/home/hebasto/dev/libevent/kqueue.c:56:27: error: called object is not a function or function pointer
   56 | #define INT_TO_UDATA(x) ((typeof(((struct kevent *)0)->udata))(intptr_t)(x))
      |                          ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/hebasto/dev/libevent/kqueue.c:184:16: note: in expansion of macro 'INT_TO_UDATA'
  184 |   out->udata = INT_TO_UDATA(ADD_UDATA);
      |                ^~~~~~~~~~~~
gmake[2]: *** [CMakeFiles/event_core_static.dir/build.make:342: CMakeFiles/event_core_static.dir/kqueue.c.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:185: CMakeFiles/event_core_static.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```

This PR adheres to GCC's recommendation by replacing the `typeof` keyword with its alternative, `__typeof__`.