### PR TITLE
cmake: alias targets for `add_subdirectory`

### DIFF
--- a/cmake/AddEventLibrary.cmake
+++ b/cmake/AddEventLibrary.cmake
@@ -177,5 +177,10 @@ macro(add_event_library LIB_NAME)
     add_library(${LIB_NAME} INTERFACE)
     target_link_libraries(${LIB_NAME} INTERFACE ${ADD_EVENT_LIBRARY_INTERFACE})
 
+    if(NOT "${LIB_NAME}" STREQUAL "event")
+        string(REPLACE "event_" "" PURE_NAME "${LIB_NAME}")
+        add_library("${PROJECT_NAME}::${PURE_NAME}" ALIAS "${LIB_NAME}")
+    endif()
+
     generate_pkgconfig("${LIB_NAME}")
 endmacro()


### PR DESCRIPTION
Define alias targets in `add_event_library`, so that you can use the exported targets after `add_subdirectory(libevent)` as if you've ran `find_package(Libevent)`.