### PR TITLE
cmake: alias targets for `add_subdirectory`

### DIFF
--- a/cmake/AddEventLibrary.cmake
+++ b/cmake/AddEventLibrary.cmake
@@ -67,6 +67,8 @@ macro(export_install_target TYPE LIB_NAME)
             RUNTIME DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib
             COMPONENT dev
         )
+
+        add_library("${PROJECT_NAME}::${PURE_NAME}" ALIAS "${LIB_NAME}")
     endif()
 endmacro()
 


### PR DESCRIPTION
Define alias targets in `add_event_library`, so that you can use the exported targets after `add_subdirectory(libevent)` as if you've ran `find_package(Libevent)`.