### PR TITLE
Prevent segfault in `evbuffer_drain` to causing potential `NULL` dereference

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -1156,7 +1156,7 @@ evbuffer_drain(struct evbuffer *buf, size_t len)
 		buf->total_len -= len;
 		remaining = len;
 		for (chain = buf->first;
-		     remaining >= chain->off;
+		     chain != NULL && remaining >= chain->off;
 		     chain = next) {
 			next = chain->next;
 			remaining -= chain->off;
@@ -1176,10 +1176,12 @@ evbuffer_drain(struct evbuffer *buf, size_t len)
 				evbuffer_chain_free(chain);
 		}
 
-		buf->first = chain;
-		EVUTIL_ASSERT(remaining <= chain->off);
-		chain->misalign += remaining;
-		chain->off -= remaining;
+        buf->first = chain;
+        if (chain != NULL) {
+            EVUTIL_ASSERT(remaining <= chain->off);
+            chain->misalign += remaining;
+            chain->off -= remaining;
+        }
 	}
 
 	buf->n_del_for_cb += len;


### PR DESCRIPTION
This PR addresses a critical issue in `evbuffer_drain` where the pointer chain can be `NULL` after the main draining loop. The original code dereferenced chain without checking for `NULL`, leading to a segmentation fault in certain edge cases when the entire buffer is drained.

Changes include:
- Added a `NULL` check before accessing `chain->off` and `chain->misalign` after the loop.
- Ensured safe handling when no remaining chains exist after draining.

This fix improves stability and prevents crashes during buffer draining operations, especially when consuming the entire buffer content.