### PR TITLE
Stop reading after errors occurring in evdns

### DIFF
--- a/evdns.c
+++ b/evdns.c
@@ -2873,6 +2873,12 @@ client_tcp_read_packet_cb(struct bufferevent *bev, void *ctx)
 		reply_parse(server->base, msg, msg_len);
 		mm_free(msg);
 		msg = NULL;
+		if (server->connection == NULL) {
+			/* Some errors occurred in reply_parse, and TCP connection has been
+			 * close. Stop reading from it. */
+			EVDNS_UNLOCK(server->base);
+			return;
+		}
 		conn->awaiting_packet_size = 0;
 	}
 


### PR DESCRIPTION
Some servers may return DNS_ERR_NOTIMPL or DNS_ERR_REFUSED when queried via TCP. In such cases, evdns closes the connection within the `reply_handle` function; however, `client_tcp_read_packet_cb` continues to attempt reading from the already-closed connection, leading to a use-after-free vulnerability.