### PR TITLE
Android: revert "Add postfix for Debug configuration"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,14 +38,6 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
 
-# Usually it is OK to define it unconditionally, but the problem is that we use
-# CMAKE_DEBUG_POSTFIX in *.pc.in
-if (CMAKE_BUILD_TYPE_LOWER STREQUAL "debug")
-    if(NOT DEFINED CMAKE_DEBUG_POSTFIX)
-        set(CMAKE_DEBUG_POSTFIX d)
-    endif()
-endif()
-
 set(EVENT__LIBRARY_TYPE DEFAULT CACHE STRING
     "Set library type to SHARED/STATIC/BOTH (default SHARED for MSVC, otherwise BOTH)")
 


### PR DESCRIPTION
Partial revert of #1314.

This fixes Android builds of Transmission when adopting libevent 2.2. You can see the build error here:
https://github.com/transmission/transmission/actions/runs/19076761825/job/54494494995
> clang++: error: no such file or directory: 'third-party/libevent.bld/pfx/lib/libevent.a'

Looking at #1313, I see Azat commenting:
> I'm not against reverting the original change, but the reasoning should be strong enough to do this.

Well, causing a build error is a strong argument.