### PR TITLE
Fix tautological pointer comparison warning in evhttp_uriencode

### DIFF
--- a/http.c
+++ b/http.c
@@ -3483,7 +3483,7 @@ evhttp_uriencode(const char *uri, ev_ssize_t len, int space_as_plus)
 			goto out;
 		}
 
-		if (uri + slen < uri) {
+		if (slen > (size_t)(UINTPTR_MAX - (uintptr_t)uri)) {
 			goto out;
 		}
 


### PR DESCRIPTION
Fixes #1784

The latest Clang was throwing a -Wtautological-compare warning on this line:

```c
if (uri + slen < uri) {
```

This is checking for pointer overflow, but modern compilers optimize this away since pointer overflow is undefined behavior. The comparison always evaluates to false.

I changed it to properly check for overflow before doing the addition:

```c
if (slen > (size_t)(UINTPTR_MAX - (uintptr_t)uri)) {
```

This checks whether adding slen to the uri pointer would exceed UINTPTR_MAX, which is a valid overflow check that won't get optimized away.