### PR TITLE
build: fix "Compatibility with CMake < 3.5 has been removed from CMake"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 #       start libevent.sln
 #
 
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10...4.1 FATAL_ERROR)
 
 if (POLICY CMP0074)
     cmake_policy(SET CMP0074 NEW)


### PR DESCRIPTION
Fixes: https://github.com/libevent/libevent/issues/1782