### PR TITLE
FIX: header warning in clangd checks

### DIFF
--- a/include/event2/bufferevent_compat.h
+++ b/include/event2/bufferevent_compat.h
@@ -35,7 +35,6 @@
  */
 
 #include <event2/visibility.h>
-#include <event2/bufferevent.h>
 
 #define evbuffercb bufferevent_data_cb
 #define everrorcb bufferevent_event_cb

--- a/include/event2/bufferevent_struct.h
+++ b/include/event2/bufferevent_struct.h
@@ -53,7 +53,6 @@ extern "C" {
 #include <event2/util.h>
 /* For struct event */
 #include <event2/event_struct.h>
-#include <event2/bufferevent.h>
 
 struct event_watermark {
 	size_t low;

--- a/include/event2/dns_compat.h
+++ b/include/event2/dns_compat.h
@@ -50,7 +50,6 @@ extern "C" {
 /* For int types. */
 #include <event2/util.h>
 #include <event2/visibility.h>
-#include <event2/dns.h>
 
 /**
   Initialize the asynchronous DNS library.

--- a/include/event2/http_struct.h
+++ b/include/event2/http_struct.h
@@ -48,7 +48,6 @@ extern "C" {
 
 /* For int types. */
 #include <event2/util.h>
-#include <event2/http.h>
 
 /**
  * the request structure that a server receives.


### PR DESCRIPTION
notice some missing include in header files, add missing headers