### PR TITLE
Fix retaining const qualifier from pointer -Wdiscarded-qualifiers

### DIFF
--- a/evutil.c
+++ b/evutil.c
@@ -2228,6 +2228,7 @@ evutil_inet_pton_scope(int af, const char *src, void *dst, unsigned *indexp)
 	int r;
 	unsigned if_index;
 	char *check, *cp, *tmp_src;
+	const char *cp2;
 
 	*indexp = 0; /* Reasonable default */
 
@@ -2235,16 +2236,16 @@ evutil_inet_pton_scope(int af, const char *src, void *dst, unsigned *indexp)
 	if (af != AF_INET6)
 		return evutil_inet_pton(af, src, dst);
 
-	cp = strchr(src, '%');
+	cp2 = strchr(src, '%');
 
 	/* Bail out if no zone ID */
-	if (cp == NULL)
+	if (cp2 == NULL)
 		return evutil_inet_pton(af, src, dst);
 
-	if_index = if_nametoindex(cp + 1);
+	if_index = if_nametoindex(cp2 + 1);
 	if (if_index == 0) {
 		/* Could be numeric */
-		if_index = strtoul(cp + 1, &check, 10);
+		if_index = strtoul(cp2 + 1, &check, 10);
 		if (check[0] != '\0')
 			return 0;
 	}


### PR DESCRIPTION
- fixes #1834 

Since glibc-2.43:

For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the in put argument is a pointer to a const-qualified type.

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html

Resolves the following warning:
```

../evutil.c: In function 'evutil_inet_pton_scope': ../evutil.c:2004:12: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 2004 |         cp = strchr(src, '%');
      |            ^
``` 