### PR TITLE
http: server-side streaming uploads for memory-constrained devices

### DIFF
--- a/http.c
+++ b/http.c
@@ -1095,7 +1095,7 @@ evhttp_handle_chunked_read(struct evhttp_request *req, struct evbuffer *buf)
 		req->ntoread = -1;
 		if (req->chunk_cb != NULL) {
 			req->flags |= EVHTTP_REQ_DEFER_FREE;
-			(*req->chunk_cb)(req, req->cb_arg);
+			(*req->chunk_cb)(req, req->chunk_cb_arg);
 			evbuffer_drain(req->input_buffer,
 			    evbuffer_get_length(req->input_buffer));
 			req->flags &= ~EVHTTP_REQ_DEFER_FREE;
@@ -1221,7 +1221,7 @@ evhttp_read_body(struct evhttp_connection *evcon, struct evhttp_request *req)
 
 	if (evbuffer_get_length(req->input_buffer) > 0 && req->chunk_cb != NULL) {
 		req->flags |= EVHTTP_REQ_DEFER_FREE;
-		(*req->chunk_cb)(req, req->cb_arg);
+		(*req->chunk_cb)(req, req->chunk_cb_arg);
 		req->flags &= ~EVHTTP_REQ_DEFER_FREE;
 		evbuffer_drain(req->input_buffer,
 		    evbuffer_get_length(req->input_buffer));
@@ -2424,6 +2424,9 @@ evhttp_get_body(struct evhttp_connection *evcon, struct evhttp_request *req)
 			return;
 		case NO: break;
 	}
+
+	if (req->body_start_cb != NULL)
+		(*req->body_start_cb)(req, req->body_start_cb_arg);
 
 	evhttp_read_body(evcon, req);
 	/* note the request may have been freed in evhttp_read_body */
@@ -4484,6 +4487,26 @@ evhttp_request_set_chunked_cb(struct evhttp_request *req,
     void (*cb)(struct evhttp_request *, void *))
 {
 	req->chunk_cb = cb;
+	/* Preserve the historical contract: the chunked callback was always
+	 * invoked with the same argument as the request completion callback.
+	 * Capture it here so that the new chunk_cb_arg slot is populated. */
+	req->chunk_cb_arg = req->cb_arg;
+}
+
+void
+evhttp_request_set_body_read_cb(struct evhttp_request *req,
+    void (*cb)(struct evhttp_request *, void *), void *arg)
+{
+	req->chunk_cb = cb;
+	req->chunk_cb_arg = arg;
+}
+
+void
+evhttp_request_set_body_start_cb(struct evhttp_request *req,
+    void (*cb)(struct evhttp_request *, void *), void *arg)
+{
+	req->body_start_cb = cb;
+	req->body_start_cb_arg = arg;
 }
 
 void

--- a/include/event2/http.h
+++ b/include/event2/http.h
@@ -760,6 +760,45 @@ void evhttp_request_set_header_cb(struct evhttp_request *,
     int (*cb)(struct evhttp_request *, void *));
 
 /**
+ * Stream the request body to the caller as it arrives.
+ *
+ * On the server side this lets a handler process an upload without buffering
+ * the whole body in memory: register the callback from a body-start callback
+ * (see evhttp_request_set_body_start_cb()) and the callback will be invoked
+ * each time more body bytes are read off the wire, for both
+ * Content-Length and Transfer-Encoding: chunked bodies. On the client side
+ * this behaves like evhttp_request_set_chunked_cb() but takes an explicit
+ * @p arg instead of reusing the request completion callback's argument.
+ *
+ * The callback should consume req->input_buffer (e.g. via evbuffer_remove or
+ * evbuffer_write); whatever it leaves behind is drained automatically on
+ * return. It is never called on an empty buffer.
+ *
+ * @param cb will be called after every read of body data.
+ * @param arg user-supplied argument passed to @p cb on every invocation.
+ */
+EVENT2_EXPORT_SYMBOL
+void evhttp_request_set_body_read_cb(struct evhttp_request *,
+    void (*cb)(struct evhttp_request *, void *), void *arg);
+
+/**
+ * Register a callback to fire once request headers have been fully parsed,
+ * before the body is read.
+ *
+ * Intended for server-side streaming uploads: by the time this fires the URI,
+ * method, request headers, Content-Length and chunked flag are all known, so
+ * the application can decide whether and how to stream the body via
+ * evhttp_request_set_body_read_cb(). To install this callback for every
+ * incoming request, register it from an evhttp_set_newreqcb() handler.
+ *
+ * @param cb will be called after all headers received, before body read.
+ * @param arg user-supplied argument passed to @p cb on every invocation.
+ */
+EVENT2_EXPORT_SYMBOL
+void evhttp_request_set_body_start_cb(struct evhttp_request *,
+    void (*cb)(struct evhttp_request *, void *), void *arg);
+
+/**
  * The different error types supported by evhttp
  *
  * @see evhttp_request_set_error_cb()

--- a/include/event2/http_struct.h
+++ b/include/event2/http_struct.h
@@ -110,6 +110,7 @@ struct {
 	 * the regular callback.
 	 */
 	void (*chunk_cb)(struct evhttp_request *, void *);
+	void *chunk_cb_arg;
 
 	/*
 	 * Callback added for forked-daapd so they can collect ICY
@@ -132,6 +133,18 @@ struct {
 	 */
 	void (*on_complete_cb)(struct evhttp_request *, void *);
 	void *on_complete_cb_arg;
+
+	/*
+	 * Body-start callback - invoked once on the server after the request
+	 * headers have been parsed (so URI, method, Content-Length and the
+	 * chunked flag are all known) but before any body bytes are read.
+	 * This is the place to install evhttp_request_set_body_read_cb() when
+	 * streaming a request body.
+	 *
+	 * @see evhttp_request_set_body_start_cb()
+	 */
+	void (*body_start_cb)(struct evhttp_request *, void *);
+	void *body_start_cb_arg;
 };
 
 #ifdef __cplusplus

--- a/sample/http-server.c
+++ b/sample/http-server.c
@@ -9,6 +9,7 @@
 /* Compatibility for possible missing IPv6 declarations */
 #include "../util-internal.h"
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -75,6 +76,15 @@
 #endif
 #ifndef O_RDONLY
 #define O_RDONLY _O_RDONLY
+#endif
+#ifndef O_WRONLY
+#define O_WRONLY _O_WRONLY
+#endif
+#ifndef O_CREAT
+#define O_CREAT _O_CREAT
+#endif
+#ifndef O_TRUNC
+#define O_TRUNC _O_TRUNC
 #endif
 #endif /* _WIN32 */
 
@@ -347,6 +357,112 @@ done:
 		evbuffer_free(evb);
 }
 
+/* Streaming-upload demo: receive a request body without buffering the whole
+ * thing in memory.  The form at GET /upload submits to POST /upload, which is
+ * streamed to disk as it arrives. */
+
+struct upload_state {
+	int fd;
+	ev_uint64_t bytes;
+	char path[128];
+};
+
+static void
+upload_state_free(struct upload_state *st)
+{
+	if (st == NULL)
+		return;
+	if (st->fd >= 0)
+		close(st->fd);
+	free(st);
+}
+
+static void
+upload_drain_to_fd(struct evbuffer *src, int fd)
+{
+	while (evbuffer_get_length(src) > 0) {
+		int written = evbuffer_write(src, fd);
+		if (written < 0) {
+			if (errno == EINTR)
+				continue;
+			perror("write");
+			return;
+		}
+		if (written == 0)
+			return;
+	}
+}
+
+static void
+upload_body_read_cb(struct evhttp_request *req, void *arg)
+{
+	struct upload_state *st = arg;
+	struct evbuffer *in = evhttp_request_get_input_buffer(req);
+	size_t n = evbuffer_get_length(in);
+
+	if (st->fd < 0)
+		return;
+	st->bytes += n;
+	upload_drain_to_fd(in, st->fd);
+}
+
+static void
+upload_on_complete_cb(struct evhttp_request *req, void *arg)
+{
+	struct upload_state *st = arg;
+	printf("Upload to %s complete: %llu bytes\n",
+	    st->path, (unsigned long long)st->bytes);
+	upload_state_free(st);
+}
+
+static void
+upload_body_start_cb(struct evhttp_request *req, void *arg)
+{
+	struct upload_state *st;
+
+	if (evhttp_request_get_command(req) != EVHTTP_REQ_POST)
+		return;
+	if (strcmp(evhttp_request_get_uri(req), "/upload") != 0)
+		return;
+
+	st = calloc(1, sizeof(*st));
+	if (st == NULL)
+		return;
+	st->fd = -1;
+	evutil_snprintf(st->path, sizeof(st->path), "upload.txt");
+
+	st->fd = open(st->path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	if (st->fd < 0) {
+		perror("open");
+		upload_state_free(st);
+		evhttp_send_error(req, HTTP_INTERNAL, NULL);
+		return;
+	}
+	printf("Start file receive -> %s\n", st->path);
+	evhttp_request_set_body_read_cb(req, upload_body_read_cb, st);
+	evhttp_request_set_on_complete_cb(req, upload_on_complete_cb, st);
+}
+
+static int
+upload_newreq_cb(struct evhttp_request *req, void *arg)
+{
+	evhttp_request_set_body_start_cb(req, upload_body_start_cb, NULL);
+	return 0;
+}
+
+static void
+upload_form_cb(struct evhttp_request *req, void *arg)
+{
+	struct evbuffer *out = evhttp_request_get_output_buffer(req);
+	evbuffer_add_printf(out,
+	    "<html><body>"
+	    "<form enctype=\"multipart/form-data\" action=\"/upload\" method=\"POST\">"
+	    "<input type=\"file\" name=\"file\">"
+	    "<p><input type=\"submit\"></p>"
+	    "</form></body></html>\n");
+	evhttp_send_reply(req, HTTP_OK, "OK", NULL);
+}
+
 static void
 print_usage(FILE *out, const char *prog, int exit_code)
 {
@@ -512,6 +628,12 @@ main(int argc, char **argv)
 
 	/* The /dump URI will dump all requests to stdout and say 200 ok. */
 	evhttp_set_cb(http, "/dump", dump_request_cb, NULL);
+
+	/* GET /upload serves a form; POST /upload streams its body to disk
+	 * without ever buffering it whole. The streaming wiring is installed
+	 * from upload_newreq_cb() below. */
+	evhttp_set_cb(http, "/upload", upload_form_cb, NULL);
+	evhttp_set_newreqcb(http, upload_newreq_cb, NULL);
 
 	/* We want to accept arbitrary requests, so we need to set a "generic"
 	 * cb.  We can also add callbacks for specific paths. */

--- a/test/regress_http.c
+++ b/test/regress_http.c
@@ -4356,6 +4356,228 @@ http_stream_in_cancel_test(void *arg)
 
 }
 
+/*
+ * Server-side streaming request body: verify body_start_cb fires once after
+ * headers are parsed, body_read_cb is invoked incrementally, the input buffer
+ * is drained by the time the gencb fires, and the captured bytes match what
+ * the client sent.  Covers both Content-Length and Transfer-Encoding: chunked.
+ */
+
+struct stream_in_body_state {
+	int body_start_calls;
+	int body_read_calls;
+	int gencb_calls;
+	struct evbuffer *captured;
+	/* When body_start_cb fires it has full request metadata; record it
+	 * so the test thread can assert on it after the loop returns. */
+	int saw_post;
+	int saw_uri;
+};
+
+static void
+stream_in_body_read_cb(struct evhttp_request *req, void *arg)
+{
+	struct stream_in_body_state *s = arg;
+	s->body_read_calls++;
+	evbuffer_add_buffer(s->captured, evhttp_request_get_input_buffer(req));
+}
+
+static void
+stream_in_body_start_cb(struct evhttp_request *req, void *arg)
+{
+	struct stream_in_body_state *s = arg;
+	const char *uri;
+
+	s->body_start_calls++;
+	s->saw_post = (evhttp_request_get_command(req) == EVHTTP_REQ_POST);
+	uri = evhttp_request_get_uri(req);
+	s->saw_uri = (uri && !strcmp(uri, "/streamed_in"));
+
+	evhttp_request_set_body_read_cb(req, stream_in_body_read_cb, s);
+}
+
+static int
+stream_in_body_newreq_cb(struct evhttp_request *req, void *arg)
+{
+	evhttp_request_set_body_start_cb(req, stream_in_body_start_cb, arg);
+	return 0;
+}
+
+static void
+stream_in_body_server_cb(struct evhttp_request *req, void *arg)
+{
+	struct stream_in_body_state *s = arg;
+	s->gencb_calls++;
+	evhttp_send_reply(req, HTTP_OK, "OK", NULL);
+}
+
+static void
+stream_in_body_client_done(struct evhttp_request *req, void *arg)
+{
+	struct event_base *base = arg;
+	if (req && evhttp_request_get_response_code(req) == HTTP_OK)
+		test_ok = 1;
+	event_base_loopexit(base, NULL);
+}
+
+static void
+http_stream_in_body_test(void *arg)
+{
+	struct basic_test_data *data = arg;
+	struct stream_in_body_state state;
+	ev_uint16_t port = 0;
+	struct evhttp *http = NULL;
+	struct evhttp_connection *evcon = NULL;
+	struct evhttp_request *req = NULL;
+
+	memset(&state, 0, sizeof(state));
+	state.captured = evbuffer_new();
+	tt_assert(state.captured);
+	test_ok = 0;
+
+	http = http_setup_gencb(&port, data->base, 0,
+	    stream_in_body_server_cb, &state);
+	tt_assert(http);
+	evhttp_set_newreqcb(http, stream_in_body_newreq_cb, &state);
+
+	evcon = evhttp_connection_base_new(data->base, NULL, "127.0.0.1", port);
+	tt_assert(evcon);
+
+	req = evhttp_request_new(stream_in_body_client_done, data->base);
+	tt_assert(req);
+	evhttp_add_header(evhttp_request_get_output_headers(req),
+	    "Host", "somehost");
+	evbuffer_add_printf(evhttp_request_get_output_buffer(req), POST_DATA);
+
+	tt_int_op(evhttp_make_request(evcon, req, EVHTTP_REQ_POST,
+	    "/streamed_in"), ==, 0);
+	event_base_dispatch(data->base);
+
+	tt_int_op(test_ok, ==, 1);
+	tt_int_op(state.body_start_calls, ==, 1);
+	tt_int_op(state.body_read_calls, >=, 1);
+	tt_int_op(state.gencb_calls, ==, 1);
+	tt_assert(state.saw_post);
+	tt_assert(state.saw_uri);
+	tt_int_op(evbuffer_get_length(state.captured), ==, strlen(POST_DATA));
+	tt_int_op(evbuffer_datacmp(state.captured, POST_DATA), ==, 0);
+
+ end:
+	if (state.captured)
+		evbuffer_free(state.captured);
+	if (evcon)
+		evhttp_connection_free(evcon);
+	if (http)
+		evhttp_free(http);
+}
+
+/* Chunked-encoded server-side streaming: drive the request over a raw
+ * bufferevent (no client-side libevent chunked-upload helper exists) and
+ * check that the body is delivered incrementally as chunks arrive. */
+
+static const char STREAM_IN_CHUNK_A[] = "alpha";
+static const char STREAM_IN_CHUNK_B[] = "bravo!";
+static const char STREAM_IN_CHUNK_C[] = "charlie";
+
+static void
+stream_in_body_chunked_client_read_cb(struct bufferevent *bev, void *arg)
+{
+	struct evbuffer *input = bufferevent_get_input(bev);
+	/* Look for the end of the response status line - good enough for a
+	 * smoke check; the real assertions are on the server side. */
+	char *line = evbuffer_readln(input, NULL, EVBUFFER_EOL_CRLF);
+	if (line && !strncmp(line, "HTTP/1.1 200", 12))
+		test_ok++;
+	free(line);
+	event_base_loopexit(exit_base, NULL);
+}
+
+static void
+stream_in_body_chunked_client_error_cb(struct bufferevent *bev, short what, void *arg)
+{
+	event_base_loopexit(exit_base, NULL);
+}
+
+static void
+http_stream_in_body_chunked_test(void *arg)
+{
+	struct basic_test_data *data = arg;
+	struct stream_in_body_state state;
+	ev_uint16_t port = 0;
+	struct evhttp *http = NULL;
+	struct bufferevent *bev = NULL;
+	evutil_socket_t fd = EVUTIL_INVALID_SOCKET;
+	struct evbuffer *out = NULL;
+	size_t expected_len = strlen(STREAM_IN_CHUNK_A) +
+	    strlen(STREAM_IN_CHUNK_B) + strlen(STREAM_IN_CHUNK_C);
+
+	memset(&state, 0, sizeof(state));
+	state.captured = evbuffer_new();
+	tt_assert(state.captured);
+	test_ok = 0;
+	exit_base = data->base;
+
+	http = http_setup_gencb(&port, data->base, 0,
+	    stream_in_body_server_cb, &state);
+	tt_assert(http);
+	evhttp_set_newreqcb(http, stream_in_body_newreq_cb, &state);
+
+	fd = http_connect("127.0.0.1", port);
+	tt_assert(fd != EVUTIL_INVALID_SOCKET);
+
+	bev = create_bev(data->base, fd, 0, BEV_OPT_CLOSE_ON_FREE);
+	tt_assert(bev);
+	bufferevent_setcb(bev,
+	    stream_in_body_chunked_client_read_cb, NULL,
+	    stream_in_body_chunked_client_error_cb, data->base);
+	bufferevent_enable(bev, EV_READ | EV_WRITE);
+
+	out = bufferevent_get_output(bev);
+	evbuffer_add_printf(out,
+	    "POST /streamed_in HTTP/1.1\r\n"
+	    "Host: somehost\r\n"
+	    "Transfer-Encoding: chunked\r\n"
+	    "Connection: close\r\n"
+	    "\r\n");
+	evbuffer_add_printf(out, "%x\r\n%s\r\n",
+	    (unsigned)strlen(STREAM_IN_CHUNK_A), STREAM_IN_CHUNK_A);
+	evbuffer_add_printf(out, "%x\r\n%s\r\n",
+	    (unsigned)strlen(STREAM_IN_CHUNK_B), STREAM_IN_CHUNK_B);
+	evbuffer_add_printf(out, "%x\r\n%s\r\n",
+	    (unsigned)strlen(STREAM_IN_CHUNK_C), STREAM_IN_CHUNK_C);
+	evbuffer_add_printf(out, "0\r\n\r\n");
+
+	event_base_dispatch(data->base);
+
+	tt_int_op(test_ok, ==, 1);
+	tt_int_op(state.body_start_calls, ==, 1);
+	/* Three non-empty chunks should produce at least one body_read_cb
+	 * invocation; the chunked-read path calls it once per parsed chunk,
+	 * so we expect three, but allow the runtime to coalesce. */
+	tt_int_op(state.body_read_calls, >=, 1);
+	tt_int_op(state.gencb_calls, ==, 1);
+	tt_assert(state.saw_post);
+	tt_assert(state.saw_uri);
+	tt_int_op(evbuffer_get_length(state.captured), ==, expected_len);
+	{
+		size_t got = evbuffer_get_length(state.captured);
+		char *blob = malloc(got + 1);
+		tt_assert(blob);
+		evbuffer_copyout(state.captured, blob, got);
+		blob[got] = '\0';
+		tt_str_op(blob, ==, "alphabravo!charlie");
+		free(blob);
+	}
+
+ end:
+	if (state.captured)
+		evbuffer_free(state.captured);
+	if (bev)
+		bufferevent_free(bev);
+	if (http)
+		evhttp_free(http);
+}
+
 static void
 http_connection_fail_done(struct evhttp_request *req, void *arg)
 {
@@ -6194,6 +6416,8 @@ struct testcase_t http_testcases[] = {
 
 	HTTP(stream_in),
 	HTTP(stream_in_cancel),
+	HTTP(stream_in_body),
+	HTTP(stream_in_body_chunked),
 
 	HTTP(connection_fail),
 	{ "connection_retry", http_connection_retry_test, TT_ISOLATED|TT_OFF_BY_DEFAULT, &basic_setup, NULL },


### PR DESCRIPTION
Add two new public APIs that let server-side handlers receive a request
body incrementally instead of having the whole upload buffered in
`req->input_buffer` before the gencb fires:

```
evhttp_request_set_body_start_cb(req, cb, arg)
  Invoked once after request headers are parsed (URI, method,
  Content-Length and chunked flag all known) and before any body
  bytes are read.  Intended to be installed from
  evhttp_set_newreqcb() so it fires on every inbound request; the
  natural place to look at headers and decide to stream.

evhttp_request_set_body_read_cb(req, cb, arg)
  Invoked each time more body bytes are read, for both
  Content-Length and Transfer-Encoding: chunked bodies.  The
  callback drains req->input_buffer; whatever it leaves behind is
  drained automatically on return, matching the existing
  chunk_cb contract.
```

Internally these reuse the existing `chunk_cb` slot but route the
callback argument through a new `chunk_cb_arg` field instead of the
request completion `cb_arg`.  The pre-existing client-side
`evhttp_request_set_chunked_cb()` keeps its old no-arg signature and
its old semantics by seeding `chunk_cb_arg = cb_arg`, which is safe
under the standard `request_new -> set_chunked_cb -> make_request`
order.

Resubmit of stale PR #606 (closed 2024-10 by maintainer for lacking
unit tests); the sample upload demo from that PR is preserved with
the int-to-pointer-cast and fd-tracking bugs fixed (state struct is
heap-allocated, fd init to -1, drain loop for short writes).