### PR TITLE
cmake,autotools: add EVENT__DISABLE_RPC, EVENT__DISABLE_EVENT_TAGGING, EVENT__DISABLE_WS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,21 @@ option(EVENT__DISABLE_REGRESS
 option(EVENT__DISABLE_SAMPLES
     "Disable sample files" OFF)
 
+option(EVENT__DISABLE_RPC
+    "Define if libevent should be compiled without the RPC subsystem (evrpc_*)" OFF)
+
+option(EVENT__DISABLE_EVENT_TAGGING
+    "Define if libevent should be compiled without the event-tagging subsystem (evtag_*). Requires EVENT__DISABLE_RPC=ON because evrpc uses evtag internally." OFF)
+
+option(EVENT__DISABLE_WS
+    "Define if libevent should be compiled without the WebSocket subsystem (evws_*); also drops sha1.c which is only used by ws.c" OFF)
+
+if (EVENT__DISABLE_EVENT_TAGGING AND NOT EVENT__DISABLE_RPC)
+    message(FATAL_ERROR
+        "EVENT__DISABLE_EVENT_TAGGING=ON requires EVENT__DISABLE_RPC=ON "
+        "(evrpc.c calls evtag_init()).")
+endif()
+
 option(EVENT__DISABLE_CLOCK_GETTIME
     "Do not use clock_gettime even if it is available" OFF)
 
@@ -1000,12 +1015,21 @@ if (NOT EVENT__DISABLE_TESTS)
 endif()
 
 set(SRC_EXTRA
-    event_tagging.c
     http.c
-    evdns.c
-    ws.c
-    sha1.c
-    evrpc.c)
+    evdns.c)
+
+if (NOT EVENT__DISABLE_WS)
+    # sha1.c is only used by ws.c (Sec-WebSocket-Accept handshake)
+    list(APPEND SRC_EXTRA ws.c sha1.c)
+endif()
+
+if (NOT EVENT__DISABLE_EVENT_TAGGING)
+    list(APPEND SRC_EXTRA event_tagging.c)
+endif()
+
+if (NOT EVENT__DISABLE_RPC)
+    list(APPEND SRC_EXTRA evrpc.c)
+endif()
 
 if(${CMAKE_VERSION} VERSION_LESS "3.20")
   include(TestBigEndian)
@@ -1255,20 +1279,20 @@ if (NOT EVENT__DISABLE_TESTS)
 
             add_definitions(-DTINYTEST_LOCAL)
 
-            add_custom_command(
-                OUTPUT
-                    ${CMAKE_CURRENT_SOURCE_DIR}/test/regress.gen.c
-                    ${CMAKE_CURRENT_SOURCE_DIR}/test/regress.gen.h
-                DEPENDS
-                    event_rpcgen.py
-                    test/regress.rpc
-                COMMAND ${PYTHON_EXECUTABLE} ../event_rpcgen.py --quiet regress.rpc
-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
+            if (NOT EVENT__DISABLE_RPC)
+                add_custom_command(
+                    OUTPUT
+                        ${CMAKE_CURRENT_SOURCE_DIR}/test/regress.gen.c
+                        ${CMAKE_CURRENT_SOURCE_DIR}/test/regress.gen.h
+                    DEPENDS
+                        event_rpcgen.py
+                        test/regress.rpc
+                    COMMAND ${PYTHON_EXECUTABLE} ../event_rpcgen.py --quiet regress.rpc
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
+            endif()
 
             list(APPEND SRC_REGRESS
                  test/regress.c
-                 test/regress.gen.c
-                 test/regress.gen.h
                  test/regress_buffer.c
                  test/regress_bufferevent.c
                  test/regress_dns.c
@@ -1279,15 +1303,26 @@ if (NOT EVENT__DISABLE_TESTS)
                  test/regress_listener.c
                  test/regress_main.c
                  test/regress_minheap.c
-                 test/regress_rpc.c
                  test/regress_testutils.c
                  test/regress_testutils.h
                  test/regress_util.c
                  test/regress_watch.c
                  test/regress_timer_timeout.c
-                 test/regress_ws.c
-                 test/regress_ws.h
                  test/tinytest.c)
+
+            if (NOT EVENT__DISABLE_RPC)
+                # regress.gen.{c,h} are generated from regress.rpc
+                list(APPEND SRC_REGRESS
+                     test/regress.gen.c
+                     test/regress.gen.h
+                     test/regress_rpc.c)
+            endif()
+
+            if (NOT EVENT__DISABLE_WS)
+                list(APPEND SRC_REGRESS
+                     test/regress_ws.c
+                     test/regress_ws.h)
+            endif()
 
             if (WIN32)
                 list(APPEND SRC_REGRESS test/regress_iocp.c)

--- a/Makefile.am
+++ b/Makefile.am
@@ -264,11 +264,20 @@ CORE_SRC =					\
 
 EXTRAS_SRC =					\
 	evdns.c					\
-	event_tagging.c				\
-	evrpc.c					\
-	sha1.c					\
-	ws.c					\
 	http.c
+
+if !DISABLE_WS
+# sha1.c is only used by ws.c (Sec-WebSocket-Accept handshake)
+EXTRAS_SRC += ws.c sha1.c
+endif
+
+if !DISABLE_EVENT_TAGGING
+EXTRAS_SRC += event_tagging.c
+endif
+
+if !DISABLE_RPC
+EXTRAS_SRC += evrpc.c
+endif
 
 if BUILD_WITH_NO_UNDEFINED
 NO_UNDEFINED = -no-undefined

--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,15 @@ AC_ARG_ENABLE([mbedtls],
 AC_ARG_ENABLE([debug-mode],
      AS_HELP_STRING([--disable-debug-mode, disable support for running in debug mode]),
     [], [enable_debug_mode=yes])
+AC_ARG_ENABLE([rpc],
+     AS_HELP_STRING([--disable-rpc, disable support for the RPC subsystem (evrpc_*)]),
+    [], [enable_rpc=yes])
+AC_ARG_ENABLE([event-tagging],
+     AS_HELP_STRING([--disable-event-tagging, disable support for the event-tagging subsystem (evtag_*); requires --disable-rpc]),
+    [], [enable_event_tagging=yes])
+AC_ARG_ENABLE([ws],
+     AS_HELP_STRING([--disable-ws, disable support for the WebSocket subsystem (evws_*); also drops sha1.c which is only used by ws.c]),
+    [], [enable_ws=yes])
 AC_ARG_ENABLE([libevent-install],
      AS_HELP_STRING([--disable-libevent-install, disable installation of libevent]),
 	[], [enable_libevent_install=yes])
@@ -689,6 +698,32 @@ if test "$enable_debug_mode" = "no"; then
   AC_DEFINE(DISABLE_DEBUG_MODE, 1,
         [Define if libevent should build without support for a debug mode])
 fi
+
+dnl check whether to omit the RPC subsystem (evrpc_*)
+if test "$enable_rpc" = "no"; then
+  AC_DEFINE(DISABLE_RPC, 1,
+        [Define if libevent should be compiled without the RPC subsystem])
+fi
+AM_CONDITIONAL(DISABLE_RPC, [test "$enable_rpc" = "no"])
+
+dnl check whether to omit event-tagging (evtag_*). RPC uses evtag internally,
+dnl so disabling tagging requires disabling RPC too.
+if test "$enable_event_tagging" = "no" && test "$enable_rpc" != "no"; then
+  AC_MSG_ERROR([--disable-event-tagging requires --disable-rpc (evrpc.c calls evtag_init()).])
+fi
+if test "$enable_event_tagging" = "no"; then
+  AC_DEFINE(DISABLE_EVENT_TAGGING, 1,
+        [Define if libevent should be compiled without the event-tagging subsystem])
+fi
+AM_CONDITIONAL(DISABLE_EVENT_TAGGING, [test "$enable_event_tagging" = "no"])
+
+dnl check whether to omit the WebSocket subsystem (evws_*). sha1.c is only
+dnl used by ws.c, so it follows automatically.
+if test "$enable_ws" = "no"; then
+  AC_DEFINE(DISABLE_WS, 1,
+        [Define if libevent should be compiled without the WebSocket subsystem])
+fi
+AM_CONDITIONAL(DISABLE_WS, [test "$enable_ws" = "no"])
 
 dnl check if we should enable verbose debugging
 if test "$enable_verbose_debug" = "yes"; then

--- a/event-config.h.cmake
+++ b/event-config.h.cmake
@@ -44,6 +44,15 @@
 /* Define if libevent should not be compiled with thread support */
 #cmakedefine EVENT__DISABLE_THREAD_SUPPORT 1
 
+/* Define if libevent should be compiled without the RPC subsystem */
+#cmakedefine EVENT__DISABLE_RPC 1
+
+/* Define if libevent should be compiled without the event-tagging subsystem */
+#cmakedefine EVENT__DISABLE_EVENT_TAGGING 1
+
+/* Define if libevent should be compiled without the WebSocket subsystem */
+#cmakedefine EVENT__DISABLE_WS 1
+
 /* Define to 1 if you have the `accept4' function. */
 #cmakedefine EVENT__HAVE_ACCEPT4 1
 

--- a/http.c
+++ b/http.c
@@ -4082,7 +4082,9 @@ evhttp_free(struct evhttp* http)
 {
 	struct evhttp_cb *http_cb;
 	struct evhttp_connection *evcon;
+#ifndef EVENT__DISABLE_WS
 	struct evws_connection *evws;
+#endif
 	struct evhttp_bound_socket *bound;
 	struct evhttp* vhost;
 	struct evhttp_server_alias *alias;
@@ -4101,9 +4103,11 @@ evhttp_free(struct evhttp* http)
 		evhttp_connection_free(evcon);
 	}
 
+#ifndef EVENT__DISABLE_WS
 	while ((evws = TAILQ_FIRST(&http->ws_sessions)) != NULL) {
 		evws_connection_free(evws);
 	}
+#endif
 
 	while ((http_cb = TAILQ_FIRST(&http->callbacks)) != NULL) {
 		TAILQ_REMOVE(&http->callbacks, http_cb, next);

--- a/test/include.am
+++ b/test/include.am
@@ -92,7 +92,9 @@ test_runner_timerfd_changelist: $(top_srcdir)/test/test.sh
 DISTCLEANFILES += test/regress.gen.c test/regress.gen.h
 
 if BUILD_REGRESS
+if !DISABLE_RPC
 BUILT_SOURCES += test/regress.gen.c test/regress.gen.h
+endif
 endif
 
 test_test_init_SOURCES = test/test-init.c
@@ -125,8 +127,6 @@ endif
 
 test_regress_SOURCES = 				\
 	test/regress.c				\
-	test/regress.gen.c				\
-	test/regress.gen.h				\
 	test/regress_buffer.c			\
 	test/regress_bufferevent.c			\
 	test/regress_dns.c				\
@@ -137,17 +137,27 @@ test_regress_SOURCES = 				\
 	test/regress_listener.c			\
 	test/regress_main.c				\
 	test/regress_minheap.c			\
-	test/regress_rpc.c				\
 	test/regress_testutils.c			\
 	test/regress_testutils.h			\
 	test/regress_util.c				\
 	test/regress_watch.c				\
-	test/regress_ws.c				\
-	test/regress_ws.h				\
 	test/regress_timer_timeout.c		\
 	test/tinytest.c				\
 	$(regress_thread_SOURCES)		\
 	$(regress_zlib_SOURCES)
+
+if !DISABLE_RPC
+test_regress_SOURCES +=				\
+	test/regress.gen.c			\
+	test/regress.gen.h			\
+	test/regress_rpc.c
+endif
+
+if !DISABLE_WS
+test_regress_SOURCES +=				\
+	test/regress_ws.c			\
+	test/regress_ws.h
+endif
 
 if PTHREADS
 regress_thread_SOURCES = test/regress_thread.c

--- a/test/regress.c
+++ b/test/regress.c
@@ -72,7 +72,9 @@
 #include "regress_thread.h"
 
 #ifndef _WIN32
+#ifndef EVENT__DISABLE_RPC
 #include "regress.gen.h"
+#endif
 #endif
 
 evutil_socket_t pair[2];
@@ -2548,10 +2550,12 @@ test_multiple_events_for_same_fd(void)
    cleanup_test();
 }
 
+#ifndef EVENT__DISABLE_EVENT_TAGGING
 int evtag_decode_int(ev_uint32_t *pnumber, struct evbuffer *evbuf);
 int evtag_decode_int64(ev_uint64_t *pnumber, struct evbuffer *evbuf);
 int evtag_encode_tag(struct evbuffer *evbuf, ev_uint32_t number);
 int evtag_decode_tag(ev_uint32_t *pnumber, struct evbuffer *evbuf);
+#endif
 
 static void
 read_once_cb(evutil_socket_t fd, short event, void *arg)
@@ -2602,6 +2606,7 @@ test_want_only_once(void)
 	cleanup_test();
 }
 
+#ifndef EVENT__DISABLE_EVENT_TAGGING
 #define TEST_MAX_INT	6
 
 static void
@@ -2739,6 +2744,7 @@ evtag_test_peek(void *ptr)
 end:
 	evbuffer_free(tmp);
 }
+#endif /* EVENT__DISABLE_EVENT_TAGGING */
 
 
 static void
@@ -3776,6 +3782,7 @@ struct testcase_t main_testcases[] = {
 	END_OF_TESTCASES
 };
 
+#ifndef EVENT__DISABLE_EVENT_TAGGING
 struct testcase_t evtag_testcases[] = {
 	{ "int", evtag_int_test, TT_FORK, NULL, NULL },
 	{ "fuzz", evtag_fuzz, TT_FORK, NULL, NULL },
@@ -3784,6 +3791,7 @@ struct testcase_t evtag_testcases[] = {
 
 	END_OF_TESTCASES
 };
+#endif /* EVENT__DISABLE_EVENT_TAGGING */
 
 /* Apparently there is a bug in OSX that leads to subsequent ALRM signal
  * delivered even though it_interval is set to 0, so let's retry the tests */

--- a/test/regress_http.c
+++ b/test/regress_http.c
@@ -65,7 +65,9 @@
 #include "http-internal.h"
 #include "regress.h"
 #include "regress_http.h"
+#ifndef EVENT__DISABLE_WS
 #include "regress_ws.h"
+#endif
 #include "regress_testutils.h"
 
 #define ARRAY_SIZE(x) (sizeof(x)/sizeof((x)[0]))
@@ -231,7 +233,9 @@ http_setup_gencb(ev_uint16_t *pport, struct event_base *base, int mask,
 	evhttp_set_cb(myhttp, "/largedelay", http_large_delay_cb, base);
 	evhttp_set_cb(myhttp, "/badrequest", http_badreq_cb, base);
 	evhttp_set_cb(myhttp, "/oncomplete", http_on_complete_cb, base);
+#ifndef EVENT__DISABLE_WS
 	evhttp_set_cb(myhttp, "/ws", http_on_ws_cb, base);
+#endif
 	evhttp_set_cb(myhttp, "/", http_dispatcher_cb, base);
 	return (myhttp);
 }
@@ -6181,7 +6185,9 @@ struct testcase_t http_testcases[] = {
 	HTTP(terminate_chunked),
 	HTTP(terminate_chunked_oneshot),
 	HTTP(on_complete),
+#ifndef EVENT__DISABLE_WS
 	HTTP(ws),
+#endif
 
 	HTTP(highport),
 	HTTP(dispatcher),

--- a/test/regress_main.c
+++ b/test/regress_main.c
@@ -452,8 +452,12 @@ struct testgroup_t testgroups[] = {
 	{ "bufferevent/", bufferevent_testcases },
 	{ "http/", http_testcases },
 	{ "dns/", dns_testcases },
+#ifndef EVENT__DISABLE_EVENT_TAGGING
 	{ "evtag/", evtag_testcases },
+#endif
+#ifndef EVENT__DISABLE_RPC
 	{ "rpc/", rpc_testcases },
+#endif
 	{ "thread/", thread_testcases },
 	{ "listener/", listener_testcases },
 	{ "watch/", watch_testcases },


### PR DESCRIPTION
## Summary

Three opt-in flags that omit unused subsystems from `libevent_extra`:

- `EVENT__DISABLE_RPC` / `--disable-rpc` — drops `evrpc.c`
- `EVENT__DISABLE_EVENT_TAGGING` / `--disable-event-tagging` — drops `event_tagging.c`
- `EVENT__DISABLE_WS` / `--disable-ws` — drops `ws.c` and `sha1.c` (sha1 is only used by ws for the `Sec-WebSocket-Accept` handshake)

All default `OFF`; existing builds are byte-identical. The regress harness is updated to match, so `EVENT__DISABLE_TESTS=ON` is **not** required when any toggle is on — `./bin/regress` builds and passes the suite in every combination.

## Motivation

I maintain libevent packaging for [OpenIPC firmware](https://github.com/OpenIPC/firmware), a Buildroot OS for IP cameras. Rootfs is a few-MB squashfs on NOR flash, so every KB counts. Four firmware packages link libevent (`majestic`, `mavfwd`, `msposd`, `libwebsockets-openipc`); a cross-binary symbol scan finds zero `evrpc_*` / `evtag_*` references. The existing size-oriented toggles (`DISABLE_DEBUG_MODE`, `MM_REPLACEMENT`, `THREAD_SUPPORT`) don't cover any of these three least-coupled `libevent_extra` subsystems.

## Measured impact

**ARMv7-openipc-linux-musleabi** (hi3516ev300, Buildroot 2024.02.10, `-O2`, stripped), sysupgraded onto a physical camera, with `DISABLE_RPC=ON + DISABLE_EVENT_TAGGING=ON`. Same `majestic` binary on both sides; HTTP, RTSP, evdns, evconnlistener, evws all work; `curl http://<cam>/image.jpg` returns a 1920×1080 JPEG before and after.

| Library              | Before  | After   | Δ        |
|----------------------|---------|---------|----------|
| `libevent_core`      | 104,676 | 104,676 | 0        |
| **`libevent_extra`** | **88,264** | **80,000** | **−8,264 (−9.4%)** |
| `libevent_mbedtls`   |  13,788 |  13,788 | 0        |
| `libevent_pthreads`  |   5,328 |   5,328 | 0        |

`strings libevent_extra-2.2.so.1.0.0 | grep -cE '^(evrpc|evtag)_'` → **51 → 0**.

**x86_64, `-O3`, stripped**, `libevent_extra` across all four flag combinations:

| Config                                  | `libevent_extra` | savings  |
|-----------------------------------------|------------------|----------|
| baseline                                | 200,744          | 0        |
| `DISABLE_WS` only                       | 184,264          | −8.2%    |
| `DISABLE_RPC + DISABLE_EVENT_TAGGING`   | 184,232          | −8.2%    |
| all three                               | 167,720          | **−16.4%** |

## Design

- Source-list pruning in both build systems (matching the `--disable-openssl` / `--disable-mbedtls` pattern). The disabled `.c` files don't compile at all.
- Single in-source guard in `http.c`: `evhttp_free()` drains `http->ws_sessions` via `evws_connection_free()`; guarded with `#ifndef EVENT__DISABLE_WS`. The `struct evwsq ws_sessions` field stays in `struct evhttp` regardless of the flag so `sizeof(struct evhttp)` doesn't change.
- Public headers `event2/rpc*.h`, `event2/tag*.h`, `event2/ws.h` continue to install — third-party consumers linking against a libevent built with the defaults are unaffected.
- Regress harness:
  - `test/regress.c`: `#include "regress.gen.h"` under `!DISABLE_RPC`; evtag extern decls, the four evtag test functions, and `evtag_testcases[]` under `!DISABLE_EVENT_TAGGING`.
  - `test/regress_main.c`: `evtag/` and `rpc/` testgroup entries under their respective flags.
  - `test/regress_http.c`: `regress_ws.h` include, `evhttp_set_cb("/ws", …)`, and `HTTP(ws)` entry under `!DISABLE_WS`.
  - `SRC_REGRESS` / `test_regress_SOURCES` lose `regress.gen.{c,h}`+`regress_rpc.c` under `DISABLE_RPC` and `regress_ws.{c,h}` under `DISABLE_WS`. The rpcgen `add_custom_command` is also skipped under `DISABLE_RPC`.
- Constraint: `EVENT__DISABLE_EVENT_TAGGING=ON` requires `EVENT__DISABLE_RPC=ON` — `evrpc.c:79` calls `evtag_init()`. Enforced at configure time with CMake `FATAL_ERROR` / autotools `AC_MSG_ERROR`.
- Autotools mirror knobs: `--disable-rpc`, `--disable-event-tagging`, `--disable-ws`, with matching `AC_DEFINE` and `AM_CONDITIONAL`. `event-config.h.cmake` gains three new `#cmakedefine`s.

## Validation

- Default build: identical `libevent_extra` to master.
- All four combinations build the regress executable on x86_64.
- `./bin/regress --terse --timeout 30 --retries 1 .. ':http/connection_retry' ':http/read_on_write_error'` exits 0 in every combination.
- Cross-build for ARMv7 musl, sysupgrade to physical hi3516ev300 hardware: end-to-end HTTP / RTSP / evdns / evws verified.
- Constraint errors fire as expected: `-DEVENT__DISABLE_EVENT_TAGGING=ON -DEVENT__DISABLE_RPC=OFF` → fatal error.