### PR TITLE
ws: free the connection on BEV_EVENT_ERROR, not only BEV_EVENT_EOF

### DIFF
--- a/ws.c
+++ b/ws.c
@@ -367,6 +367,12 @@ ws_evhttp_error_cb(struct bufferevent *bufev, short what, void *arg)
 	/* when client just disappears after connection (wscat closed by Cmd+Q) */
 	if (what & BEV_EVENT_EOF) {
 		close_after_write_cb(bufev, arg);
+	} else if (what & BEV_EVENT_ERROR) {
+		/* On an abrupt reset or a failed write there is nothing left to
+		 * flush, so free the session now. Otherwise evws_connection_free()
+		 * -- and the user close callback it invokes -- is never reached and
+		 * the connection leaks. */
+		evws_connection_free(arg);
 	}
 }
 


### PR DESCRIPTION
### Problem

In the server-side WebSocket support, `ws_evhttp_error_cb()` only tears the connection down on `BEV_EVENT_EOF`:

```c
static void
ws_evhttp_error_cb(struct bufferevent *bufev, short what, void *arg)
{
	/* when client just disappears after connection (wscat closed by Cmd+Q) */
	if (what & BEV_EVENT_EOF) {
		close_after_write_cb(bufev, arg);
	}
}
```

`BEV_EVENT_ERROR` falls through and does nothing. The user close callback is only ever reached via `evws_connection_free()`, so when a peer disconnects **abruptly** (TCP RST, or a server write that fails with `ECONNRESET`/`EPIPE`):

- the callback registered with `evws_connection_set_closecb()` is never invoked, and
- the `evws_connection` and its bufferevent leak.

Applications that free per-connection resources in the close callback (a spawned child process, an fd/event, etc.) leak them on every abrupt disconnect.

### Reproduction

A server that accepts an upgrade via `evws_new_session()`, sets a close callback, and writes to the client right after the upgrade. A client that resets immediately after the first server write — before sending a close frame — e.g.:

```sh
curl -s -i --http1.1 \
  -H "Connection: Upgrade" -H "Upgrade: websocket" \
  -H "Sec-WebSocket-Version: 13" -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
  http://127.0.0.1:PORT/ws | head -1
```

`curl` is `SIGPIPE`'d as soon as the server writes, so the connection is reset right after the upgrade. A fraction of such runs (~40% in testing on Linux/glibc, ARM) leave the close callback uninvoked and the connection leaked. A graceful WebSocket close (close frame / FIN) always reaps correctly. Real-world trigger: a browser tab closed without a clean close handshake.

### Fix

Handle `BEV_EVENT_ERROR` by freeing the session immediately, mirroring `close_event_cb()`. The `BEV_EVENT_EOF` path is unchanged, so pending output is still flushed on a graceful close.

```c
} else if (what & BEV_EVENT_ERROR) {
	evws_connection_free(arg);
}
```

Verified against a real WebSocket server under repeated abrupt resets: with the fix, every connection is reaped and the close callback always fires.