### PR TITLE
Support customizing TCP_KEEPINTVL and TCP_KEEPCNT for evutil

### DIFF
--- a/evutil.c
+++ b/evutil.c
@@ -3181,6 +3181,14 @@ evutil_free_globals_(void)
 	evutil_free_sock_err_globals();
 }
 
+int
+evutil_set_tcp_keepalive(evutil_socket_t fd, int on, int timeout)
+{
+	if (timeout < 1)
+		return -1;
+	return evutil_set_tcp_keepalive_ex(fd, on, timeout, timeout/3, 3);
+}
+
 #if (defined(EVENT__SOLARIS_11_4) && !EVENT__SOLARIS_11_4) || \
     (defined(__DragonFly__) && __DragonFly_version < 500702) || \
     (defined(_WIN32) && !defined(TCP_KEEPIDLE))
@@ -3190,36 +3198,24 @@ evutil_free_globals_(void)
 #else
 #define EVENT_KEEPALIVE_FACTOR(x)
 #endif
+
 int
-evutil_set_tcp_keepalive(evutil_socket_t fd, int on, int timeout)
+evutil_set_tcp_keepalive_ex(evutil_socket_t fd, int on, unsigned int idle, unsigned int intvl, unsigned int cnt)
 {
-	int idle;
-	int intvl;
-	int cnt;
-
-	/* Prevent compiler from complaining unused variables warnings. */
-	(void) idle;
-	(void) intvl;
-	(void) cnt;
-
-	if (timeout <= 0)
-		return 0;
-
 #ifdef _WIN32
 	if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, (const char*)&on, sizeof(on)))
 #else
 	if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &on, sizeof(on)))
 #endif
 		return -1;
+
 	if (!on)
 		return 0;
 
-#ifdef _WIN32
-	idle = timeout;
-	intvl = idle/3;
-	if (intvl == 0)
-		intvl = 1;
+	if (idle < 1 || intvl < 1 || cnt < 1)
+		return -1;
 
+#ifdef _WIN32
 	EVENT_KEEPALIVE_FACTOR(idle);
 	EVENT_KEEPALIVE_FACTOR(intvl);
 
@@ -3233,7 +3229,6 @@ evutil_set_tcp_keepalive(evutil_socket_t fd, int on, int timeout)
 	if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, (const char*)&intvl, sizeof(intvl)))
 		return -1;
 
-	cnt = 3;
 	if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, (const char*)&cnt, sizeof(cnt)))
 		return -1;
 
@@ -3279,13 +3274,16 @@ evutil_set_tcp_keepalive(evutil_socket_t fd, int on, int timeout)
 	 * The TCP connection will be aborted after certain amount of probes, which is set by TCP_KEEPCNT, without receiving response.
 	 */
 
-	idle = timeout;
-	/* Kernel expects at least 10 seconds. */
+	/* Kernel expects at least 10 seconds for TCP_KEEPIDLE and TCP_KEEPINTVL. */
 	if (idle < 10)
 		idle = 10;
-	/* Kernel expects at most 10 days. */
+	if (intvl < 10)
+		intvl = 10;
+	/* Kernel expects at most 10 days for TCP_KEEPIDLE and TCP_KEEPINTVL. */
 	if (idle > 10*24*60*60)
 		idle = 10*24*60*60;
+	if (intvl > 10*24*60*60)
+		intvl = 10*24*60*60;
 
 	EVENT_KEEPALIVE_FACTOR(idle);
 
@@ -3296,15 +3294,10 @@ evutil_set_tcp_keepalive(evutil_socket_t fd, int on, int timeout)
 	if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle)))
 		return -1;
 
-	intvl = idle/3;
-	/* Kernel expects at least 10 seconds. */
-	if (intvl < 10)
-		intvl = 10;
 	EVENT_KEEPALIVE_FACTOR(intvl);
 	if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl)))
 		return -1;
 
-	cnt = 3;
 	if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &cnt, sizeof(cnt)))
 		return -1;
 #else
@@ -3317,14 +3310,14 @@ evutil_set_tcp_keepalive(evutil_socket_t fd, int on, int timeout)
 	/* Note that the consequent probes will not be sent at equal intervals on Solaris,
 	 * but will be sent using the exponential backoff algorithm.
 	 */
-	int time_to_abort = idle;
+	unsigned int time_to_abort = intvl * cnt;
+	EVENT_KEEPALIVE_FACTOR(time_to_abort);
 	if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE_ABORT_THRESHOLD, &time_to_abort, sizeof(time_to_abort)))
 		return -1;
 #endif
 
 #else /* !__sun */
 
-	idle = timeout;
 	EVENT_KEEPALIVE_FACTOR(idle);
 #ifdef TCP_KEEPIDLE
 	if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle)))
@@ -3336,23 +3329,12 @@ evutil_set_tcp_keepalive(evutil_socket_t fd, int on, int timeout)
 #endif
 
 #ifdef TCP_KEEPINTVL
-	/* Set the interval between individual keep-alive probes as timeout / 3
-	 * and the maximum number of keepalive probes as 3 to make it double timeout
-	 * before aborting a dead connection.
-	 */
-	intvl = timeout/3;
-	if (intvl == 0)
-		intvl = 1;
 	EVENT_KEEPALIVE_FACTOR(intvl);
 	if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl)))
 		return -1;
 #endif
 
 #ifdef TCP_KEEPCNT
-	/* Set the maximum number of keepalive probes as 3 to collaborate with
-	 * TCP_KEEPINTVL, see the previous comment.
-	 */
-	cnt = 3;
 	if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &cnt, sizeof(cnt)))
 		return -1;
 #endif

--- a/include/event2/util.h
+++ b/include/event2/util.h
@@ -511,14 +511,54 @@ int evutil_make_tcp_listen_socket_deferred(evutil_socket_t sock);
 /** Do platform-specific operations to set/unset TCP keep-alive options
  * TCP_KEEPIDLE, TCP_KEEPINTVL and TCP_KEEPCNT on a socket.
  *
+ * Note that this function accepts only the timeout parameter for setting TCP_KEEPIDLE,
+ * and calculates the values for TCP_KEEPINTVL and TCP_KEEPCNT based on the timeout value.
+ * The default values for TCP_KEEPINTVL and TCP_KEEPCNT are set to one third of the timeout value
+ * and 3 respectively, which are commonly used settings for TCP keep-alive.
+ *
  *  @param sock The socket to be set TCP keep-alive
  *  @param on Nonzero value to enable TCP keep-alive, 0 to disable
  *  @param timeout The timeout in seconds with no activity until
- * 	   the first keepalive probe is sent
+ * 	   the first keepalive probe is sent, it must be greater or equal to 1
  *  @return 0 on success, -1 on failure
 */
 EVENT2_EXPORT_SYMBOL
 int evutil_set_tcp_keepalive(evutil_socket_t sock, int on, int timeout);
+
+/** Do platform-specific operations to set/unset TCP keep-alive options,
+  * enable / disable TCP keep-alive with all socket options: `TCP_KEEPIDLE`,
+	* `TCP_KEEPINTVL` and `TCP_KEEPCNT`.
+  * `idle` is the value for `TCP_KEEPIDLE`, `intvl` is the value for `TCP_KEEPINTVL`,
+  * `cnt` is the value for `TCP_KEEPCNT`, all will be ignored when `on` is zero.
+  *
+  * With TCP keep-alive enabled, `idle` is the time (in seconds) the connection needs to remain idle before
+  * TCP starts sending keep-alive probes. `intvl` is the time (in seconds) between individual keep-alive probes.
+  * TCP will drop the connection after sending `cnt` probes without getting any replies from the peer, then the
+  * handle is destroyed with a ``UV_ETIMEDOUT`` error passed to the corresponding callback.
+  *
+  * If one of `idle`, `intvl`, or `cnt` is less than 1, -1 is returned.
+  *
+  * Ensure that the socket options are supported by the underlying operating system.
+  * Currently supported platforms:
+  *   - AIX
+  *   - DragonFlyBSD
+  *   - FreeBSD
+  *   - illumos
+  *   - Linux
+  *   - macOS
+  *   - NetBSD
+  *   - Solaris
+  *   - Windows
+  *
+	* @param sock The socket to be set TCP_CORK/TCP_NOPUSH
+	* @param on Nonzero value to enable TCP_CORK/TCP_NOPUSH, 0 to disable
+	* @param idle The timeout in seconds with no activity until the first keepalive probe is sent
+	* @param intvl The time in seconds between individual keep-alive probes
+	* @param cnt The number of keep-alive probes TCP should send before dropping the connection
+	* @return 0 on success, -1 on failure
+*/
+EVENT2_EXPORT_SYMBOL
+int evutil_set_tcp_keepalive_ex(evutil_socket_t sock, int on, unsigned int idle, unsigned int intvl, unsigned int cnt);
 
 #ifdef _WIN32
 /** Return the most recent socket error.  Not idempotent on all platforms. */
@@ -707,7 +747,7 @@ int evutil_sockaddr_cmp(const struct sockaddr *sa1, const struct sockaddr *sa2,
     int include_port);
 
 /** As strcasecmp, but always compares the characters in locale-independent
-    ASCII.  That's useful if you're handling data in ASCII-based protocols. 
+    ASCII.  That's useful if you're handling data in ASCII-based protocols.
     str1 and str2 must not be NULL.
  */
 EVENT2_EXPORT_SYMBOL


### PR DESCRIPTION
Implement `evutil_set_tcp_keepalive_ex` function that extends `evutil_set_tcp_keepalive` to support `TCP_KEEPINTVL` and `TCP_KEEPCN` socket options in addition to `TCP_KEEPIDLE`.