### PR TITLE
Fix gcc and clang warnings in libevent 2.1

### DIFF
--- a/event.c
+++ b/event.c
@@ -1353,6 +1353,15 @@ event_haveevents(struct event_base *base)
 static inline void
 event_signal_closure(struct event_base *base, struct event *ev)
 {
+#if defined(__clang__)
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+/* NOTE: it is better to avoid such code all together, by using separate
+ * variable to break the loop in the event structure, but now this code is safe
+ * */
+#pragma GCC diagnostic ignored "-Wdangling-pointer"
+#endif
+
 	short ncalls;
 	int should_break;
 
@@ -1378,6 +1387,11 @@ event_signal_closure(struct event_base *base, struct event *ev)
 			return;
 		}
 	}
+
+#if defined(__clang__)
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 }
 
 /* Common timeouts are special timeouts that are handled as queues rather than

--- a/evthread.c
+++ b/evthread.c
@@ -74,12 +74,12 @@ evthread_set_id_callback(unsigned long (*id_fn)(void))
 	evthread_id_fn_ = id_fn;
 }
 
-struct evthread_lock_callbacks *evthread_get_lock_callbacks()
+struct evthread_lock_callbacks *evthread_get_lock_callbacks(void)
 {
 	return evthread_lock_debugging_enabled_
 	    ? &original_lock_fns_ : &evthread_lock_fns_;
 }
-struct evthread_condition_callbacks *evthread_get_condition_callbacks()
+struct evthread_condition_callbacks *evthread_get_condition_callbacks(void)
 {
 	return evthread_lock_debugging_enabled_
 	    ? &original_cond_fns_ : &evthread_cond_fns_;

--- a/evutil.c
+++ b/evutil.c
@@ -2531,7 +2531,7 @@ evutil_memclear_(void *mem, size_t len)
 int
 evutil_sockaddr_is_loopback_(const struct sockaddr *addr)
 {
-	static const char LOOPBACK_S6[16] =
+	EVUTIL_NONSTRING static const char LOOPBACK_S6[16] =
 	    "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\1";
 	if (addr->sa_family == AF_INET) {
 		struct sockaddr_in *sin = (struct sockaddr_in *)addr;

--- a/evutil.c
+++ b/evutil.c
@@ -210,7 +210,7 @@ evutil_socketpair(int family, int type, int protocol, evutil_socket_t fd[2])
 
 int
 evutil_ersatz_socketpair_(int family, int type, int protocol,
-    evutil_socket_t fd[2])
+    evutil_socket_t fd[])
 {
 	/* This code is originally from Tor.  Used with permission. */
 

--- a/http.c
+++ b/http.c
@@ -3131,10 +3131,6 @@ evhttp_uriencode(const char *uri, ev_ssize_t len, int space_as_plus)
 			goto out;
 		}
 
-		if (uri + slen < uri) {
-			goto out;
-		}
-
 		end = uri + slen;
 	}
 

--- a/sample/le-proxy.c
+++ b/sample/le-proxy.c
@@ -10,6 +10,9 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
+/* This example is very old, and it uses some deprecated OpenSSL APIs */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #include <stdio.h>
 #include <assert.h>
 #include <stdlib.h>

--- a/strlcpy.c
+++ b/strlcpy.c
@@ -45,10 +45,7 @@ static char *rcsid = "$OpenBSD: strlcpy.c,v 1.5 2001/05/13 15:40:16 deraadt Exp 
  * Returns strlen(src); if retval >= siz, truncation occurred.
  */
 size_t
-event_strlcpy_(dst, src, siz)
-	char *dst;
-	const char *src;
-	size_t siz;
+event_strlcpy_(char *dst, const char *src, size_t siz)
 {
 	register char *d = dst;
 	register const char *s = src;

--- a/test/regress_buffer.c
+++ b/test/regress_buffer.c
@@ -443,7 +443,7 @@ test_evbuffer_pullup_with_empty(void *ptr)
 	buf = evbuffer_new();
 	evbuffer_validate(buf);
 	tt_int_op(evbuffer_get_length(buf), ==, 0);
-	tt_int_op(evbuffer_pullup(buf, -1), ==, NULL);
+	tt_ptr_op(evbuffer_pullup(buf, -1), ==, NULL);
 
 	evbuffer_free(buf);
 	buf = evbuffer_new();

--- a/test/regress_buffer.c
+++ b/test/regress_buffer.c
@@ -164,6 +164,8 @@ evbuffer_get_waste(struct evbuffer *buf, size_t *allocatedp, size_t *wastedp, si
 	*allocatedp = a;
 	*wastedp = w;
 	*usedp = u;
+
+	(void) n;
 }
 
 #define evbuffer_validate(buf)			\

--- a/test/regress_http.c
+++ b/test/regress_http.c
@@ -1465,7 +1465,7 @@ http_cancel_test(void *arg)
 	struct event_base *base_to_fill = data->base;
 
 	enum http_cancel_test_type type =
-		(enum http_cancel_test_type)data->setup_data;
+	    (enum http_cancel_test_type)(size_t)data->setup_data;
 	struct evhttp *http = http_setup(&port, data->base, 0);
 
 	if (type & BY_HOST) {
@@ -4220,8 +4220,8 @@ struct terminate_state {
 	struct evhttp_request *req;
 	struct bufferevent *bev;
 	evutil_socket_t fd;
-	int gotclosecb: 1;
-	int oneshot: 1;
+	unsigned int gotclosecb: 1;
+	unsigned int oneshot: 1;
 };
 
 static void

--- a/test/regress_ssl.c
+++ b/test/regress_ssl.c
@@ -323,7 +323,7 @@ respond_to_number(struct bufferevent *bev, void *ctx)
 	int n;
 
 	enum regress_openssl_type type;
-	type = (enum regress_openssl_type)ctx;
+	type = (enum regress_openssl_type)(size_t)ctx;
 
 	line = evbuffer_readln(b, NULL, EVBUFFER_EOL_LF);
 	if (! line)
@@ -366,7 +366,7 @@ eventcb(struct bufferevent *bev, short what, void *ctx)
 	X509 *peer_cert = NULL;
 	enum regress_openssl_type type;
 
-	type = (enum regress_openssl_type)ctx;
+	type = (enum regress_openssl_type)(size_t)ctx;
 
 	TT_BLATHER(("Got event %d", (int)what));
 	if (what & BEV_EVENT_CONNECTED) {
@@ -466,7 +466,7 @@ regress_bufferevent_openssl(void *arg)
 	evutil_socket_t *fd_pair = NULL;
 
 	enum regress_openssl_type type;
-	type = (enum regress_openssl_type)data->setup_data;
+	type = (enum regress_openssl_type)(size_t)data->setup_data;
 
 	if (type & REGRESS_OPENSSL_RENEGOTIATE) {
 		if (OPENSSL_VERSION_NUMBER >= 0x10001000 &&
@@ -583,7 +583,7 @@ acceptcb(struct evconnlistener *listener, evutil_socket_t fd,
 	enum regress_openssl_type type;
 	SSL *ssl = SSL_new(get_ssl_ctx());
 
-	type = (enum regress_openssl_type)data->setup_data;
+	type = (enum regress_openssl_type)(size_t)data->setup_data;
 
 	SSL_use_certificate(ssl, the_cert);
 	SSL_use_PrivateKey(ssl, the_key);
@@ -739,7 +739,7 @@ regress_bufferevent_openssl_connect(void *arg)
 	struct rwcount rw = { -1, 0, 0 };
 	enum regress_openssl_type type;
 
-	type = (enum regress_openssl_type)data->setup_data;
+	type = (enum regress_openssl_type)(size_t)data->setup_data;
 
 	memset(&sin, 0, sizeof(sin));
 	sin.sin_family = AF_INET;
@@ -889,7 +889,7 @@ regress_bufferevent_openssl_wm(void *arg)
 	struct sockaddr_in sin;
 	struct sockaddr_storage ss;
 	enum regress_openssl_type type =
-		(enum regress_openssl_type)data->setup_data;
+		(enum regress_openssl_type)(size_t)data->setup_data;
 	int bev_flags = BEV_OPT_CLOSE_ON_FREE;
 	ev_socklen_t slen;
 	SSL *ssl;

--- a/test/regress_util.c
+++ b/test/regress_util.c
@@ -979,6 +979,8 @@ test_evutil_rand(void *arg)
 		tt_int_op(r, <, 9999);
 	}
 
+	(void) n;
+
 	/* for (i=0;i<256;++i) { printf("%3d %2d\n", i, counts[i]); } */
 end:
 	;

--- a/util-internal.h
+++ b/util-internal.h
@@ -355,6 +355,12 @@ ev_int32_t evutil_weakrand_range_(struct evutil_weakrand_state *seed, ev_int32_t
 #define EVUTIL_FALLTHROUGH /* fallthrough */
 #endif
 
+#if EVUTIL_HAS_ATTRIBUTE(nonstring)
+#define EVUTIL_NONSTRING __attribute__((nonstring))
+#else
+#define EVUTIL_NONSTRING
+#endif
+
 /* Replacement for assert() that calls event_errx on failure. */
 #ifdef NDEBUG
 #define EVUTIL_ASSERT(cond) EVUTIL_NIL_CONDITION_(cond)


### PR DESCRIPTION
This is partly a finger exercise to make sure I can still commit and merge stuff, and partly an attempt to get ready to try other stuff.