### PR TITLE
CI: Attempt to fix Windows VS jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,7 +308,7 @@ jobs:
           mkdir build -ea 0
           cd build
 
-          $CMAKE_CMD="cmake -G 'Visual Studio 17 2022' -A x64 -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake .. $EVENT_CMAKE_OPTIONS"
+          $CMAKE_CMD="cmake -G 'Visual Studio 18 2026' -A x64 -DCMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake .. $EVENT_CMAKE_OPTIONS"
           function cmake_configure($retry)
           {
             $errcode=0


### PR DESCRIPTION
If I'm interpreting the errors right, we updated to something that provides a newer version of visual studio, but we didn't update our cmake invocation to use it.