### PR TITLE
2.2.2 release prep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,14 +81,14 @@ set(EVENT_PACKAGE_VERSION
 
 # equals to VERSION_INFO in Makefile.am
 set(EVENT_ABI_LIBVERSION_CURRENT   1)
-set(EVENT_ABI_LIBVERSION_REVISION  0)
+set(EVENT_ABI_LIBVERSION_REVISION  1)
 set(EVENT_ABI_LIBVERSION_AGE       0)
 
 # equals to RELEASE in Makefile.am
 set(EVENT_PACKAGE_RELEASE 2.2)
 
 # The last number is development version or not.
-set(EVENT_NUMERIC_VERSION 0x02020100)
+set(EVENT_NUMERIC_VERSION 0x02020200)
 
 # only a subset of names can be used, defaults to "beta"
 set(EVENT_STAGE_NAME ${EVENT_VERSION_STAGE})

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,10 @@
-Changes in version 2.2.2-alpha stable (30 June 2026)
+Changes in version 2.2.2-alpha (01 July 2026)
 
  This release contains several security fixes, affecting users of the
  following modules: evbuffer, bufferevent, evtag, evrpc, evdns, evhttp,
  and evws.
  If you have a program that uses one of those modules,
- or if you distribute distribute libevent, you should upgrade.
+ or if you distribute libevent, you should upgrade.
 
  (Note: the latest stable release as of this writing is 2.1.13.)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,7 @@ RELEASE = -release 2.2
 #
 # Once an RC is out, DO NOT MAKE ANY ABI-BREAKING CHANGES IN THAT SERIES
 # UNLESS YOU REALLY REALLY HAVE TO.
-VERSION_INFO = 1:0:0
+VERSION_INFO = 1:1:0
 
 # History:          RELEASE    VERSION_INFO
 #  2.0.1-alpha --     2.0        1:0:0
@@ -71,6 +71,7 @@ VERSION_INFO = 1:0:0
 #
 # For Libevent 2.2:
 #  2.2.1-alpha --     2.2        1:0:0
+#  2.2.2-alpha --     2.2        1:1:0 (No ABI change)
 
 # ABI version history for this package effectively restarts every time
 # we change RELEASE.  Version 1.4.x had RELEASE of 1.4.

--- a/cmake/VersionViaGit.cmake
+++ b/cmake/VersionViaGit.cmake
@@ -23,7 +23,7 @@ macro(event_fuzzy_version_from_git)
 	# set our defaults.
 	set(EVENT_GIT___VERSION_MAJOR 2)
 	set(EVENT_GIT___VERSION_MINOR 2)
-	set(EVENT_GIT___VERSION_PATCH 1)
+	set(EVENT_GIT___VERSION_PATCH 2)
 	set(EVENT_GIT___VERSION_STAGE "alpha-dev")
 
 	find_package(Git)

--- a/test/regress_http.c
+++ b/test/regress_http.c
@@ -4886,7 +4886,8 @@ end:
 static void
 http_check_transfer_encoding_test(void *arg)
 {
-#define CH evhttp_check_transfer_encoding_
+	enum evhttp_transfer_encoding_header_status status;
+#define CH(s) (status = evhttp_check_transfer_encoding_(s))
 	tt_int_op(CH("hello"), ==, TE_NO_CHUNKED);
 	tt_int_op(CH("hello, world"), ==, TE_NO_CHUNKED);
 	tt_int_op(CH("hello, world, chunked"), ==, TE_ENDS_IN_CHUNKED);


### PR DESCRIPTION
Bump CMake versions and ABI info.  2.2.2 only adds/changes internal symbols.