### PR TITLE
ci: refresh the BSD jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -668,7 +668,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ["13.4", "14.1"]
+        release: ["14", "15"]
         EVENT_MATRIX:
           - NONE
           - NO_SSL
@@ -695,6 +695,7 @@ jobs:
           release: ${{ matrix.release }}
           prepare: |
             pkg install -y mbedtls3 cmake python3
+          cache-after-prepare: true
           usesh: true
           run: |
             if [ "${{ matrix.EVENT_MATRIX }}" == "DISABLE_OPENSSL" ]; then
@@ -733,8 +734,7 @@ jobs:
         run: |
           ssh freebsd sh <<EOF
           cd $GITHUB_WORKSPACE
-          JOBS=1
-          export CTEST_PARALLEL_LEVEL=$JOBS
+          export CTEST_PARALLEL_LEVEL=1
           export CTEST_OUTPUT_ON_FAILURE=1
           cd build
           if [ "${{ matrix.EVENT_MATRIX }}" == "TEST_EXPORT_STATIC" ]; then
@@ -758,7 +758,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ["13.4", "14.1"]
+        release: ["14", "15"]
 
     steps:
       - uses: actions/checkout@v6
@@ -777,6 +777,7 @@ jobs:
           release: ${{ matrix.release }}
           prepare: |
             pkg install -y mbedtls3 python3 autoconf automake libtool pkgconf
+          cache-after-prepare: true
           usesh: true
           run: |
             ./autogen.sh
@@ -843,6 +844,7 @@ jobs:
           release: ${{ matrix.release }}
           prepare: |
             pkg_add mbedtls cmake py3-pip
+          cache-after-prepare: true
           usesh: true
           run: |
             if [ "${{ matrix.EVENT_MATRIX }}" == "DISABLE_OPENSSL" ]; then
@@ -882,8 +884,7 @@ jobs:
           ssh openbsd sh <<EOF
           ulimit -n 102400
           cd $GITHUB_WORKSPACE
-          JOBS=1
-          export CTEST_PARALLEL_LEVEL=$JOBS
+          export CTEST_PARALLEL_LEVEL=1
           export CTEST_OUTPUT_ON_FAILURE=1
           cd build
           if [ "${{ matrix.EVENT_MATRIX }}" == "TEST_EXPORT_STATIC" ]; then
@@ -926,6 +927,7 @@ jobs:
           release: ${{ matrix.release }}
           prepare: |
             pkg_add mbedtls py3-pip automake-1.16.5p0 autoconf-2.72p0 libtool pkg-config
+          cache-after-prepare: true
           usesh: true
           run: |
             export AUTOMAKE_VERSION=1.16


### PR DESCRIPTION
The BSD jobs still ask for FreeBSD 13.4 and 14.1. 14.1 is EOL, and the
`release` input takes the leading part and picks the newest match, so `"14"`
and `"15"` keep themselves current -- this run booted 14.4 and 15.1 without the
file naming either one.

Three changes:

- `release: ["13.4", "14.1"]` -> `["14", "15"]`

- `cache-after-prepare: true` on the four VM steps, so the `pkg install` is not
  repeated on every run

- `CTEST_PARALLEL_LEVEL` was coming out empty. The heredoc in the Test steps is
  unquoted, so `$JOBS` gets expanded by the runner's shell, where it is unset,
  rather than inside the VM. Set it to 1 directly. The linux and macos jobs
  have the same two lines but run them locally where the expansion works, so
  they are untouched.

Verified on a fork, all 26 BSD jobs green:
https://github.com/neilpang/libevent/actions/runs/31070990387

The last `build` run on master, 2026-07-01, had three of these red:
`freebsd-autotools (13.4)` on a DNS timeout, and 14.1 cmake on
`regress__KQUEUE` and `regress__POLL`. All three pass here, but one run is not
proof that the version bump is what fixed them.

Left alone on purpose: the openbsd prepare still pins `automake-1.16.5p0` and
`autoconf-2.72p0`. Those can be resolved at run time too, but that is a
separate change.
